### PR TITLE
Add support for logging options.

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiUi.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiUi.java
@@ -24,16 +24,30 @@ public class AnsiUi {
     AnsiPrinter.println(new AnsiSnippet(message).toString());
   }
 
-  public static void info(String message) {
+  public static void listItem(String message) {
+    AnsiParagraphBuilder builder = new AnsiParagraphBuilder()
+        .setIndentFirstLine(true)
+        .setIndentWidth(4);
+
+    builder.addSnippet("- ")
+        .addStyle(AnsiStyle.BOLD);
+
+    builder.addSnippet(message);
+
+    AnsiPrinter.println(builder.toString());
+  }
+
+  public static void location(String message) {
     AnsiParagraphBuilder builder = new AnsiParagraphBuilder()
         .setIndentFirstLine(false)
         .setIndentWidth(2);
 
-    builder.addSnippet(". ")
-        .setForegroundColor(AnsiForegroundColor.BLUE)
+    builder.addSnippet("Problems in ");
+
+    builder.addSnippet(message)
         .addStyle(AnsiStyle.BOLD);
 
-    builder.addSnippet(message);
+    builder.addSnippet(":");
 
     AnsiPrinter.println(builder.toString());
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/Problem.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/Problem.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.config.model.v1.problem;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeReference;
+import java.util.List;
 import lombok.Getter;
 
 /**
@@ -60,9 +61,9 @@ public class Problem {
    */
   public String getReferenceTitle() {
     if (reference != null) {
-      return "In " + reference + ":";
+      return reference.toString();
     } else {
-      return "Global:";
+      return "Global";
     }
   }
 
@@ -79,12 +80,18 @@ public class Problem {
   final private String remediation;
 
   /**
+   * An optional list of alternative entries.
+   */
+  @Getter
+  final private List<String> options;
+
+  /**
    * Indicates if this will cause the deployment to fail or not.
    */
   @Getter
   final private Severity severity;
 
-  public Problem(Severity severity, NodeReference reference, String message, String remediation) {
+  public Problem(Severity severity, NodeReference reference, String message, String remediation, List<String> options) {
     if (severity == Severity.NONE) {
       throw new RuntimeException("A halconfig problem may not be intialized with \"NONE\" severity");
     }
@@ -92,5 +99,6 @@ public class Problem {
     this.reference = reference;
     this.message = message;
     this.remediation = remediation;
+    this.options = options;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/ProblemBuilder.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/ProblemBuilder.java
@@ -17,9 +17,16 @@
 package com.netflix.spinnaker.halyard.config.model.v1.problem;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeReference;
+import java.util.List;
 import lombok.Setter;
 
 public class ProblemBuilder {
+  @Setter
+  Problem.Severity severity;
+
+  @Setter
+  NodeReference reference;
+
   @Setter
   String message;
 
@@ -27,10 +34,7 @@ public class ProblemBuilder {
   String remediation;
 
   @Setter
-  NodeReference reference;
-
-  @Setter
-  Problem.Severity severity;
+  List<String> options;
 
   public ProblemBuilder(Problem.Severity severity, String message) {
     this.severity = severity;
@@ -38,6 +42,6 @@ public class ProblemBuilder {
   }
 
   public Problem build() {
-    return new Problem(severity, reference, message, remediation);
+    return new Problem(severity, reference, message, remediation, options);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/ProblemSet.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/ProblemSet.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.halyard.config.model.v1.problem;
 
 import com.netflix.spinnaker.halyard.config.errors.v1.HalconfigException;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Getter;
 
 import java.util.ArrayList;
@@ -30,11 +32,20 @@ public class ProblemSet {
   @Getter
   private List<Problem> problems = new ArrayList<>();
 
-  /**
-   * Sort the listed problems in increasing order of severity.
-   */
-  public void sortIncreasingSeverity() {
-    Collections.sort(problems, (Problem a, Problem b) -> a.getSeverity().compareTo(b.getSeverity()));
+  public Map<String, List<Problem>> groupByLocation() {
+    Map<String, List<Problem>> result = new HashMap<>();
+    for (Problem problem : problems) {
+      result.merge(problem.getReferenceTitle(),
+          new ArrayList<Problem>() {{
+            add(problem);
+          }},
+          (List a, List b) -> {
+            a.addAll(b);
+            return a;
+          });
+    }
+
+    return result;
   }
 
   public void add(Problem problem) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/ProblemSetBuilder.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/problem/ProblemSetBuilder.java
@@ -17,14 +17,12 @@
 package com.netflix.spinnaker.halyard.config.model.v1.problem;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
-import com.netflix.spinnaker.halyard.config.model.v1.node.NodeReference;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem.Severity;
-import lombok.AccessLevel;
-import lombok.Setter;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Setter;
 
 public class ProblemSetBuilder {
   private List<ProblemBuilder> builders = new ArrayList<>();
@@ -36,10 +34,19 @@ public class ProblemSetBuilder {
   private Node node;
 
   public ProblemBuilder addProblem(Problem.Severity severity, String message) {
+    return addProblem(severity, message, null);
+  }
+
+  public ProblemBuilder addProblem(Problem.Severity severity, String message, String field) {
     ProblemBuilder problemBuilder = new ProblemBuilder(severity, message);
     if (node != null) {
       problemBuilder.setReference(node.getReference());
+
+      if (field != null && !field.isEmpty()) {
+        problemBuilder.setOptions(node.fieldOptions(new ProblemSetBuilder(), field));
+      }
     }
+
     builders.add(problemBuilder);
     return problemBuilder;
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.config.services.v1;
 
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
@@ -34,6 +35,9 @@ import org.springframework.stereotype.Component;
 public class ValidateService {
   @Autowired
   HalconfigParser parser;
+
+  @Autowired
+  DeploymentService deploymentService;
 
   @Autowired
   ValidatorCollection validatorCollection;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -90,7 +90,7 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
           .findFirst();
 
       if (!namedContext.isPresent()) {
-        psBuilder.addProblem(ERROR, "Context \"" + context + "\" not found in kubeconfig \"" + kubeconfigFile + "\"")
+        psBuilder.addProblem(ERROR, "Context \"" + context + "\" not found in kubeconfig \"" + kubeconfigFile + "\"", "context")
             .setRemediation("Either add this context to your kubeconfig, rely on the default context, or pick another kubeconfig file");
         smoketest = false;
       }


### PR DESCRIPTION
Any field that has a corresponding "fieldName"Options() method will supply alternative entries during validation.

I also updated the formatting of errors to group them by location.

![validate-options](https://cloud.githubusercontent.com/assets/4874941/22075057/815b4df6-dd78-11e6-93a3-c7c9b7bbefab.png)

@duftler @jtk54 PTAL
