### PR TITLE
Make core package to compile cli alongwith web

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -1,10 +1,9 @@
 dependencies {
   compile spinnaker.dependency('lombok')
-  compile "com.beust:jcommander:1.48"
-  compile group: 'jline', name: 'jline', version: '2.11'
 
   compile project(':halyard-config')
-  compile project(':halyard-web')
+  compile project(':halyard-core')
+  compile project(':halyard-deploy')
 }
 
 apply plugin: 'java'

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -20,20 +20,17 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.DaemonResponse;
 import com.netflix.spinnaker.halyard.cli.services.v1.ResponseUnwrapper;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiParagraphBuilder;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiPrinter;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiStoryBuilder;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiStyle;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
-import java.net.ConnectException;
-import java.util.HashMap;
-import java.util.Map;
+import com.netflix.spinnaker.halyard.cli.ui.v1.*;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import retrofit.RetrofitError;
+
+import java.net.ConnectException;
+import java.util.HashMap;
+import java.util.Map;
 
 @Parameters(separators = "=")
 public abstract class NestableCommand {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -16,13 +16,13 @@
 
 package com.netflix.spinnaker.halyard.cli.services.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import java.util.List;
 
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.Versions;
 import retrofit.http.Body;
 import retrofit.http.DELETE;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
@@ -16,11 +16,12 @@
 
 package com.netflix.spinnaker.halyard.cli.services.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem.Severity;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.ProblemSet;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;

--- a/halyard-core/halyard-core.gradle
+++ b/halyard-core/halyard-core.gradle
@@ -2,9 +2,8 @@ dependencies {
   compile spinnaker.dependency('bootActuator')
   compile spinnaker.dependency('bootWeb')
   compile spinnaker.dependency('lombok')
-  compile spinnaker.dependency('clouddriverKubernetes')
-  compile spinnaker.dependency('fabric8Api')
+
+  compile "com.beust:jcommander:1.48"
 
   compile project(':halyard-config')
-  compile project(':halyard-core')
 }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard;
+package com.netflix.spinnaker.halyard.core;
 
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.errors.v1.HalconfigException;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.ProblemSet;
-import java.util.function.Supplier;
 import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.function.Supplier;
 
 /**
  * This serves to return exceptions encountered during validation that the client can explicitly chose to ignore alongside the desired response.

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -20,7 +20,9 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
   compile spinnaker.dependency('lombok')
 
+  compile project(':halyard-cli')
   compile project(':halyard-config')
+  compile project(':halyard-core')
   compile project(':halyard-deploy')
 }
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
@@ -17,9 +17,6 @@
 package com.netflix.spinnaker.halyard.controllers.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.halyard.DaemonResponse;
-import com.netflix.spinnaker.halyard.DaemonResponse.StaticRequestBuilder;
-import com.netflix.spinnaker.halyard.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
@@ -29,6 +26,10 @@ import com.netflix.spinnaker.halyard.config.model.v1.problem.ProblemSet;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import java.util.List;
 import java.util.function.Supplier;
+
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
@@ -16,10 +16,10 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
-import com.netflix.spinnaker.halyard.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.ConfigService;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
@@ -16,14 +16,14 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
-import com.netflix.spinnaker.halyard.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem.Severity;
 import com.netflix.spinnaker.halyard.config.services.v1.DeploymentService;
-import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.deploy.services.v1.DeployService;
+import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
@@ -17,15 +17,14 @@
 package com.netflix.spinnaker.halyard.controllers.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.halyard.DaemonResponse;
-import com.netflix.spinnaker.halyard.DaemonResponse.StaticRequestBuilder;
-import com.netflix.spinnaker.halyard.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem.Severity;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.ProblemSet;
 import com.netflix.spinnaker.halyard.config.services.v1.FeaturesService;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -44,13 +43,12 @@ public class FeaturesController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonResponse<Features> getFeatures(
-      @PathVariable String deployment,
+  DaemonResponse<Features> getFeatures(@PathVariable String deployment,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
     NodeFilter filter = new NodeFilter().setDeployment(deployment);
 
-    StaticRequestBuilder<Features> builder = new StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<Features> builder = new DaemonResponse.StaticRequestBuilder<>();
 
     builder.setBuildResponse(() -> featuresService.getFeatures(filter));
 
@@ -58,8 +56,7 @@ public class FeaturesController {
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
-  DaemonResponse<Void> setFeatures(
-      @PathVariable String deployment,
+  DaemonResponse<Void> setFeatures(@PathVariable String deployment,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
       @RequestBody Object rawFeatures) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
@@ -16,15 +16,15 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
-import com.netflix.spinnaker.halyard.DaemonResponse.StaticRequestBuilder;
-import com.netflix.spinnaker.halyard.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.Problem.Severity;
 import com.netflix.spinnaker.halyard.config.model.v1.problem.ProblemSet;
 import com.netflix.spinnaker.halyard.config.services.v1.ProviderService;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.deploy.services.v1.VersionsService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.Versions;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigExceptionHandler.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/errors/v1/HalconfigExceptionHandler.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.halyard.errors.v1;
 
-import com.netflix.spinnaker.halyard.DaemonResponse;
 import com.netflix.spinnaker.halyard.config.errors.v1.HalconfigException;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;

--- a/settings.gradle
+++ b/settings.gradle
@@ -18,6 +18,7 @@ rootProject.name="halyard"
 
 include 'halyard-cli'
 include 'halyard-config'
+include 'halyard-core'
 include 'halyard-deploy'
 include 'halyard-web'
 


### PR DESCRIPTION
This moves a shared dependency from -web to -core, allowing us to build one jar containing both cli & web entrypoints.