### PR TITLE
Remove --account-name parameter when it's required

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,19 +57,19 @@ $ hal config provider PROVIDER disable
 If you want to examine only a particular account's configuration, run:
 
 ```
-$ hal config provider PROVIDER get-account ACCOUNT
+$ hal config provider PROVIDER get-account ACCOUNT-NAME
 ```
 
 To add an account, run:
 
 ```
-$ hal config provider PROVIDER add-account --account-name ACCOUNT-NAME [provider-specific flags]
+$ hal config provider PROVIDER add-account ACCOUNT-NAME [provider-specific flags]
 ```
 
 To delete an account, run:
 
 ```
-$ hal config provider PROVIDER delete-account --account-name ACCOUNT-NAME
+$ hal config provider PROVIDER delete-account ACCOUNT-NAME
 ```
 
 #### hal config generate

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractDeleteAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractDeleteAccountCommand.java
@@ -16,15 +16,11 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.providers;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,7 +29,7 @@ import lombok.Getter;
  * Delete a specific PROVIDER account
  */
 @Parameters()
-public abstract class AbstractDeleteAccountCommand extends AbstractProviderCommand {
+public abstract class AbstractDeleteAccountCommand extends AbstractHasAccountCommand {
   @Getter(AccessLevel.PROTECTED)
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
@@ -41,26 +37,7 @@ public abstract class AbstractDeleteAccountCommand extends AbstractProviderComma
   private String commandName = "delete-account";
 
   public String getDescription() {
-    return "Delete a specific " + getProviderName() + " account by name";
-  }
-
-  @Parameter(description = "The name of the account to delete", arity = 1)
-  List<String> accounts = new ArrayList<>();
-
-  @Override
-  public String getMainParameter() {
-    return "account";
-  }
-
-  public String getAccountName() {
-    switch (accounts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No account name supplied");
-      case 1:
-        return accounts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one account supplied");
-    }
+    return "Delete a specific " + getProviderName() + " account by name.";
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractGetAccountCommand.java
@@ -16,16 +16,13 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.providers;
 
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,7 +31,7 @@ import lombok.Getter;
  * Describe a specific PROVIDER account
  */
 @Parameters()
-public abstract class AbstractGetAccountCommand extends AbstractProviderCommand {
+public abstract class AbstractGetAccountCommand extends AbstractHasAccountCommand {
   @Getter(AccessLevel.PROTECTED)
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
@@ -42,26 +39,7 @@ public abstract class AbstractGetAccountCommand extends AbstractProviderCommand 
   private String commandName = "get-account";
 
   public String getDescription() {
-    return "Get details for a specific " + getProviderName() + " account";
-  }
-
-  @Parameter(description = "The name of the account to show", arity = 1)
-  List<String> accounts = new ArrayList<>();
-
-  @Override
-  public String getMainParameter() {
-    return "account";
-  }
-
-  public String getAccountName() {
-    switch (accounts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No account name supplied");
-      case 1:
-        return accounts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one account supplied");
-    }
+    return "Get details for a specific " + getProviderName() + " account.";
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractHasAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/providers/AbstractHasAccountCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -16,38 +16,39 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.providers;
 
+import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
 
+/**
+ * An abstract definition for commands that accept ACCOUNT as a main parameter
+ */
 @Parameters()
-public abstract class AbstractAddAccountCommand extends AbstractHasAccountCommand {
-  @Getter(AccessLevel.PROTECTED)
-  private Map<String, NestableCommand> subcommands = new HashMap<>();
-
-  @Getter(AccessLevel.PUBLIC)
-  private String commandName = "add-account";
-
-  protected abstract Account buildAccount(String accountName);
-
-  public String getDescription() {
-    return "Add a " + getProviderName() + " account";
-  }
+public abstract class AbstractHasAccountCommand extends AbstractProviderCommand {
+  @Parameter(description = "The name of the account to operate on.", arity = 1)
+  List<String> accounts = new ArrayList<>();
 
   @Override
-  protected void executeThis() {
-    String accountName = getAccountName();
-    Account account = buildAccount(accountName);
-    String providerName = getProviderName();
+  public String getMainParameter() {
+    return "account";
+  }
 
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.addAccount(currentDeployment, providerName, !noValidate, account);
-    AnsiUi.success("Added " + providerName + " account \"" + accountName + "\"");
+  public String getAccountName() {
+    switch (accounts.size()) {
+      case 0:
+        throw new IllegalArgumentException("No account name supplied");
+      case 1:
+        return accounts.get(0);
+      default:
+        throw new IllegalArgumentException("More than one account supplied");
+    }
   }
 }


### PR DESCRIPTION
This makes commands that require account-name easier to write, i.e.

```
hal config provider kubernetes add-account my-k8s-account --context my-context
```

vs.

```
hal config provider kubernetes add-account --account-name my-k8s-account --context my-context
```