### PR TITLE
Refactor abstract provider naming

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GenerateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GenerateCommand.java
@@ -1,0 +1,4 @@
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+public class GenerateCommand {
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractGetAccountCommand.java
@@ -76,10 +76,9 @@ public abstract class AbstractGetAccountCommand extends AbstractProviderCommand 
     DaemonService service = Daemon.getService();
     String currentDeployment = service.getCurrentDeployment();
     ObjectMapper mapper = new ObjectMapper();
-    String providerName = getProviderName();
     return mapper.convertValue(
-        service.getAccount(currentDeployment, providerName, accountName, !noValidate),
-        Providers.translateAccountType(providerName)
+        service.getAccount(currentDeployment, getProviderName(), accountName, !noValidate),
+        Providers.translateAccountType(getProviderName())
     );
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractNamedProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractNamedProviderCommand.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.providers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.DaemonService;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
+
+public abstract class AbstractNamedProviderCommand extends AbstractProviderCommand {
+  @Override
+  public String getCommandName() {
+    return getProviderName();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Manage Spinnaker configuration for the " + getProviderName() + " provider";
+  }
+
+  protected AbstractNamedProviderCommand() {
+    registerSubcommand(new GetAccountCommandBuilder()
+        .setProviderName(getProviderName())
+        .build()
+    );
+
+    registerSubcommand(new ProviderEnableDisableCommandBuilder()
+        .setProviderName(getProviderName())
+        .setEnable(false)
+        .build()
+    );
+
+    registerSubcommand(new ProviderEnableDisableCommandBuilder()
+        .setProviderName(getProviderName())
+        .setEnable(true)
+        .build()
+    );
+  }
+
+  private Provider getProvider() {
+    DaemonService service = Daemon.getService();
+    String currentDeployment = service.getCurrentDeployment();
+    ObjectMapper mapper = new ObjectMapper();
+    return mapper.convertValue(
+        service.getProvider(currentDeployment, getProviderName(), !noValidate),
+        Providers.translateProviderType(getProviderName())
+    );
+  }
+
+  @Override
+  protected void executeThis() {
+    AnsiUi.success(getProvider().toString());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractProviderCommand.java
@@ -17,65 +17,11 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.providers;
 
 import com.beust.jcommander.Parameter;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.services.v1.DaemonService;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 
 public abstract class AbstractProviderCommand extends NestableCommand {
   @Parameter(names = { "--no-validate" }, description = "Skip validation")
   public boolean noValidate = false;
 
-  protected abstract String getProviderName();
-
-  @Override
-  public String getCommandName() {
-    return getProviderName();
-  }
-
-  @Override
-  public String getDescription() {
-    return "Manage Spinnaker configuration for the " + getProviderName() + " provider";
-  }
-
-  protected AbstractProviderCommand() {
-    String providerName = getProviderName();
-
-    registerSubcommand(new GetAccountCommandBuilder()
-        .setProviderName(providerName)
-        .build()
-    );
-
-    registerSubcommand(new ProviderEnableDisableCommandBuilder()
-        .setProviderName(providerName)
-        .setEnable(false)
-        .build()
-    );
-
-    registerSubcommand(new ProviderEnableDisableCommandBuilder()
-        .setProviderName(providerName)
-        .setEnable(false)
-        .build()
-    );
-  }
-
-  private Provider getProvider() {
-    DaemonService service = Daemon.getService();
-    String currentDeployment = service.getCurrentDeployment();
-    ObjectMapper mapper = new ObjectMapper();
-    String providerName = getProviderName();
-    return mapper.convertValue(
-        service.getProvider(currentDeployment, providerName, !noValidate),
-        Providers.translateProviderType(providerName)
-    );
-  }
-
-  @Override
-  protected void executeThis() {
-    AnsiUi.success(getProvider().toString());
-  }
+  abstract protected String getProviderName();
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/GetAccountCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/GetAccountCommandBuilder.java
@@ -39,6 +39,6 @@ public class GetAccountCommandBuilder implements CommandBuilder {
     }
 
     @Getter(AccessLevel.PROTECTED)
-    String providerName;
+    private String providerName;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/ProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/ProviderCommand.java
@@ -24,9 +24,6 @@ import com.netflix.spinnaker.halyard.cli.command.v1.providers.kubernetes.Kuberne
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * This is a top-level command for dealing with your halconfig.
  *

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/ProviderEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/ProviderEnableDisableCommandBuilder.java
@@ -43,9 +43,9 @@ public class ProviderEnableDisableCommandBuilder implements CommandBuilder {
     }
 
     @Getter(AccessLevel.PROTECTED)
-    String providerName;
+    boolean enable;
 
     @Getter(AccessLevel.PROTECTED)
-    boolean enable;
+    private String providerName;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/dockerRegistry/DockerRegistryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/dockerRegistry/DockerRegistryCommand.java
@@ -17,23 +17,16 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.providers.dockerRegistry;
 
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractProviderCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractNamedProviderCommand;
 import lombok.AccessLevel;
 import lombok.Getter;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Describe a specific dockerRegistry account
  */
 @Parameters()
-public class DockerRegistryCommand extends AbstractProviderCommand {
-  @Getter(AccessLevel.PROTECTED)
-  private String providerName = "dockerRegistry";
-
-  public DockerRegistryCommand() {
-    super();
+public class DockerRegistryCommand extends AbstractNamedProviderCommand {
+  protected String getProviderName() {
+    return "dockerRegistry";
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/google/GoogleCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/google/GoogleCommand.java
@@ -17,24 +17,17 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.providers.google;
 
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractProviderCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractNamedProviderCommand;
 import lombok.AccessLevel;
 import lombok.Getter;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Interact with the google provider
  */
 @Parameters()
-public class GoogleCommand extends AbstractProviderCommand {
-  @Getter(AccessLevel.PROTECTED)
-  private String providerName = "google";
-
-  public GoogleCommand() {
-    super();
+public class GoogleCommand extends AbstractNamedProviderCommand {
+  protected String getProviderName() {
+    return "google";
   }
 }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/kubernetes/KubernetesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/kubernetes/KubernetesCommand.java
@@ -18,7 +18,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.providers.kubernetes;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractProviderCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractNamedProviderCommand;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -29,14 +29,8 @@ import java.util.Map;
  * Interact with the kubernetes provider
  */
 @Parameters()
-public class KubernetesCommand extends AbstractProviderCommand {
-  @Getter(AccessLevel.PROTECTED)
-  private Map<String, NestableCommand> subcommands = new HashMap<>();
-
-  @Getter(AccessLevel.PROTECTED)
-  private String providerName = "kubernetes";
-
-  public KubernetesCommand() {
-    super();
+public class KubernetesCommand extends AbstractNamedProviderCommand {
+  protected String getProviderName() {
+    return "kubernetes";
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/FileWriter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/FileWriter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.config.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.*;
+import java.util.Map;
+
+@Component
+public class YamlWriter {
+  @Autowired
+  Yaml yamlParser;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  public void write(Object node, String path) throws IOException {
+    write(node, path, false);
+  }
+
+  public void write(Object node, String path, boolean append) throws IOException {
+    Writer writer = null;
+    try {
+      writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(path, append), "utf-8"));
+      writer.write(yamlParser.dump(objectMapper.convertValue(node, Map.class)));
+    } finally {
+      if (writer != null) {
+        writer.close();
+      }
+    }
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/GenerateService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/GenerateService.java
@@ -1,0 +1,4 @@
+package com.netflix.spinnaker.halyard.config.services.v1;
+
+public class GenerateService {
+}


### PR DESCRIPTION
I didn't like how the subcommands of the concrete provider commands would extend the concrete provider command, so I separated AbstractProviderCommand into AbstractNamedProviderCommand (for things like DockerRegistry, Kubernetes, etc..), and AbstractProviderCommand (for any command that depends on a providerName).