### PR TITLE
Add doxygen style comments

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/v1/HalconfigParser.java
@@ -30,18 +30,37 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 
-/*
+/**
+ * A parser for all Config read by Halyard at runtime.
+ *
+ * @see Halconfig
+ *
  * Since we aren't relying on SpringBoot to configure Halyard's ~/.hal/config, we instead use this class as a utility
  * method to read ~/.hal/config's contents.
  */
 @Component
 public class HalconfigParser {
+  /**
+   * Path to where the halconfig file is located.
+   *
+   * @param path Defaults to ~/.hal/config.
+   * @return The path with home (~) expanded.
+   */
   @Bean
   String halconfigPath(@Value("${halconfig.filesystem.halconfig:~/.hal/config}") String path) {
     path = path.replaceFirst("^~", System.getProperty("user.home"));
     return path;
   }
 
+  /**
+   * Version of halyard.
+   *
+   * This is useful for implementing breaking version changes in Spinnaker that need to be migrated by some tool
+   * (in this case Halyard).
+   *
+   * @param version The version (seems like the i.d. function for Spring Boot).
+   * @return The version.
+   */
   @Bean
   String halyardVersion(@Value("${Implementation-Version:unknown}") String version) {
     return version;
@@ -59,6 +78,14 @@ public class HalconfigParser {
   @Autowired
   Yaml yamlParser;
 
+  /**
+   * Parse Halyard's config.
+   *
+   * @see Halconfig
+   * @param is The input stream to read from.
+   * @return The fully parsed halconfig.
+   * @throws UnrecognizedPropertyException
+   */
   Halconfig parseConfig(InputStream is) throws UnrecognizedPropertyException {
     try {
       Object obj = yamlParser.load(is);
@@ -68,6 +95,14 @@ public class HalconfigParser {
     }
   }
 
+  /**
+   * Returns the current halconfig stored at the halconfigPath.
+   *
+   * @see HalconfigParser#halconfigPath(String)
+   * @see Halconfig
+   * @return The fully parsed halconfig.
+   * @throws UnrecognizedPropertyException
+   */
   public Halconfig getConfig() throws UnrecognizedPropertyException {
     Halconfig res = null;
     try {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/DeploymentConfiguration.java
@@ -17,17 +17,39 @@
 package com.netflix.spinnaker.halyard.model.v1;
 
 import com.netflix.spinnaker.halyard.model.v1.providers.Providers;
+import lombok.Data;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-/*
- * A DeploymentConfiguration is an installation of Spinnaker
+/**
+ * A DeploymentConfiguration is an installation of Spinnaker, described in your Halconfig.
+ *
+ * @see Halconfig
  */
+@Data
 public class DeploymentConfiguration {
-  public String name;
-  public String version;
-  public Providers providers;
-  public List<Map> webhooks = new ArrayList<>();
+  /**
+   * Human-readable name for this deployment of Spinnaker.
+   */
+  String name;
+
+  /**
+   * Version of Spinnaker being deployed (not to be confused with the halyard version).
+   *
+   * @see Halconfig#halyardVersion
+   */
+  String version;
+
+  /**
+   * Providers, e.g. Kubernetes, GCE, AWS, ...
+   */
+  Providers providers;
+
+
+  /**
+   * Webhooks, e.g. Jenkins, TravisCI, ...
+   */
+  List<Map> webhooks = new ArrayList<>();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Halconfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Halconfig.java
@@ -21,12 +21,25 @@ import lombok.Data;
 import java.util.ArrayList;
 import java.util.List;
 
-/*
- * Maps the entire contents of ~/.hal/config
+/**
+ * Maps the entire contents of ~/.hal/config.
  */
 @Data
 public class Halconfig {
+  /**
+   * Version of Halyard required to manage this deployment.
+   */
   private String halyardVersion;
+
+  /**
+   * Current deployment being managed.
+   *
+   * @see DeploymentConfiguration#getName()
+   */
   private String currentDeployment;
+
+  /**
+   * List of available deployments.
+   */
   private List<DeploymentConfiguration> deploymentConfigurations = new ArrayList<>();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Updateable.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Updateable.java
@@ -26,8 +26,25 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * This allows fields making use of validators to be validated.
+ *
+ * This is meant to be implemented by all halconfig contents meant to be updated. It reads the Validate* anotations, and
+ * runs the validators on the fields changed.
+ *
+ * @see Validator
+ */
 public interface Updateable {
-  /* Attempts to update field to value, but will be rejected if the validation based on `context fails */
+  /**
+   * Attempts to update field to value, but will be rejected if the validation fails.
+   *
+   * @param fieldName Name of the field to be updated.
+   * @param value The value to update the named field to.
+   * @param valueType The type of value being updated (can't be inferred when value is null).
+   * @return The list of errors when validation fails (or null/[] when there are no failures).
+   * @throws IllegalAccessException
+   * @throws NoSuchFieldException
+   */
   default public List<String> update(String fieldName, Object value, Class<?> valueType) throws NoSuchFieldException, IllegalAccessException {
     Field field = this.getClass().getDeclaredField(fieldName);
     field.setAccessible(true);
@@ -52,6 +69,15 @@ public interface Updateable {
     return errors;
   }
 
+  /**
+   * Validate a given field without updating it.
+   *
+   * @param fieldName Name of the field to be validated.
+   * @param valueType The type of value being validated (can't be inferred when value is null).
+   * @return The list of errors when validation fails (or null/[] when there are no failures).
+   * @throws IllegalAccessException
+   * @throws NoSuchFieldException
+   */
   default public List<String> validate(String fieldName, Class<?> valueType) throws IllegalAccessException, NoSuchFieldException {
     Field field = this.getClass().getDeclaredField(fieldName);
     field.setAccessible(true);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateField.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateField.java
@@ -21,6 +21,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * An annotation to validate a specific field.
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface ValidateField {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateFieldRegex.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateFieldRegex.java
@@ -19,6 +19,9 @@ package com.netflix.spinnaker.halyard.validate.v1;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+/**
+ * Ensure the given value matches the input regex.
+ */
 public class ValidateFieldRegex extends Validator<String> {
   final String pattern;
   final String patternDescription;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateNotNull.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/ValidateNotNull.java
@@ -18,6 +18,9 @@ package com.netflix.spinnaker.halyard.validate.v1;
 
 import java.util.stream.Stream;
 
+/**
+ * Ensure given value is not null.
+ */
 public class ValidateNotNull extends Validator<Object> {
   protected ValidateNotNull(Object subject) {
     super(subject);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/Validator.java
@@ -18,20 +18,37 @@ package com.netflix.spinnaker.halyard.validate.v1;
 
 import java.util.stream.Stream;
 
-/* Every instance implementing this class should be run at most once against a single Spinnaker deployment's configuration */
+/**
+ * A validator that can pass, fail, or be skipped. It is stored inside the Validate* annotations.
+ *
+ * @see ValidateField
+ *
+ * Every instance implementing this class should be run at most once against a single Spinnaker deployment's configuration.
+ */
 public abstract class Validator<T> {
   protected Validator(T subject) {
     this.subject = subject;
   }
 
+  /**
+   * The value being validated.
+   */
   protected final T subject;
 
-  /* Describe what this validator is doing, i.e. "Ensure that the Kubernetes account has a Docker Registry configured" */
+  /**
+   *  Describes what this validator is doing.
+   *
+   *  e.g. "Ensure that the Kubernetes account has a Docker Registry configured".
+   */
   protected String description;
 
-  /* This returns a list of human-readable error messages. If the stream is empty, it is assumed that the validator has passed */
+  /**
+   * A list of human-readable error messages. If the stream is empty, it is assumed that the validator has passed.
+   */
   abstract public Stream<String> validate();
 
-  /* When true, this validator won't be run */
+  /**
+   * When true, this validator won't be run.
+   */
   abstract public boolean skip();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/providers/ValidateAccountName.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/providers/ValidateAccountName.java
@@ -20,6 +20,9 @@ import com.netflix.spinnaker.halyard.validate.v1.ValidateFieldRegex;
 
 import java.util.stream.Stream;
 
+/**
+ * Ensure that an account name matches the Spinnaker restrictions on account names. Applies to all account names.
+ */
 public class ValidateAccountName extends ValidateFieldRegex {
   public ValidateAccountName(String subject) {
     super(subject, "^[a-z0-9]+([-a-z0-9_]*[a-z0-9])?$",

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/providers/ValidateFileExists.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/validate/v1/providers/ValidateFileExists.java
@@ -21,6 +21,9 @@ import com.netflix.spinnaker.halyard.validate.v1.Validator;
 import java.io.*;
 import java.util.stream.Stream;
 
+/**
+ * Ensure that the given file exists, and is readable.
+ */
 public class ValidateFileExists extends Validator<String> {
   protected ValidateFileExists(String subject) {
     super(subject);


### PR DESCRIPTION
`@` annotations aren't punctuated when they refer to a class/method/exception/field.