### PR TITLE
Two fixes to debian installer scripts

### DIFF
--- a/halyard-web/pkg_scripts/postInstall.sh
+++ b/halyard-web/pkg_scripts/postInstall.sh
@@ -13,12 +13,12 @@ fi
 
 
 echo '#!/usr/bin/env bash' | sudo tee /usr/local/bin/hal
-echo '/opt/halyard/bin/hal "$@"' | sudo tee -a /usr/local/bin/hal
+echo '/opt/halyard/bin/hal "$@"' | sudo tee /usr/local/bin/hal
 
 chmod +x /usr/local/bin/hal
 
 sudo mkdir -p /etc/bash_completion.d
-sudo hal --print-bash-completion > /etc/bash_completion.d/hal
+hal --print-bash-completion | sudo tee /etc/bash_completion.d/hal
 
 . /etc/bash_completion.d/hal
 


### PR DESCRIPTION
1. Overwrite rather than append to command-completion & wrapper scripts
2. Use tee rather than pipes to write command completion

@duftler or @jtk54 or @danielpeach PTAL