### PR TITLE
Adds basic tab-completion support to halyard

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1;
 
+import com.beust.jcommander.Parameter;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -32,6 +33,12 @@ public class HalCommand extends NestableCommand {
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "hal";
 
+  @Parameter(
+      names = "--print-bash-completion",
+      description = "Print bash command completion."
+  )
+  private boolean printBashCompletion;
+
   public HalCommand() {
     registerSubcommand(new ConfigCommand());
     registerSubcommand(new DeployCommand());
@@ -45,6 +52,10 @@ public class HalCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    showHelp();
+    if (printBashCompletion) {
+      System.out.println(commandCompletor());
+    } else {
+      showHelp();
+    }
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -23,6 +23,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.services.v1.ResponseUnwrapper;
 import com.netflix.spinnaker.halyard.cli.ui.v1.*;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.resource.v1.JarResource;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -38,7 +39,7 @@ public abstract class NestableCommand {
   private JCommander commander;
 
   @Parameter(names = { "-h", "--help" }, help = true, description = "Display help text about this command.")
-  public boolean help;
+  private boolean help;
 
   @Parameter(names = {"-d", "--debug"}, description = "Show detailed network traffic with halyard daemon.")
   public void setDebug(boolean debug) {
@@ -101,7 +102,7 @@ public abstract class NestableCommand {
     }
   }
 
-  public void showHelp() {
+  protected void showHelp() {
     AnsiStoryBuilder story = new AnsiStoryBuilder();
     int indentWidth = 2;
 
@@ -215,6 +216,45 @@ public abstract class NestableCommand {
     paragraph = story.addParagraph().setIndentWidth(indentWidth * 2);
     paragraph.addSnippet(parameter.getDescription());
     story.addNewline();
+  }
+
+  public String commandCompletor() {
+    JarResource completorBody = new JarResource("/hal-completor-body");
+    Map<String, String> bindings = new HashMap<>();
+
+    String body = aggregateCompletorCases();
+    bindings.put("body", body);
+
+    return completorBody.setBindings(bindings).toString();
+  }
+
+  private String aggregateCompletorCases() {
+    String result = commandCompletorCase();
+
+    return subcommands.entrySet()
+        .stream()
+        .map(c -> c.getValue().aggregateCompletorCases())
+        .reduce(result, (a, b) -> a + b);
+  }
+
+  private String commandCompletorCase() {
+    JarResource completorCase = new JarResource("/hal-completor-case");
+    Map<String, String> bindings = new HashMap<>();
+    String flagNames = commander.getParameters()
+        .stream()
+        .map(ParameterDescription::getLongestName)
+        .reduce("", (a, b) -> a + " " + b);
+
+    String subcommandNames = subcommands.entrySet()
+        .stream()
+        .map(Map.Entry::getKey)
+        .reduce("", (a, b) -> a + " " + b);
+
+    bindings.put("subcommands", subcommandNames);
+    bindings.put("flags", flagNames);
+    bindings.put("command", getCommandName());
+
+    return completorCase.setBindings(bindings).toString();
   }
 
   abstract public String getDescription();

--- a/halyard-cli/src/main/resources/hal-completor-body
+++ b/halyard-cli/src/main/resources/hal-completor-body
@@ -1,0 +1,12 @@
+# halyard-cli command completion
+
+_hal() {
+    local cur prev
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+{%body%}
+}
+
+complete -F _hal hal

--- a/halyard-cli/src/main/resources/hal-completor-case
+++ b/halyard-cli/src/main/resources/hal-completor-case
@@ -1,0 +1,14 @@
+    if [[ ${prev} == {%command%} ]]; then
+        local flags subcommands
+        flags="{%flags%}"
+        subcommands="{%subcommands%}"
+
+        if [[ ${cur} == -* ]]; then
+            COMPREPLY=( $(compgen -W "${flags}" -- ${cur}) )
+            return 0
+        fi
+
+        COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
+        return 0
+    fi
+

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/JarResource.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/JarResource.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.deploy.resource.v1;
+package com.netflix.spinnaker.halyard.core.resource.v1;
 
 import com.amazonaws.util.IOUtils;
 import com.netflix.spinnaker.halyard.config.resource.v1.TemplatedResource;

--- a/halyard-web/pkg_scripts/postInstall.sh
+++ b/halyard-web/pkg_scripts/postInstall.sh
@@ -17,4 +17,9 @@ echo '/opt/halyard/bin/hal "$@"' | sudo tee -a /usr/local/bin/hal
 
 chmod +x /usr/local/bin/hal
 
+sudo mkdir -p /etc/bash_completion.d
+sudo hal --print-bash-completion > /etc/bash_completion.d/hal
+
+. /etc/bash_completion.d/hal
+
 install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/halyard 


### PR DESCRIPTION
@duftler or @jtk54 or @danielpeach PTAL

This doesn't (yet) do fancy things like ask the daemon for options, but generates completion help for all statically known subcommands & flags. If you're interested in how it works, read [this](https://debian-administration.org/article/317/An_introduction_to_bash_completion_part_2).