### PR TITLE
Fix javadoc build errors & warnings

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
@@ -62,8 +62,8 @@ public class HalconfigParser {
    * This is useful for implementing breaking version changes in Spinnaker that need to be migrated by some tool
    * (in this case Halyard).
    *
-   * @param version The version (seems like the i.d. function for Spring Boot).
-   * @return The version.
+   * @param version is the version (seems like the i.d. function for Spring Boot).
+   * @return the version of halyard.
    */
   @Bean
   String halyardVersion(@Value("${Implementation-Version:unknown}") String version) {
@@ -86,9 +86,8 @@ public class HalconfigParser {
    * Parse Halyard's config.
    *
    * @see Halconfig
-   * @param is The input stream to read from.
-   * @return The fully parsed halconfig.
-   * @throws UnrecognizedPropertyException
+   * @param is is the input stream to read from.
+   * @return the fully parsed halconfig.
    */
   Halconfig parseConfig(InputStream is) throws UnrecognizedPropertyException {
     try {
@@ -104,8 +103,7 @@ public class HalconfigParser {
    *
    * @see HalconfigParser#halconfigPath(String)
    * @see Halconfig
-   * @return The fully parsed halconfig.
-   * @throws UnrecognizedPropertyException
+   * @return the fully parsed halconfig.
    */
   public Halconfig getConfig() {
     Halconfig res = null;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/Updateable.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/Updateable.java
@@ -38,10 +38,11 @@ public interface Updateable {
   /**
    * Attempts to update field to value, but will be rejected if the validation fails.
    *
-   * @param field The Field being updated.
-   * @return The list of errors when validation fails ([] when there are no failures and validation has passed).
-   * @throws IllegalAccessException
-   * @throws NoSuchFieldException
+   * @param context is the context being updated.
+   * @param field is the field being updated in provided context.
+   * @return the list of errors when validation fails ([] when there are no failures and validation has passed).
+   * @throws IllegalAccessException when the provided context's field cannot be accessed.
+   * @throws NoSuchFieldException when the requested field isn't found in the context.
    */
   default public List<String> update(Halconfig context, FieldReference<?> field) throws NoSuchFieldException, IllegalAccessException {
     Field aField = this.getClass().getDeclaredField(field.getFieldName());
@@ -71,10 +72,11 @@ public interface Updateable {
   /**
    * Validate a given field without updating it.
    *
-   * @param field The Field being validated.
-   * @return The list of errors when validation fails ([] when there are no failures and validation has passed).
-   * @throws IllegalAccessException
-   * @throws NoSuchFieldException
+   * @param context is the context being validated.
+   * @param field is the Field being validated.
+   * @return the list of errors when validation fails ([] when there are no failures and validation has passed).
+   * @throws IllegalAccessException when the provided context's field cannot be accessed.
+   * @throws NoSuchFieldException when the requested field isn't found in the context.
    */
   default public List<String> validate(Halconfig context, FieldReference<?> field)
       throws IllegalAccessException, NoSuchFieldException {
@@ -105,14 +107,10 @@ public interface Updateable {
   /**
    * Validate this entire class
    *
-   * @return The list of errors when validation fails ([] when there are no failures and validation has passed).
-   * @throws IllegalAccessException
-   * @throws NoSuchFieldException
+   * @return the list of errors when validation fails ([] when there are no failures and validation has passed).
    */
-  default public List<String> validate(Halconfig context) throws IllegalAccessException, NoSuchFieldException {
-    List<String> errors = new ArrayList<>();
-
-    return errors;
+  default public List<String> validate(Halconfig context) {
+    return new ArrayList<>();
   }
 }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/Validator.java
@@ -59,13 +59,18 @@ public abstract class Validator<T> {
   protected String description;
 
   /**
-   * A list of human-readable error messages. If the stream is empty, it is assumed that the validator has passed.
+   * A list of human-readable error messages.
+   *
+   * @return a stream of all validation errors encountered. Empty i.f.f this validator passed. Should never be null.
    */
   abstract public Stream<String> validate();
 
   /**
-   * When true, this validator won't be run.
+   * Indicates whether or not this validator should be run.
+   *
+   * @return true i.f.f. this validator should be skipped.
    */
+
   abstract public boolean skip();
 
   public static Validator construct(Halconfig context, Class<? extends Validator> v, Reference<?> reference)


### PR DESCRIPTION
The `@throws UnrecognizedPropertyException` was an error after I removed it from the method signature. The others were all warnings due to missing descriptions or properties.

@duftler (another quickie, barring any spelling/grammar errors)