### PR TITLE
Use k8s api rather than kubectl to construct objects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ allprojects {
   apply plugin: 'groovy'
 
   spinnaker {
-    dependenciesVersion = "0.70.0"
+    dependenciesVersion = "0.72.0"
   }
   test {
     testLogging {

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/spinnaker/v1/component/SpinnakerComponentSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/spinnaker/v1/component/SpinnakerComponentSpec.groovy
@@ -67,7 +67,7 @@ class SpinnakerComponentSpec extends Specification {
 
   void "find all required files referenced by config"() {
     setup:
-    Node node = new NodeWithChildren();
+    Node node = new NodeWithChildren()
     SpinnakerComponent c = new SpinnakerComponent() {
       @Override
       protected String commentPrefix() {

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -3,6 +3,7 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
   compile spinnaker.dependency('lombok')
   compile spinnaker.dependency('clouddriverKubernetes')
+  compile spinnaker.dependency('fabric8Api')
 
   compile project(':halyard-config')
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/provider/v1/ProviderInterface.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/provider/v1/ProviderInterface.java
@@ -17,6 +17,8 @@
 package com.netflix.spinnaker.halyard.deploy.provider.v1;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.services.v1.DeploymentService;
+import com.netflix.spinnaker.halyard.config.spinnaker.v1.component.ComponentConfig;
 import com.netflix.spinnaker.halyard.config.spinnaker.v1.component.SpinnakerComponent;
 import com.netflix.spinnaker.halyard.deploy.component.v1.ComponentType;
 import com.netflix.spinnaker.halyard.deploy.component.v1.ServiceFactory;
@@ -26,7 +28,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * A ProviderInterface is an abstraction for communicating with a specific cloud-provider's installation
@@ -43,8 +47,27 @@ public abstract class ProviderInterface<T extends Account> {
   @Autowired
   String spinnakerOutputPath;
 
+  @Autowired
+  DeploymentService deploymentService;
+
   @Autowired(required = false)
   List<SpinnakerComponent> spinnakerComponents = new ArrayList<>();
+
+  Map<String, SpinnakerComponent> componentMap = null;
+
+  protected SpinnakerComponent getComponentByName(String name) {
+    if (componentMap == null) {
+      componentMap = new HashMap<>();
+      spinnakerComponents.forEach(c -> componentMap.put(c.getComponentName(), c));
+    }
+
+    return componentMap.get(name);
+  }
+
+  /**
+   * @return the docker image/debian package/etc... for a certain component.
+   */
+  abstract protected String componentArtifact(DeploymentDetails<T> details, SpinnakerComponent component);
 
   abstract public Object connectTo(DeploymentDetails<T> details, ComponentType componentType);
 


### PR DESCRIPTION
Given that the secrets/volumes will get fairly complicated to create, it's easier to instantiate our kubernetes objects like this.

@duftler or @jtk54 or @danielpeach PTAL