### PR TITLE
(cli) added command parsing framework

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -1,4 +1,5 @@
 dependencies {
+  compile spinnaker.dependency('lombok')
   compile "com.beust:jcommander:1.48"
 }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/Main.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/Main.java
@@ -1,15 +1,23 @@
 package com.netflix.spinnaker.halyard.cli;
 
 import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
+import com.netflix.spinnaker.halyard.cli.command.v1.HalCommand;
+import com.netflix.spinnaker.halyard.cli.ui.v1.Ui;
 
 public class Main {
-  @Parameter(names = "--param1", description = "my param")
-  private String param1;
-
   public static void main(String[] args) {
-    Main ep = new Main();
-    new JCommander(ep, args);
-    System.out.println("hi  ~~" + ep.param1 + "~~");
+    GlobalOptions globalOptions = new GlobalOptions();
+    JCommander jc = new JCommander(globalOptions);
+
+    HalCommand hal = new HalCommand(globalOptions, jc);
+
+    try {
+      jc.parse(args);
+    } catch (ParameterException e) {
+      System.out.println(e.getMessage());
+      jc.usage();
+    }
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.Parameters;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is a top-level command for dealing with your halconfig.
+ *
+ * Usage is `$ hal config`
+ */
+@Parameters(commandDescription = "Configure and view your halconfig")
+public class ConfigCommand extends NestableCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PROTECTED)
+  private String commandName = "config";
+
+  public ConfigCommand(GlobalOptions globalOptions) {
+    super(globalOptions);
+
+    ShowCommand show = new ShowCommand(globalOptions);
+    this.subcommands.put(show.getCommandName(), show);
+  }
+
+  @Override
+  protected void executeThis() {
+
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import lombok.Data;
+
+/**
+ * This is the collection of general, top-level flags to be interpreted by halyard.
+ */
+@Data
+@Parameters(separators = "=")
+public class GlobalOptions {
+  @Parameter(names = { "-v", "--verbose" }, description = "Enable verbose output")
+  private boolean verbose = false;
+
+  @Parameter(names = { "-c", "--color" }, description = "Enable terminal color output.", arity = 1)
+  private boolean color = true;
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.JCommander;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This is the base command, where we will register all the subcommands.
+ */
+public class HalCommand extends NestableCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PROTECTED)
+  private String commandName = "hal";
+
+  public HalCommand(GlobalOptions globalOptions, JCommander commander) {
+    super(globalOptions);
+
+    commander.setProgramName(getCommandName());
+    setCommander(commander);
+
+    ConfigCommand config = new ConfigCommand(globalOptions);
+    this.subcommands.put(config.getCommandName(), config);
+
+    this.configureSubcommands();
+  }
+
+  @Override
+  protected void executeThis() {
+    commander.usage();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.Parameter;
+import lombok.Setter;
+
+import java.util.Map;
+
+abstract class NestableCommand {
+  @Setter
+  protected JCommander commander;
+  private GlobalOptions globalOptions;
+
+  @Parameter(names = { "-h", "--help" }, help = true)
+  private boolean help;
+
+  public NestableCommand(GlobalOptions globalOptions) {
+    this.globalOptions = globalOptions;
+  }
+
+  /**
+   * This recusively walks the chain of subcommands, until it finds the last in the chain, and runs executeThis.
+   *
+   * @see NestableCommand#executeThis()
+   */
+  public void execute() {
+    String subCommand = commander.getParsedCommand();
+    if (subCommand == null) {
+      executeThis();
+    } else {
+      getSubcommands().get(subCommand).execute();
+    }
+  }
+
+  abstract protected void executeThis();
+  abstract protected Map<String, NestableCommand> getSubcommands();
+  abstract protected String getCommandName();
+
+  /**
+   * Register all subcommands with this class's commander, and then recursively set the subcommands.
+   */
+  protected void configureSubcommands() {
+    for (NestableCommand subCommand: getSubcommands().values()) {
+      commander.addCommand(subCommand.getCommandName(), subCommand);
+      // We need to provide the subcommand with its own commander before recursively populating its subcommands, since
+      // they need to be registered with this subcommander we retrieve here.
+      JCommander subCommander = commander.getCommands().get(subCommand.getCommandName());
+      subCommand.setCommander(subCommander);
+      subCommand.configureSubcommands();
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ShowCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ShowCommand.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This command displays its parent's resource.
+ *
+ * Usage is `$ hal config show`
+ */
+@Parameters(commandDescription = "Show the resource in question", separators = "=")
+public class ShowCommand extends NestableCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PROTECTED)
+  private String commandName = "show";
+
+  @Parameter(names = "--provider", description = "Select the provider's config to display", arity = 1)
+  protected String provider;
+
+  public ShowCommand(GlobalOptions globalOptions) {
+    super(globalOptions);
+  }
+
+  @Override
+  protected void executeThis() {
+
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/Color.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/Color.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.ui.v1;
+
+public class Color {
+  public final String RESET;
+  public final String BOLD;
+  public final String RED;
+  public final String GREEN;
+  public final String YELLOW;
+  public final String BLUE;
+
+  public Color (boolean colorEnabled) {
+    RESET = colorEnabled ? "\033[0m" : "";
+    BOLD = colorEnabled ? "\033[1m": "";
+    RED = colorEnabled ? "\033[31m": "";
+    GREEN = colorEnabled ? "\033[32m": "";
+    YELLOW = colorEnabled ? "\033[33m": "";
+    BLUE = colorEnabled ? "\033[34m": "";
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/Ui.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/Ui.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.ui.v1;
+
+/**
+ * A shared colored terminal output class
+ */
+public class Ui {
+  private Color color;
+  private boolean verbose;
+
+  public Ui(boolean colorEnabled, boolean verbose) {
+    this.color = new Color(colorEnabled);
+    this.verbose = verbose;
+  }
+
+  private void reset(String message) {
+    try {
+      System.out.print(message);
+    } catch (Exception e) {
+      throw e;
+    } finally {
+      System.out.println(color.RESET);
+    }
+  }
+
+  public void raw(String message) {
+    reset(message);
+  }
+
+  public void info(String message) {
+    if (verbose) {
+      reset(color.BOLD + color.BLUE + ". " + color.RESET + message);
+    }
+  }
+
+  public void warning(String message) {
+    reset(color.BOLD + color.YELLOW + "- " + color.RESET + message);
+  }
+
+  public void failure(String message) {
+    reset(color.BOLD + color.RED + "! " + color.RESET + message);
+  }
+
+  public void success(String message) {
+    reset(color.BOLD + color.GREEN + "+ " + color.RESET + message);
+  }
+}


### PR DESCRIPTION
I'm breaking the actual communication with the daemon into the next PR, but this enables commands like

```
hal config show --provider=kubernetes

hal -v --color=false config

hal --help
```

etc, etc...

@duftler @ttomsu @jtk54 PTAL