### PR TITLE
Fix retrofit error suppression

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -84,10 +84,17 @@ public abstract class NestableCommand {
       if (e.getCause() instanceof ConnectException) {
         AnsiUi.error(e.getCause().getMessage());
         AnsiUi.remediation("Is your daemon running?");
-      } else {
-        ResponseUnwrapper.get((DaemonResponse) e.getBodyAs(DaemonResponse.class));
         System.exit(1);
+      } else if (e.getBody() instanceof DaemonResponse) {
+        DaemonResponse d = (DaemonResponse) e.getBodyAs(DaemonResponse.class);
+        if (d.getProblemSet() != null) {
+          ResponseUnwrapper.get(d);
+          System.exit(1);
+        }
       }
+      AnsiUi.error(e.getMessage());
+      AnsiUi.remediation("Try the command again with the --debug flag.");
+      System.exit(1);
     } catch (Exception e) {
       if (GlobalOptions.getGlobalOptions().isDebug()) {
         e.printStackTrace();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.config.v1;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -65,11 +66,6 @@ public class ResourceConfig {
   @Bean
   String spinnakerOutputPath(@Value("${spinnaker.config.output.directory:~/.halyard}") String path) {
     return normalizePath(path);
-  }
-
-  @Bean
-  ObjectMapper objectMapper() {
-    return new ObjectMapper();
   }
 
   @Bean

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/StrictObjectMapper.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/StrictObjectMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.config.v1;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StrictObjectMapper extends ObjectMapper {
+  StrictObjectMapper() {
+    super();
+    this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/errors/v1/config/ParseConfigException.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/errors/v1/config/ParseConfigException.java
@@ -25,18 +25,20 @@ import org.yaml.snakeyaml.scanner.ScannerException;
 
 public class ParseConfigException extends HalconfigException {
   public ParseConfigException(UnrecognizedPropertyException e) {
-    Problem
-        problem = new ProblemBuilder(Problem.Severity.FATAL, "Unrecognized property in your halconfig: " + e.getMessage()).build();
+    Problem problem = new ProblemBuilder(Problem.Severity.FATAL,
+        "Unrecognized property in your halconfig: " + e.getMessage()).build();
     getProblems().add(problem);
   }
 
   public ParseConfigException(ParserException e) {
-    Problem problem = new ProblemBuilder(Problem.Severity.FATAL, "Could not parse your halconfig: " + e.getMessage()).build();
+    Problem problem = new ProblemBuilder(Problem.Severity.FATAL,
+        "Could not parse your halconfig: " + e.getMessage()).build();
     getProblems().add(problem);
   }
 
   public ParseConfigException(ScannerException e) {
-    Problem problem = new ProblemBuilder(Problem.Severity.FATAL, "Could not parse your halconfig: " + e.getMessage()).build();
+    Problem problem = new ProblemBuilder(Problem.Severity.FATAL,
+        "Could not parse your halconfig: " + e.getMessage()).build();
     getProblems().add(problem);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
@@ -47,9 +47,9 @@ public class ValidateService {
   }
 
   private void recursiveValidate(ProblemSetBuilder psBuilder, Node node, NodeFilter filter) {
-    log.info("Running all validators for node " + node.getNodeName() + " with class " + node.getClass().getCanonicalName());
+    int runCount = validatorCollection.runAllValidators(psBuilder, node);
 
-    validatorCollection.runAllValidators(psBuilder, node);
+    log.info("Ran " + runCount + " validators for node \"" + node.getNodeName() + "\" with class \"" + node.getClass().getSimpleName() + "\"");
 
     NodeIterator children = node.getChildren();
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/ValidatorCollection.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/ValidatorCollection.java
@@ -52,8 +52,6 @@ public class ValidatorCollection {
       validatorRuns += runMatchingValidators(psBuilder, validator, node, node.getClass());
     }
 
-    log.info("Total validators run for node " + node.getClass() + " == " + validatorRuns);
-
     return validatorRuns;
   }
 
@@ -83,7 +81,7 @@ public class ValidatorCollection {
     } catch (NoSuchMethodException e) {
       // Do nothing, odds are most validators don't validate every class.
     } catch (InvocationTargetException | IllegalAccessException e) {
-      log.warn("Failed to invoke validate() on " + validator.getClass() + " for node " + c + " with cause " + e.getCause(), e);
+      log.warn("Failed to invoke validate() on \"" + validator.getClass().getSimpleName() + "\" for node \"" + c + "\" with cause " + e.getCause(), e);
     }
 
     return runMatchingValidators(psBuilder, validator, node, c.getSuperclass()) + result;

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParserSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParserSpec.groovy
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.halyard.config.config.v1
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig
 import org.yaml.snakeyaml.Yaml
@@ -33,7 +32,7 @@ class HalconfigParserSpec extends Specification {
   void setup() {
     parser = new HalconfigParser()
     parser.yamlParser = new Yaml()
-    parser.objectMapper = new ObjectMapper()
+    parser.objectMapper = new StrictObjectMapper()
   }
 
   void "Accept minimal config"() {

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/HalconfigParserMocker.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/HalconfigParserMocker.groovy
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.halyard.config.services.v1
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser
+import com.netflix.spinnaker.halyard.config.config.v1.StrictObjectMapper
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig
 import org.yaml.snakeyaml.Yaml
 import spock.lang.Specification
@@ -27,7 +27,7 @@ import java.nio.charset.StandardCharsets
 class HalconfigParserMocker extends Specification {
   HalconfigParser mockHalconfigParser(String config) {
     def parserStub = new HalconfigParser()
-    parserStub.objectMapper = new ObjectMapper()
+    parserStub.objectMapper = new StrictObjectMapper()
     parserStub.yamlParser = new Yaml()
     parserStub.halconfigPath = "/some/nonsense/file"
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
@@ -25,15 +25,11 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem.Severity;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.ProblemSet;
 import com.netflix.spinnaker.halyard.config.services.v1.ProviderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 import java.util.function.Supplier;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/config/deployments/{deployment:.+}/providers")


### PR DESCRIPTION
Errors without a problem set causing halyard to fail without an explanation.

The object mapper was also being instantiated incorrectly, using a bean definition from another imported project causing it to ignore unknown properties. @duftler or @danielpeach or @jtk54 PTAL