### PR TITLE
Remove postInstall bash completion

### DIFF
--- a/halyard-web/pkg_scripts/postInstall.sh
+++ b/halyard-web/pkg_scripts/postInstall.sh
@@ -17,9 +17,4 @@ echo '/opt/halyard/bin/hal "$@"' | sudo tee /usr/local/bin/hal
 
 chmod +x /usr/local/bin/hal
 
-sudo mkdir -p /etc/bash_completion.d
-hal --print-bash-completion | sudo tee /etc/bash_completion.d/hal
-
-. /etc/bash_completion.d/hal
-
 install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/halyard 


### PR DESCRIPTION
This is currently the wrong approach - the completion is only sourced in the shell running the installer. I'm not sure what the right approach is yet, but right now the install is broken.