### PR TITLE
Propagate errors & warnings to client

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/v1/HalconfigParser.java
@@ -18,12 +18,16 @@ package com.netflix.spinnaker.halyard.config.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.netflix.spinnaker.halyard.errors.v1.config.NoConfigException;
+import com.netflix.spinnaker.halyard.errors.v1.config.ParseConfigException;
 import com.netflix.spinnaker.halyard.model.v1.Halconfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.parser.ParserException;
+import org.yaml.snakeyaml.scanner.ScannerException;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -103,14 +107,21 @@ public class HalconfigParser {
    * @return The fully parsed halconfig.
    * @throws UnrecognizedPropertyException
    */
-  public Halconfig getConfig() throws UnrecognizedPropertyException {
+  public Halconfig getConfig() {
     Halconfig res = null;
     try {
       InputStream is = new FileInputStream(new File(halconfigPath));
       res = parseConfig(is);
     } catch (FileNotFoundException e) {
-      res = new Halconfig().setHalyardVersion(halyardVersion);
+      throw new NoConfigException(halconfigPath);
+    } catch (UnrecognizedPropertyException e) {
+      throw new ParseConfigException(e);
+    } catch (ParserException e) {
+      throw new ParseConfigException(e);
+    } catch (ScannerException e) {
+      throw new ParseConfigException(e);
     }
+
     return res;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigException.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigException.java
@@ -14,23 +14,26 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.model.v1;
+package com.netflix.spinnaker.halyard.errors.v1;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import lombok.Getter;
 
 /**
- * A reference to a field in halconfig.
- * @param <T> The type of the update
+ * This is the base exception class that needs to be thrown by all validators.
  */
-@Data
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
-public class FieldReference<T> extends Reference<T> {
+public class HalconfigException extends RuntimeException {
+  @Getter
+  protected HalconfigFixableIssue issue = new HalconfigFixableIssue();
 
-  /**
-   * The name of the field being updated.
-   */
-  private String fieldName;
+  public void addError(String error) {
+    issue.getErrors().add(error);
+  }
+
+  public void addWarning(String warning) {
+    issue.getWarnings().add(warning);
+  }
+
+  public HalconfigException() {
+    super();
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigFixableIssue.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigFixableIssue.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.errors.v1;
+
+import lombok.Data;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is what Halyard will return to a client in case of an error fixable by the client. This includes validation
+ * failures, lack of a halconfig file, a bad deployment, etc...
+ */
+@Data
+public class HalconfigFixableIssue {
+  /**
+   * A set of messages for things that Halyard is positive is a problem. This includes verifiably incorrect credentials,
+   * lists of regions/namespaces not supported by the cloud provider, unresolved references to other configuration, etc...
+   */
+  protected List<String> errors = new ArrayList<>();
+  /**
+   * Warnings are things that Halyard thinks might be a problem. This includes credentials with leading/trailing spaces,
+   * an apparent but uncheckable lack of IAM permissions, etc...
+   */
+  protected List<String> warnings = new ArrayList<>();
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/config/IllegalConfigException.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/config/IllegalConfigException.java
@@ -14,23 +14,17 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.model.v1;
+package com.netflix.spinnaker.halyard.errors.v1.config;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import com.netflix.spinnaker.halyard.errors.v1.HalconfigException;
 
 /**
- * A reference to a field in halconfig.
- * @param <T> The type of the update
+ * This is reserved for Halyard configs that fall between unparseable (not valid yaml), and incorrectly configured
+ * (provider-specific error). Essentially, when a config has problems that prevent halyard from validating it, although
+ * it is readable by our yaml parser into the halfconfig Object, this is thrown
  */
-@Data
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
-public class FieldReference<T> extends Reference<T> {
-
-  /**
-   * The name of the field being updated.
-   */
-  private String fieldName;
+public class IllegalConfigException extends HalconfigException {
+  public IllegalConfigException(String message) {
+    addError(message);
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/config/NoConfigException.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/config/NoConfigException.java
@@ -14,23 +14,12 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.model.v1;
+package com.netflix.spinnaker.halyard.errors.v1.config;
 
-import lombok.Data;
-import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
+import com.netflix.spinnaker.halyard.errors.v1.HalconfigException;
 
-/**
- * A reference to a field in halconfig.
- * @param <T> The type of the update
- */
-@Data
-@NoArgsConstructor
-@EqualsAndHashCode(callSuper = false)
-public class FieldReference<T> extends Reference<T> {
-
-  /**
-   * The name of the field being updated.
-   */
-  private String fieldName;
+public class NoConfigException extends HalconfigException {
+  public NoConfigException(String filePath) {
+    addError("Your halconfig could not be found at " + filePath);
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/config/ParseConfigException.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/errors/v1/config/ParseConfigException.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.errors.v1.config;
+
+import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+import com.netflix.spinnaker.halyard.errors.v1.HalconfigException;
+import org.yaml.snakeyaml.parser.ParserException;
+import org.yaml.snakeyaml.scanner.ScannerException;
+
+public class ParseConfigException extends HalconfigException {
+  public ParseConfigException(UnrecognizedPropertyException e) {
+    addError("Unrecognized property in your halconfig: " + e.getMessage());
+  }
+
+  public ParseConfigException(ParserException e) {
+    addError("Could not parse your halconfig: " + e.getMessage());
+  }
+
+  public ParseConfigException(ScannerException e) {
+    addError("Could not parse your halconfig: " + e.getMessage());
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/providers/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/model/v1/providers/Account.java
@@ -16,18 +16,15 @@
 
 package com.netflix.spinnaker.halyard.model.v1.providers;
 
-import com.netflix.spinnaker.halyard.model.v1.FieldReference;
 import com.netflix.spinnaker.halyard.model.v1.Halconfig;
 import com.netflix.spinnaker.halyard.model.v1.Reference;
 import com.netflix.spinnaker.halyard.model.v1.Updateable;
 import com.netflix.spinnaker.halyard.validate.v1.ValidateAccount;
 import com.netflix.spinnaker.halyard.validate.v1.ValidateField;
-import com.netflix.spinnaker.halyard.validate.v1.Validator;
 import com.netflix.spinnaker.halyard.validate.v1.providers.ValidateAccountName;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/services/v1/ConfigService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/services/v1/ConfigService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.services.v1;
+
+import com.netflix.spinnaker.halyard.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.model.v1.Halconfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * This class is meant to be autowired into any controller or service that needs to read the current halconfig.
+ */
+@Component
+public class ConfigService {
+  @Autowired
+  HalconfigParser halconfigParser;
+
+  public Halconfig getConfig() {
+    return halconfigParser.getConfig();
+  }
+
+  public String getCurrentDeployment() {
+    return getConfig().getCurrentDeployment();
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/services/v1/DeploymentService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/services/v1/DeploymentService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.services.v1;
+
+import com.netflix.spinnaker.halyard.errors.v1.config.IllegalConfigException;
+import com.netflix.spinnaker.halyard.model.v1.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.model.v1.Halconfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * This service is meant to be autowired into any service or controller that needs to inspect the current halconfigs
+ * deployments.
+ */
+@Component
+public class DeploymentService {
+  @Autowired
+  ConfigService configService;
+
+  public DeploymentConfiguration getDeploymentConfiguration(String deployment) {
+    Halconfig halconfig = configService.getConfig();
+    List<DeploymentConfiguration> matching = halconfig.getDeploymentConfigurations()
+        .stream()
+        .filter(d -> d.getName().equals(deployment))
+        .collect(Collectors.toList());
+
+    switch (matching.size()) {
+      case 0:
+        throw new IllegalConfigException("Deployment configuration " + deployment + " not found");
+      case 1:
+        return matching.get(0);
+      default:
+        throw new IllegalConfigException("Deployment configuration " + deployment + " appears more than once");
+    }
+  }
+
+  public List<DeploymentConfiguration> getDeploymentConfigurations() {
+    return configService.getConfig().getDeploymentConfigurations();
+  }
+}

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.controllers.v1;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
 import com.netflix.spinnaker.halyard.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.model.v1.Halconfig;
+import com.netflix.spinnaker.halyard.services.v1.ConfigService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -31,20 +32,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/config")
 public class ConfigController {
   @Autowired
-  HalconfigParser halyardConfig;
+  ConfigService configService;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  Halconfig config() throws UnrecognizedPropertyException {
-    return halyardConfig.getConfig();
+  Halconfig config() {
+    return configService.getConfig();
   }
 
   @RequestMapping(value = "/currentDeployment", method = RequestMethod.GET)
-  String currentDeployment() throws UnrecognizedPropertyException {
-    Halconfig halconfig = halyardConfig.getConfig();
-    if (halconfig != null) {
-      return halconfig.getCurrentDeployment();
-    } else {
-      return null;
-    }
+  String currentDeployment() {
+    return configService.getCurrentDeployment();
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
@@ -16,75 +16,29 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
-import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
-import com.netflix.spinnaker.halyard.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.model.v1.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.model.v1.Halconfig;
-import lombok.Data;
-import lombok.EqualsAndHashCode;
+import com.netflix.spinnaker.halyard.services.v1.DeploymentService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/v1/config/deployments")
 public class DeploymentController {
   @Autowired
-  HalconfigParser halyardConfig;
+  DeploymentService deploymentService;
 
   @RequestMapping(value = "/{deployment:.+}", method = RequestMethod.GET)
-  DeploymentConfiguration deploymentConfigurations(@PathVariable String deployment) throws UnrecognizedPropertyException {
-    Halconfig halconfig = halyardConfig.getConfig();
-    if (halconfig != null) {
-      List<DeploymentConfiguration> matching = halconfig.getDeploymentConfigurations()
-          .stream()
-          .filter(d -> d.getName().equals(deployment))
-          .collect(Collectors.toList());
-
-      if (matching.size() == 0) {
-        throw new DeploymentNotFoundExecption(deployment);
-      } else if (matching.size() > 1) {
-        throw new DuplicateDeploymentException(deployment);
-      } else {
-        return matching.get(0);
-      }
-    } else {
-      return null;
-    }
+  DeploymentConfiguration deploymentConfiguration(@PathVariable String deployment) {
+    return deploymentService.getDeploymentConfiguration(deployment);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  List<DeploymentConfiguration> deploymentConfigurations() throws UnrecognizedPropertyException {
-    Halconfig halconfig = halyardConfig.getConfig();
-    if (halconfig != null) {
-      return halconfig.getDeploymentConfigurations();
-    } else {
-      return null;
-    }
-  }
-
-  @Data
-  @EqualsAndHashCode(callSuper = false)
-  @ResponseStatus(value = HttpStatus.NOT_FOUND)
-  static public class DeploymentNotFoundExecption extends RuntimeException {
-    String deploymentName;
-
-    DeploymentNotFoundExecption(String deploymentName) {
-      this.deploymentName = deploymentName;
-    }
-  }
-
-  @Data
-  @EqualsAndHashCode(callSuper = false)
-  @ResponseStatus(value = HttpStatus.CONFLICT)
-  static public class DuplicateDeploymentException extends RuntimeException {
-    String deploymentName;
-
-    DuplicateDeploymentException(String deploymentName) {
-      this.deploymentName = deploymentName;
-    }
+  List<DeploymentConfiguration> deploymentConfigurations() {
+    return deploymentService.getDeploymentConfigurations();
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigExceptionHandler.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigExceptionHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.errors.v1;
+
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+import javax.servlet.http.HttpServletResponse;
+
+@ControllerAdvice
+public class HalconfigExceptionHandler {
+  @ExceptionHandler({HalconfigException.class})
+  @ResponseBody
+  public HalconfigFixableIssue handleHalconfigException(HttpServletResponse response, HalconfigException exception) {
+    response.setStatus(HttpServletResponse.SC_CONFLICT);
+    return exception.getIssue();
+  }
+}


### PR DESCRIPTION
@duftler or @jtk54 or @ttomsu PTAL

Spring by default only shows the `message` an exception was instantiated with and thrown when handling a response. I added a `HalconfigExceptionHandler` to catch all `HalconfigException`s and return the `errors` & `warnings` they contain.