### PR TITLE
fix script generation

### DIFF
--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -1,6 +1,5 @@
 apply plugin: 'spring-boot'
 apply plugin: 'spinnaker.package'
-apply plugin: 'application'
 
 ext {
   springConfigLocation = System.getProperty('spring.config.location', "${System.getProperty('user.home')}/.spinnaker/")
@@ -29,8 +28,16 @@ dependencies {
 
 tasks.bootRepackage.enabled = project.repackage
 
-startScripts.enabled = false
-run.enabled = false
+mainClassName = 'com.netflix.spinnaker.halyard.Main'
 
-createScript(project, 'com.netflix.spinnaker.halyard.cli.Main', 'hal')
-createScript(project, 'com.netflix.spinnaker.halyard.Main', 'halyard')
+def cliScript = project.tasks.create('createCliStartScripts', CreateStartScripts) {
+  dependsOn(project.tasks.startScripts)
+  mainClassName = 'com.netflix.spinnaker.halyard.cli.Main'
+  applicationName = 'hal'
+  outputDir = project.tasks.startScripts.outputDir
+  classpath = project.tasks.startScripts.classpath
+}
+
+tasks.installDist.dependsOn(cliScript)
+tasks.distZip.dependsOn(cliScript)
+tasks.distTar.dependsOn(cliScript)


### PR DESCRIPTION
@ttomsu @lwander PTAL

actions in the gradle build should run in a task, the calls to startScripts I think were happening during a couple phases of the buildscript interpretation

setting mainClassName on the project will make the default startScripts call generate the script/application for that and then adding another CreateStartScripts task spits out the cli script.

confirmed that the resulting distZip / distTar only has one copy of each