### PR TITLE
Sort help & subcommand flags

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
@@ -29,6 +29,8 @@ public class GlobalOptions {
 
   private boolean debug = false;
 
+  private boolean help = false;
+
   private static GlobalOptions globalOptions = null;
 
   public static boolean isGlobalOption(String name) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -29,8 +29,7 @@ import lombok.Setter;
 import retrofit.RetrofitError;
 
 import java.net.ConnectException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 @Parameters(separators = "=")
 public abstract class NestableCommand {
@@ -133,12 +132,15 @@ public abstract class NestableCommand {
     paragraph.addSnippet(usage);
     story.addNewline();
 
-    if (!commander.getParameters().isEmpty()) {
+    List<ParameterDescription> parameters = commander.getParameters();
+    parameters.sort(Comparator.comparing(ParameterDescription::getNames));
+
+    if (!parameters.isEmpty()) {
       paragraph = story.addParagraph();
       paragraph.addSnippet("GLOBAL PARAMETERS").addStyle(AnsiStyle.BOLD);
       story.addNewline();
 
-      for (ParameterDescription parameter : commander.getParameters()) {
+      for (ParameterDescription parameter : parameters) {
         if (GlobalOptions.isGlobalOption(parameter.getLongestName())) {
           formatParameter(story, parameter, indentWidth);
         }
@@ -158,7 +160,7 @@ public abstract class NestableCommand {
         story.addNewline();
       }
 
-      for (ParameterDescription parameter : commander.getParameters()) {
+      for (ParameterDescription parameter : parameters) {
         if (!GlobalOptions.isGlobalOption(parameter.getLongestName())) {
           formatParameter(story, parameter, indentWidth);
         }
@@ -177,7 +179,10 @@ public abstract class NestableCommand {
       paragraph.addSnippet("SUBCOMMANDS").addStyle(AnsiStyle.BOLD);
       story.addNewline();
 
-      for (String key : subcommands.keySet()) {
+      List<String> keys = new ArrayList<>(subcommands.keySet());
+      keys.sort(String::compareTo);
+
+      for (String key : keys) {
         paragraph = story.addParagraph().setIndentWidth(indentWidth);
         paragraph.addSnippet(key).addStyle(AnsiStyle.BOLD);
 


### PR DESCRIPTION
This makes reading the command's help a little easier, as well as pulls `--help` into a global parameters (which it is).