### PR TITLE
Validate account name by regex

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Updateable.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Updateable.java
@@ -28,7 +28,7 @@ import java.util.stream.Stream;
 
 public interface Updateable {
   /* Attempts to update field to value, but will be rejected if the validation based on `context fails */
-  default public List<String> update(String fieldName, Object value) throws NoSuchFieldException, IllegalAccessException {
+  default public List<String> update(String fieldName, Object value, Class<?> valueType) throws NoSuchFieldException, IllegalAccessException {
     Field field = this.getClass().getDeclaredField(fieldName);
     field.setAccessible(true);
     Object oldValue = field.get(this);
@@ -41,7 +41,7 @@ public interface Updateable {
         .flatMap(Stream::of)                                                   // Flatten the stream of lists
         .map(v -> {
           try {
-            return v.getConstructor(value.getClass()).newInstance(value);      // Construct the validators
+            return v.getConstructor(valueType).newInstance(value);             // Construct the validators
           } catch (Exception e) {
             throw new RuntimeException(e);
           }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/providers/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/providers/Account.java
@@ -17,11 +17,14 @@
 package com.netflix.spinnaker.halyard.model.v1.providers;
 
 import com.netflix.spinnaker.halyard.model.v1.Updateable;
+import com.netflix.spinnaker.halyard.validate.v1.ValidateField;
+import com.netflix.spinnaker.halyard.validate.v1.providers.ValidateAccountName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Account implements Cloneable, Updateable {
+  @ValidateField(validators = {ValidateAccountName.class})
   String name;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/providers/kubernetes/DockerRegistryReference.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/providers/kubernetes/DockerRegistryReference.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.halyard.model.v1.providers.kubernetes;
 
+import com.netflix.spinnaker.halyard.validate.v1.ValidateField;
+import com.netflix.spinnaker.halyard.validate.v1.providers.ValidateAccountName;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -23,6 +25,7 @@ import java.util.List;
 
 @Data
 public class DockerRegistryReference {
+  @ValidateField(validators = {ValidateAccountName.class})
   String accountName;
   List<String> namespaces = new ArrayList<>();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateFieldRegex.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateFieldRegex.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.validate.v1;
+
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+public class ValidateFieldRegex extends Validator<String> {
+  final String pattern;
+  final String patternDescription;
+
+  protected ValidateFieldRegex(String subject, String pattern, String patternDescription) {
+    super(subject);
+    this.pattern = pattern;
+    this.patternDescription = patternDescription;
+  }
+
+  @Override
+  public Stream<String> validate() {
+    boolean matches = Pattern.matches(pattern, subject);
+    if (!matches) {
+      return Stream.of(String.format("%s (\"%s\" failed to match %s)", patternDescription, subject, pattern));
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public boolean skip() {
+    return false;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/providers/ValidateAccountName.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/providers/ValidateAccountName.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.validate.v1.providers;
+
+import com.netflix.spinnaker.halyard.validate.v1.ValidateFieldRegex;
+
+import java.util.stream.Stream;
+
+public class ValidateAccountName extends ValidateFieldRegex {
+  public ValidateAccountName(String subject) {
+    super(subject, "^[a-z0-9]+([-a-z0-9_]*[a-z0-9])?$",
+        "The account name must consist of alphanumeric characters optionally separated by dashes and underscores.");
+  }
+
+  @Override
+  public Stream<String> validate() {
+    if (subject == null) {
+      return Stream.of("Account name must not be missing/null.");
+    }
+
+    return super.validate();
+  }
+
+  @Override
+  public boolean skip() {
+    return false;
+  }
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/model/v1/UpdateableSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/model/v1/UpdateableSpec.groovy
@@ -33,7 +33,7 @@ public class UpdateableSpec extends Specification{
   void "should update my field name"() {
     when:
     def test = new Test(name: ORIGINAL_VALUE)
-    def res = test.update("name", GOOD_VALUE)
+    def res = test.update("name", GOOD_VALUE, String.class)
 
     then:
     res == []
@@ -43,7 +43,7 @@ public class UpdateableSpec extends Specification{
   void "should not update my field name"() {
     when:
     def test = new Test(name: ORIGINAL_VALUE)
-    def res = test.update("name", BAD_VALUE)
+    def res = test.update("name", BAD_VALUE, String.class)
 
     then:
     res == [ERROR_MESSAGE]
@@ -53,7 +53,7 @@ public class UpdateableSpec extends Specification{
   void "should update my field name due to skip"() {
     when:
     def test = new Test(name: ORIGINAL_VALUE)
-    def res = test.update("name", SKIP_VALUE)
+    def res = test.update("name", SKIP_VALUE, String.class)
 
     then:
     res == []

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/model/v1/providers/AccountSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/model/v1/providers/AccountSpec.groovy
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.model.v1.providers;
+
+import spock.lang.Specification;
+
+public class AccountSpec extends Specification {
+  final static String ORIGINAL_NAME = "a-name"
+  final static String GOOD_NAME = "good-name"
+  final static String BAD_NAME_SPACE = "bad name"
+  final static String BAD_NAME_CHARACTER = "!bad-name"
+
+  void "account name passes validation"() {
+    when:
+    def account = new Account(name: ORIGINAL_NAME);
+    def errors = account.update("name", GOOD_NAME, String.class)
+
+    then:
+    errors == []
+    account.name == GOOD_NAME
+  }
+
+  void "account name fails validation when null"() {
+    when:
+    def account = new Account(name: ORIGINAL_NAME);
+    def errors = account.update("name", null, String.class)
+
+    then:
+    errors[0].contains("null")
+    account.name == ORIGINAL_NAME
+  }
+
+  void "account name fails validation with space"() {
+    when:
+    def account = new Account(name: ORIGINAL_NAME);
+    def errors = account.update("name", BAD_NAME_SPACE, String.class)
+
+    then:
+    errors[0].contains("must consist of")
+    account.name == ORIGINAL_NAME
+  }
+
+  void "account name fails validation with illegal character"() {
+    when:
+    def account = new Account(name: ORIGINAL_NAME);
+    def errors = account.update("name", BAD_NAME_CHARACTER, String.class)
+
+    then:
+    errors[0].contains("must consist of")
+    account.name == ORIGINAL_NAME
+  }
+}


### PR DESCRIPTION
Introduces regex-field validation & provides an example on account names. @ttomsu or @jtk54 PTAL