### PR TITLE
Allow validation based on halconfig context

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/FieldReference.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/FieldReference.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.model.v1;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A reference to a field in halconfig.
+ * @param <T> The type of the update
+ */
+@Data
+@NoArgsConstructor
+public class FieldReference<T> extends Reference<T> {
+
+  /**
+   * The name of the field being updated.
+   */
+  private String fieldName;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Reference.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/Reference.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.model.v1;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * A reference to a class in halconfig.
+ *
+ * @param <T> Type of the reference
+ */
+@Data
+@NoArgsConstructor
+public class Reference<T> {
+  /**
+   * The optional value of the reference. May be null.
+   */
+  private T value;
+
+  /**
+   * It's possible that value is null, and we can't infer T, so this is needed.
+   */
+  private Class<T> valueType;
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/model/v1/providers/AccountSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/model/v1/providers/AccountSpec.groovy
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.model.v1.providers;
+package com.netflix.spinnaker.halyard.model.v1.providers
 
+import com.netflix.spinnaker.halyard.model.v1.FieldReference;
 import spock.lang.Specification;
 
 public class AccountSpec extends Specification {
@@ -26,8 +27,9 @@ public class AccountSpec extends Specification {
 
   void "account name passes validation"() {
     when:
-    def account = new Account(name: ORIGINAL_NAME);
-    def errors = account.update("name", GOOD_NAME, String.class)
+    def account = new Account(name: ORIGINAL_NAME)
+    def fieldref = new FieldReference(fieldName: "name", value: GOOD_NAME, valueType: String.class)
+    def errors = account.update(null, fieldref)
 
     then:
     errors == []
@@ -36,8 +38,9 @@ public class AccountSpec extends Specification {
 
   void "account name fails validation when null"() {
     when:
-    def account = new Account(name: ORIGINAL_NAME);
-    def errors = account.update("name", null, String.class)
+    def account = new Account(name: ORIGINAL_NAME)
+    def fieldref = new FieldReference(fieldName: "name", value: null, valueType: String.class)
+    def errors = account.update(null, fieldref)
 
     then:
     errors[0].contains("null")
@@ -46,8 +49,9 @@ public class AccountSpec extends Specification {
 
   void "account name fails validation with space"() {
     when:
-    def account = new Account(name: ORIGINAL_NAME);
-    def errors = account.update("name", BAD_NAME_SPACE, String.class)
+    def account = new Account(name: ORIGINAL_NAME)
+    def fieldref = new FieldReference(fieldName: "name", value: BAD_NAME_SPACE, valueType: String.class)
+    def errors = account.update(null, fieldref)
 
     then:
     errors[0].contains("Must consist of")
@@ -56,8 +60,9 @@ public class AccountSpec extends Specification {
 
   void "account name fails validation with illegal character"() {
     when:
-    def account = new Account(name: ORIGINAL_NAME);
-    def errors = account.update("name", BAD_NAME_CHARACTER, String.class)
+    def account = new Account(name: ORIGINAL_NAME)
+    def fieldref = new FieldReference(fieldName: "name", value: BAD_NAME_CHARACTER, valueType: String.class)
+    def errors = account.update(null, fieldref)
 
     then:
     errors[0].contains("Must consist of")


### PR DESCRIPTION
This is necessary for validations that occur across accounts, i.e. Kubernetes depends on Docker Registries.

@duftler @ttomsu @jtk54 PTAL