### PR TITLE
Create new startup scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,3 +54,22 @@ subprojects { project ->
 }
 
 defaultTasks ':halyard-web:bootRun'
+
+// Creates scripts for entry points
+// Subproject must apply application plugin to be able to call this method.
+def createScript(project, mainClass, name) {
+  project.tasks.create(name: name, type: CreateStartScripts) {
+    outputDir       = new File(project.buildDir, 'scripts')
+    mainClassName   = mainClass
+    applicationName = name
+    classpath       = project.tasks[JavaPlugin.JAR_TASK_NAME].outputs.files + project.configurations.runtime
+  }
+  project.tasks[name].dependsOn(project.jar)
+
+  project.applicationDistribution.with {
+    into("bin") {
+      from(project.tasks[name])
+      fileMode = 0755
+    }
+  }
+}

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'spring-boot'
 apply plugin: 'spinnaker.package'
+apply plugin: 'application'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
@@ -27,3 +28,9 @@ dependencies {
 }
 
 tasks.bootRepackage.enabled = project.repackage
+
+startScripts.enabled = false
+run.enabled = false
+
+createScript(project, 'com.netflix.spinnaker.halyard.cli.Main', 'hal')
+createScript(project, 'com.netflix.spinnaker.halyard.Main', 'halyard')


### PR DESCRIPTION
This should (in theory) create startup scripts in the debian to run halyard in two modes.