### PR TITLE
add-account command implemented for k8s

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -183,6 +183,10 @@ public abstract class NestableCommand {
           paragraph.addSnippet(parameter.getDefault().toString().toUpperCase()).addStyle(AnsiStyle.UNDERLINE);
         }
 
+        if (parameter.getParameter().required()) {
+          paragraph.addSnippet(" (required)");
+        }
+
         paragraph = story.addParagraph().setIndentWidth(indentWidth * 2);
         paragraph.addSnippet(parameter.getDescription());
         story.addNewline();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractAddAccountCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.providers;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.DaemonService;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters()
+public abstract class AbstractAddAccountCommand extends AbstractProviderCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "add-account";
+
+  @Parameter(names = { "--account-name" }, description = "The name of the account to create")
+  private String accountName;
+
+  protected abstract Account buildAccount(String accountName);
+
+  public String getDescription() {
+    return "Add a " + getProviderName() + " account";
+  }
+
+  @Override
+  protected void executeThis() {
+    Account account = buildAccount(accountName);
+    String providerName = getProviderName();
+
+    DaemonService service = Daemon.getService();
+    String currentDeployment = service.getCurrentDeployment();
+
+    service.addAccount(currentDeployment, providerName, !noValidate, account);
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2016 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.providers.kubernetes;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractAddAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractNamedProviderCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.DockerRegistryReference;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import java.util.ArrayList;
+import java.util.List;
+
+@Parameters()
+public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
+  protected String getProviderName() {
+    return "kubernetes";
+  }
+
+  @Parameter(
+      names = "--context",
+      description = "The kubernetes context to be managed by Spinnaker. "
+          + "See http://kubernetes.io/docs/user-guide/kubeconfig-file/#context for more information."
+  )
+  private String context;
+
+  @Parameter(
+      names = "--namespaces",
+      variableArity = true,
+      description = "A list of namespaces this Spinnaker account can deploy to and will cache. "
+          + "Leaving this blank defaults to 'all namespaces'."
+  )
+  public List<String> namespaces = new ArrayList<>();
+
+  @Parameter(
+      names = "--docker-registries",
+      variableArity = true,
+      description = "A list of the Spinnaker docker registry account names this Spinnaker account can use as image sources. "
+          + "These docker registry accounts must be registered in your halconfig before you can add them here."
+  )
+  public List<String> dockerRegistries = new ArrayList<>();
+
+  @Override
+  protected Account buildAccount(String accountName) {
+    KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
+    account.setContext(context);
+    account.setNamespaces(namespaces);
+    dockerRegistries.forEach(registryName -> account.getDockerRegistries().add(new DockerRegistryReference().setAccountName(registryName)));
+    return account;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/kubernetes/KubernetesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/kubernetes/KubernetesCommand.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.providers.kubernetes;
 
 import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.clouddriver.kubernetes.security.KubernetesCredentials;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.providers.AbstractNamedProviderCommand;
 import lombok.AccessLevel;
@@ -32,5 +33,10 @@ import java.util.Map;
 public class KubernetesCommand extends AbstractNamedProviderCommand {
   protected String getProviderName() {
     return "kubernetes";
+  }
+
+  public KubernetesCommand() {
+    super();
+    registerSubcommand(new KubernetesAddAccountCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -16,11 +16,16 @@
 
 package com.netflix.spinnaker.halyard.cli.services.v1;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
-import retrofit.http.*;
-
 import java.util.List;
+import retrofit.http.Body;
+import retrofit.http.GET;
+import retrofit.http.POST;
+import retrofit.http.PUT;
+import retrofit.http.Path;
+import retrofit.http.Query;
 
 public interface DaemonService {
   @GET("/v1/config/")
@@ -32,34 +37,49 @@ public interface DaemonService {
   @GET("/v1/config/deployments/")
   List<DeploymentConfiguration> getDeployments();
 
-  @GET("/v1/config/deployments/{deployment}/")
+  @GET("/v1/config/deployments/{deploymentName}/")
   DeploymentConfiguration getDeployment(
-      @Path("deployment") String deployment,
+      @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate);
 
-  @POST("/v1/config/deployments/{deployment}/generate/")
+  @POST("/v1/config/deployments/{deploymentName}/generate/")
   Void generateDeployment(
-      @Path("deployment") String deployment,
+      @Path("deploymentName") String deploymentName,
       @Body String _ignore,
       @Query("validate") boolean validate);
 
-  @GET("/v1/config/deployments/{deployment}/providers/{provider}/")
+  @GET("/v1/config/deployments/{deploymentName}/providers/{providerName}/")
   Object getProvider(
-      @Path("deployment") String deployment,
-      @Path("provider") String provider,
+      @Path("deploymentName") String deploymentName,
+      @Path("providerName") String providerName,
       @Query("validate") boolean validate);
 
-  @PUT("/v1/config/deployments/{deployment}/providers/{provider}/enabled/")
+  @PUT("/v1/config/deployments/{deploymentName}/providers/{providerName}/enabled/")
   Object setProviderEnabled(
-      @Path("deployment") String deployment,
-      @Path("provider") String provider,
+      @Path("deploymentName") String deploymentName,
+      @Path("providerName") String providerName,
       @Query("validate") boolean validate,
       @Body boolean enabled);
 
-  @GET("/v1/config/deployments/{deployment}/providers/{provider}/accounts/{account}/")
+  @POST("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/")
+  Object addAccount(
+      @Path("deploymentName") String deploymentName,
+      @Path("providerName") String providerName,
+      @Query("validate") boolean validate,
+      @Body Account account);
+
+  @GET("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/{accountName}/")
   Object getAccount(
-      @Path("deployment") String deployment,
-      @Path("provider") String provider,
-      @Path("account") String account,
+      @Path("deploymentName") String deploymentName,
+      @Path("providerName") String providerName,
+      @Path("accountName") String accountName,
       @Query("validate") boolean validate);
+
+  @PUT("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/{accountName}/")
+  Object setAccount(
+      @Path("deploymentName") String deploymentName,
+      @Path("providerName") String providerName,
+      @Path("accountName") String accountName,
+      @Query("validate") boolean validate,
+      @Body Account account);
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiParagraphBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiParagraphBuilder.java
@@ -61,11 +61,13 @@ public class AnsiParagraphBuilder {
     for (int i = 0; i < lines.length; i++) {
       String line = lines[i];
 
+      line = WordUtils.wrap(line, maxLineWidth, "\n" + getIndent(), false);
+
       if (indentFirstLine) {
         line = getIndent() + line;
       }
 
-      lineBuilder.append(WordUtils.wrap(line, maxLineWidth, "\n" + getIndent(), false));
+      lineBuilder.append(line);
 
       if (i != lines.length - 1) {
         lineBuilder.append("\n");

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
@@ -83,6 +83,7 @@ public class HalconfigParser {
    */
   public Halconfig getConfig(boolean reload) {
     if (!reload && halconfig != null) {
+      halconfig.parentify();
       return halconfig;
     }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
@@ -46,7 +46,7 @@ public class ValidateService {
   }
 
   private void recursiveValidate(ProblemSetBuilder psBuilder, Node node, NodeFilter filter) {
-    log.info("Running all validators for node " + node.getNodeName() + " with class " + node.getClass());
+    log.info("Running all validators for node " + node.getNodeName() + " with class " + node.getClass().getCanonicalName());
 
     validatorCollection.runAllValidators(psBuilder, node);
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/ValidatorCollection.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/ValidatorCollection.java
@@ -83,7 +83,7 @@ public class ValidatorCollection {
     } catch (NoSuchMethodException e) {
       // Do nothing, odds are most validators don't validate every class.
     } catch (InvocationTargetException | IllegalAccessException e) {
-      log.warn("Failed to invoke validate() on " + validator.getClass() + " for node " + c, e);
+      log.warn("Failed to invoke validate() on " + validator.getClass() + " for node " + c + " with cause " + e.getCause(), e);
     }
 
     return runMatchingValidators(psBuilder, validator, node, c.getSuperclass()) + result;

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
@@ -16,40 +16,53 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
-import com.netflix.spinnaker.halyard.config.model.v1.node.NodeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeReference;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
-
+import com.netflix.spinnaker.halyard.config.services.v1.UpdateService;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/v1/config/deployments/{deployment:.+}/providers/{provider:.+}/accounts")
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/providers/{providerName:.+}/accounts")
 public class AccountController {
   @Autowired
   AccountService accountService;
 
+  @Autowired
+  UpdateService updateService;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  List<Account> accounts(@PathVariable String deployment, @PathVariable String provider) {
+  List<Account> accounts(@PathVariable String deploymentName, @PathVariable String providerName) {
     NodeReference reference = new NodeReference()
-        .setDeployment(deployment)
-        .setProvider(provider);
+        .setDeployment(deploymentName)
+        .setProvider(providerName);
 
     return accountService.getAllAccounts(reference);
 
   }
 
-  @RequestMapping(value = "/{account:.+}", method = RequestMethod.GET)
+  @RequestMapping(value = "/{accountName:.+}", method = RequestMethod.GET)
   Account account(
-      @PathVariable String deployment,
-      @PathVariable String provider,
-      @PathVariable String account,
+      @PathVariable String deploymentName,
+      @PathVariable String providerName,
+      @PathVariable String accountName,
       @RequestParam(required = false, defaultValue = "false") boolean validate) {
     NodeReference reference = new NodeReference()
-        .setDeployment(deployment)
-        .setProvider(provider)
-        .setAccount(account);
+        .setDeployment(deploymentName)
+        .setProvider(providerName)
+        .setAccount(accountName);
 
     Account result = accountService.getAccount(reference);
 
@@ -58,5 +71,58 @@ public class AccountController {
     }
 
     return result;
+  }
+
+  @RequestMapping(value = "/{accountName:.+}", method = RequestMethod.PUT)
+  void setAccount(
+      @PathVariable String deploymentName,
+      @PathVariable String providerName,
+      @PathVariable String accountName,
+      @RequestParam(required = false, defaultValue = "false") boolean validate,
+      @RequestBody Object rawAccount) {
+    NodeReference reference = new NodeReference()
+        .setDeployment(deploymentName)
+        .setProvider(providerName)
+        .setAccount(accountName);
+
+    Account account = objectMapper.convertValue(
+        rawAccount,
+        Providers.translateAccountType(providerName)
+    );
+
+    Runnable doUpdate = () -> accountService.setAccount(reference, account);
+    Runnable doValidate = () -> {};
+
+    if (validate) {
+      doValidate = () -> accountService.validateAccount(reference);
+    }
+
+    updateService.safeUpdate(doUpdate, doValidate);
+  }
+
+  @RequestMapping(value = "/", method = RequestMethod.POST)
+  void addAccount(
+      @PathVariable String deploymentName,
+      @PathVariable String providerName,
+      @RequestParam(required = false, defaultValue = "false") boolean validate,
+      @RequestBody Object rawAccount) {
+    Account account = objectMapper.convertValue(
+        rawAccount,
+        Providers.translateAccountType(providerName)
+    );
+
+    NodeReference reference = new NodeReference()
+        .setDeployment(deploymentName)
+        .setProvider(providerName)
+        .setAccount(account.getName());
+
+    Runnable doUpdate = () -> accountService.addAccount(reference, account);
+    Runnable doValidate = () -> {};
+
+    if (validate) {
+      doValidate = () -> accountService.validateAccount(reference);
+    }
+
+    updateService.safeUpdate(doUpdate, doValidate);
   }
 }


### PR DESCRIPTION
The client builds the account object for a specific provider, and sends it to the daemon for validation. If it passes, the halconfig is updated.

@duftler or @jtk54 or @ewiseblatt or @ttomsu PTAL