### PR TITLE
Start of halyard config security

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -41,22 +42,36 @@ public class DeploymentConfiguration extends Node {
   String version = "latest";
 
   /**
-   * Providers, e.g. Kubernetes, GCE, AWS, ...
+   * Providers, e.g. Kubernetes, GCE, AWS, etc...
    */
   Providers providers = new Providers();
 
+  /**
+   * Details about how Spinnaker is deployed, e.g. which account is it running in, what's the footprint, etc...
+   */
   DeploymentEnvironment deploymentEnvironment = new DeploymentEnvironment();
 
+  /**
+   * GCS/S3 configuration for front50.
+   */
   PersistentStorage persistentStorage = new PersistentStorage();
 
+  /**
+   * Spinnaker feature flags.
+   */
   Features features = new Features();
 
   String timezone = "America/Los_Angeles";
 
   /**
-   * Webhooks, e.g. Jenkins, TravisCI, ...
+   * Webhooks, e.g. Jenkins, TravisCI, etc...
    */
   Webhooks webhooks = new Webhooks();
+
+  /**
+   * Authn & Authz configuration.
+   */
+  Security security = new Security();
 
   @Override
   public String getNodeName() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authn.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authn.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.security;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIterator;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIteratorFactory;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Data
+public class Authn extends Node {
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+
+  @Getter
+  private String nodeName = "authn";
+
+  @Override
+  public NodeIterator getChildren() {
+    return NodeIteratorFactory.makeEmptyIterator();
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Security.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Security.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.security;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.*;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Data
+public class Security extends Node {
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+
+  @Getter
+  private String nodeName = "security";
+
+  @Override
+  public NodeIterator getChildren() {
+    return NodeIteratorFactory.makeReflectiveIterator(this);
+  }
+
+  private String apiAddress = "localhost";
+  private String apiDomain;
+  private String uiAddress = "localhost";
+  private String uiDomain;
+
+  private Ssl ssl = new Ssl();
+  private Authn authn = new Authn();
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Ssl.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Ssl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.security;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.*;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+@Data
+public class Ssl extends Node {
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+
+  @Getter
+  private String nodeName = "ssl";
+
+  @Override
+  public NodeIterator getChildren() {
+    return NodeIteratorFactory.makeEmptyIterator();
+  }
+
+  private boolean enabled = false;
+
+  @LocalFile private String serverKeyPath;
+  @LocalFile private String caKeyPath;
+
+  @LocalFile private String keystorePath;
+  private String keystoreAlias;
+  private String keystorePassword;
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentDetails.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentDetails.java
@@ -25,6 +25,6 @@ import lombok.Data;
 public class DeploymentDetails {
   String deploymentName;
   DeploymentEnvironment deploymentEnvironment;
-  SpinnakerEndpoints endpoints = new SpinnakerEndpoints();
+  SpinnakerEndpoints endpoints;
   GenerateResult generateResult;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/EndpointFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/EndpointFactory.java
@@ -37,7 +37,7 @@ public class EndpointFactory {
     DeploymentEnvironment.DeploymentType type = deploymentConfiguration.getDeploymentEnvironment().getType();
     switch (type) {
       case LocalhostDebian:
-        return new SpinnakerEndpoints();
+        return new SpinnakerEndpoints(deploymentConfiguration.getSecurity());
       case Flotilla:
         return createFlotillaEndpoints(deploymentConfiguration);
       default:
@@ -48,6 +48,7 @@ public class EndpointFactory {
   private SpinnakerEndpoints createFlotillaEndpoints(DeploymentConfiguration deploymentConfiguration) {
     DeploymentEnvironment deploymentEnvironment = deploymentConfiguration.getDeploymentEnvironment();
     String accountName = deploymentEnvironment.getAccountName();
+    SpinnakerEndpoints endpoints = new SpinnakerEndpoints(deploymentConfiguration.getSecurity());
 
     if (accountName == null || accountName.isEmpty()) {
       throw new HalException(new ConfigProblemBuilder(Problem.Severity.FATAL, "An account name must be "
@@ -59,7 +60,6 @@ public class EndpointFactory {
 
     switch (providerType) {
       case KUBERNETES:
-        SpinnakerEndpoints endpoints = new SpinnakerEndpoints();
         SpinnakerEndpoints.Services services = endpoints.getServices();
 
         services.getClouddriver().setAddress("spin-clouddriver.spinnaker").setHost("0.0.0.0");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalhostDebianDeployment.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalhostDebianDeployment.java
@@ -56,7 +56,7 @@ public class LocalhostDebianDeployment extends Deployment {
 
   @Override
   public SpinnakerEndpoints getEndpoints() {
-    return new SpinnakerEndpoints();
+    return deploymentDetails.getEndpoints();
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/DeckProfile.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/DeckProfile.java
@@ -59,7 +59,7 @@ public class DeckProfile extends SpinnakerProfile {
 
     Map<String, String> bindings = new HashMap<>();
     // Configure global settings
-    bindings.put("gate.baseUrl", endpoints.getServices().getGate().getBaseUrl());
+    bindings.put("gate.baseUrl", endpoints.getServices().getGate().getPublicEndpoint());
     bindings.put("timezone", deploymentConfiguration.getTimezone());
 
     // Configure feature-flags

--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,3 @@
 lombok.nonNull.exceptionType = IllegalArgumentException
 lombok.accessors.chain = true
+lombok.equalsAndHashCode.callSuper = skip


### PR DESCRIPTION
https://github.com/spinnaker/halyard/issues/108

This is the smallest amount of work needed to get Deck to read Gates new public URL by adding support for SSL configuration & public UI + API addresses. @ttomsu and I figure it's best to do TLS across all the Spinnaker services (when it's enabled) so it's an all-or-nothing approach there.

@duftler or @jtk54 or @danielpeach PTAL