### PR TITLE
Make the halconfig thread local

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -30,19 +30,21 @@ public class Daemon {
   }
 
   public static Features getFeatures(String deploymentName, boolean validate) {
-    return ResponseUnwrapper.get(service.getFeatures(deploymentName, validate));
+    Object rawFeatures = ResponseUnwrapper.get(getService().getFeatures(deploymentName, validate));
+    return getObjectMapper().convertValue(rawFeatures, Features.class);
   }
 
   public static void setFeatures(String deploymentName, boolean validate, Features features) {
-    ResponseUnwrapper.get(service.setFeatures(deploymentName, validate, features));
+    ResponseUnwrapper.get(getService().setFeatures(deploymentName, validate, features));
   }
 
   public static PersistentStorage getPersistentStorage(String deploymentName, boolean validate) {
-    return ResponseUnwrapper.get(service.getPersistentStorage(deploymentName, validate));
+    Object rawStorage = ResponseUnwrapper.get(getService().getPersistentStorage(deploymentName, validate));
+    return getObjectMapper().convertValue(rawStorage, PersistentStorage.class);
   }
 
   public static void setPersistentStorage(String deploymentName, boolean validate, PersistentStorage persistentStorage) {
-    ResponseUnwrapper.get(service.setPersistentStorage(deploymentName, validate, persistentStorage));
+    ResponseUnwrapper.get(getService().setPersistentStorage(deploymentName, validate, persistentStorage));
   }
 
   public static Account getAccount(String deploymentName, String providerName, String accountName, boolean validate) {
@@ -79,12 +81,13 @@ public class Daemon {
     ResponseUnwrapper.get(getService().deployDeployment(deploymentName, validate, ""));
   }
 
-  public static <T> DaemonTask<T> getTask(String uuid) {
+  public static <C, T> DaemonTask<C, T> getTask(String uuid) {
     return getService().getTask(uuid);
   }
 
   public static Versions getVersions() {
-    return ResponseUnwrapper.get(getService().getVersions());
+    Object rawVersions = ResponseUnwrapper.get(getService().getVersions());
+    return getObjectMapper().convertValue(rawVersions, Versions.class);
   }
 
   private static DaemonService getService() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -33,87 +33,87 @@ import retrofit.http.Query;
 
 public interface DaemonService {
   @GET("/v1/tasks/{uuid}/")
-  <T> DaemonTask<T> getTask(@Path("uuid") String uuid);
+  <C, T> DaemonTask<C, T> getTask(@Path("uuid") String uuid);
 
   @GET("/v1/config/")
-  DaemonResponse<Halconfig> getHalconfig();
+  DaemonTask<Halconfig, Halconfig> getHalconfig();
 
   @GET("/v1/config/currentDeployment/")
-  DaemonResponse<String> getCurrentDeployment();
+  DaemonTask<Halconfig, String> getCurrentDeployment();
 
   @GET("/v1/config/deployments/")
-  DaemonResponse<List<DeploymentConfiguration>> getDeployments();
+  DaemonTask<Halconfig, List<DeploymentConfiguration>> getDeployments();
 
   @GET("/v1/config/deployments/{deploymentName}/")
-  DaemonResponse<DeploymentConfiguration> getDeployment(
+  DaemonTask<Halconfig, DeploymentConfiguration> getDeployment(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate);
 
   @POST("/v1/config/deployments/{deploymentName}/generate/")
-  DaemonTask<Void> generateDeployment(
+  DaemonTask<Halconfig, Void> generateDeployment(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
       @Body String _ignore);
 
   @POST("/v1/config/deployments/{deploymentName}/deploy/")
-  DaemonTask<Void> deployDeployment(
+  DaemonTask<Halconfig, Void> deployDeployment(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
       @Body String _ignore);
 
   @GET("/v1/config/deployments/{deploymentName}/features/")
-  DaemonResponse<Features> getFeatures(
+  DaemonTask<Halconfig, Features> getFeatures(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate);
 
 
   @PUT("/v1/config/deployments/{deploymentName}/features/")
-  DaemonResponse<Void> setFeatures(
+  DaemonTask<Halconfig, Void> setFeatures(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
       @Body Features features);
 
   @GET("/v1/config/deployments/{deploymentName}/persistentStorage/")
-  DaemonResponse<PersistentStorage> getPersistentStorage(
+  DaemonTask<Halconfig, PersistentStorage> getPersistentStorage(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate);
 
 
   @PUT("/v1/config/deployments/{deploymentName}/persistentStorage/")
-  DaemonResponse<Void> setPersistentStorage(
+  DaemonTask<Halconfig, Void> setPersistentStorage(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
       @Body PersistentStorage persistentStorage);
 
   @GET("/v1/config/deployments/{deploymentName}/providers/{providerName}/")
-  DaemonResponse<Object> getProvider(
+  DaemonTask<Halconfig, Object> getProvider(
       @Path("deploymentName") String deploymentName,
       @Path("providerName") String providerName,
       @Query("validate") boolean validate);
 
   @PUT("/v1/config/deployments/{deploymentName}/providers/{providerName}/enabled/")
-  DaemonResponse<Void> setProviderEnabled(
+  DaemonTask<Halconfig, Void> setProviderEnabled(
       @Path("deploymentName") String deploymentName,
       @Path("providerName") String providerName,
       @Query("validate") boolean validate,
       @Body boolean enabled);
 
   @POST("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/")
-  DaemonResponse<Void> addAccount(
+  DaemonTask<Halconfig, Void> addAccount(
       @Path("deploymentName") String deploymentName,
       @Path("providerName") String providerName,
       @Query("validate") boolean validate,
       @Body Account account);
 
   @GET("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/{accountName}/")
-  DaemonResponse<Object> getAccount(
+  DaemonTask<Halconfig, Object> getAccount(
       @Path("deploymentName") String deploymentName,
       @Path("providerName") String providerName,
       @Path("accountName") String accountName,
       @Query("validate") boolean validate);
 
   @PUT("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/{accountName}/")
-  DaemonResponse<Void> setAccount(
+  DaemonTask<Halconfig, Void> setAccount(
       @Path("deploymentName") String deploymentName,
       @Path("providerName") String providerName,
       @Path("accountName") String accountName,
@@ -121,12 +121,12 @@ public interface DaemonService {
       @Body Account account);
 
   @DELETE("/v1/config/deployments/{deploymentName}/providers/{providerName}/accounts/{accountName}/")
-  DaemonResponse<Object> deleteAccount(
+  DaemonTask<Halconfig, Object> deleteAccount(
       @Path("deploymentName") String deploymentName,
       @Path("providerName") String providerName,
       @Path("accountName") String accountName,
       @Query("validate") boolean validate);
 
   @GET("/v1/versions/")
-  DaemonResponse<Versions> getVersions();
+  DaemonTask<Halconfig, Versions> getVersions();
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
@@ -32,14 +32,14 @@ import java.util.Map;
 import java.util.Map.Entry;
 
 public class ResponseUnwrapper<T> {
-  private static final Long WAIT_MILLIS = 500L;
+  private static final Long WAIT_MILLIS = 200L;
 
   public static <T> T get(DaemonResponse<T> response) {
     formatProblemSet(response.getProblemSet());
     return response.getResponseBody();
   }
 
-  public static <T> T get(DaemonTask<T> task) {
+  public static <C, T> T get(DaemonTask<C, T> task) {
     PrintCoordinates coords = new PrintCoordinates();
     while (task.getState() != DaemonTask.State.SUCCESS) {
       coords = formatStages(task.getStages(), coords);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/PersistentStorage.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/PersistentStorage.java
@@ -4,8 +4,10 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleProv
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -14,6 +16,7 @@ import java.util.stream.Collectors;
  */
 @Data
 @EqualsAndHashCode(callSuper = false)
+@Slf4j
 public class PersistentStorage extends Node {
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authn.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authn.java
@@ -40,4 +40,6 @@ public class Authn extends Node {
   public NodeIterator getChildren() {
     return NodeIteratorFactory.makeEmptyIterator();
   }
+
+  private boolean enabled;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ConfigService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ConfigService.java
@@ -33,7 +33,7 @@ public class ConfigService {
   private HalconfigParser halconfigParser;
 
   public Halconfig getConfig() {
-    return halconfigParser.getHalconfig(true);
+    return halconfigParser.getHalconfig();
   }
 
   public String getCurrentDeployment() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/LookupService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/LookupService.java
@@ -39,7 +39,7 @@ public class LookupService {
    * @return the nodes matching the filter and clazz.
    */
   public <T extends Node> List<T> getMatchingNodesOfType(NodeFilter filter, Class<T> clazz) {
-    Halconfig halconfig = parser.getHalconfig(true);
+    Halconfig halconfig = parser.getHalconfig();
 
     return getMatchingNodes(halconfig, filter)
         .stream()

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ValidateService.java
@@ -39,7 +39,7 @@ public class ValidateService {
   ValidatorCollection validatorCollection;
 
   ProblemSet validateMatchingFilter(NodeFilter filter, Problem.Severity severity) {
-    Halconfig halconfig = parser.getHalconfig(false);
+    Halconfig halconfig = parser.getHalconfig();
     ConfigProblemSetBuilder psBuilder = new ConfigProblemSetBuilder().setSeverity(severity);
     recursiveValidate(psBuilder, halconfig, filter);
 

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/HalconfigParserMocker.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/HalconfigParserMocker.groovy
@@ -35,7 +35,7 @@ class HalconfigParserMocker extends Specification {
     Halconfig halconfig = parserStub.parseHalconfig(stream)
     halconfig = parserStub.transformHalconfig(halconfig)
     HalconfigParser parser = Mock(HalconfigParser)
-    parser.getHalconfig(_) >> halconfig
+    parser.getHalconfig() >> halconfig
     return parser
   }
 }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.halyard.core.tasks.v1;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import lombok.Data;
 
@@ -11,12 +12,13 @@ import java.util.List;
  * It is made up of multiple stages, each of which have multiple events.
  */
 @Data
-public class DaemonTask<T> {
+public class DaemonTask<C, T> {
   List<DaemonStage> stages = new ArrayList<>();
   String uuid;
   State state = State.NOT_STARTED;
   DaemonResponse<T> response;
   Exception fatalError;
+  @JsonIgnore C context;
 
   void finishStage() {
     DaemonStage lastStage = getLastStage();

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTaskHandler.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTaskHandler.java
@@ -14,6 +14,14 @@ public class DaemonTaskHandler {
     return localTask.get();
   }
 
+  public static Object getContext() {
+    return localTask.get().getContext();
+  }
+
+  public static void setContext(Object context) {
+    localTask.get().setContext(context);
+  }
+
   public static void newStage(String name) {
     if (getTask() != null) {
       getTask().newStage(name);

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/TaskRepository.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/TaskRepository.java
@@ -18,10 +18,10 @@ import java.util.function.Supplier;
 public class TaskRepository {
   static final Map<String, DaemonTaskStatus> tasks = new ConcurrentHashMap<>();
 
-  static public <T> DaemonTask<T> submitTask(Supplier<DaemonResponse<T>> runner) {
+  static public <C, T> DaemonTask<C, T> submitTask(Supplier<DaemonResponse<T>> runner) {
     String uuid = UUID.randomUUID().toString();
     log.info("Scheduling task " + uuid);
-    DaemonTask<T> task = new DaemonTask<T>().setUuid(uuid);
+    DaemonTask<C, T> task = new DaemonTask<C, T>().setUuid(uuid);
     Runnable r = () -> {
       log.info("Starting task " + uuid);
       DaemonTaskHandler.setTask(task);
@@ -45,13 +45,13 @@ public class TaskRepository {
     return task;
   }
 
-  static public <T> DaemonTask<T> getTask(String uuid) {
+  static public <C, T> DaemonTask<C, T> getTask(String uuid) {
     DaemonTaskStatus status = tasks.get(uuid);
 
     if (status == null) {
       return null;
     }
-    DaemonTask<T> task = status.getTask();
+    DaemonTask<C, T> task = status.getTask();
     Exception fatalError = null;
     switch (task.getState()) {
       case NOT_STARTED:

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
@@ -20,6 +20,8 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.ConfigService;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -35,16 +37,16 @@ public class ConfigController {
   ConfigService configService;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonResponse<Halconfig> config() {
+  DaemonTask<Halconfig, Halconfig> config() {
     StaticRequestBuilder<Halconfig> builder = new StaticRequestBuilder<>();
     builder.setBuildResponse(() -> configService.getConfig());
-    return builder.build();
+    return TaskRepository.submitTask(builder::build);
   }
 
   @RequestMapping(value = "/currentDeployment", method = RequestMethod.GET)
-  DaemonResponse<String> currentDeployment() {
+  DaemonTask<Halconfig, String> currentDeployment() {
     StaticRequestBuilder<String> builder = new StaticRequestBuilder<>();
     builder.setBuildResponse(() -> configService.getCurrentDeployment());
-    return builder.build();
+    return TaskRepository.submitTask(builder::build);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.controllers.v1;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.DeploymentService;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
@@ -73,7 +74,7 @@ public class DeploymentController {
   }
 
   @RequestMapping(value = "/{deploymentName:.+}/generate/", method = RequestMethod.POST)
-  DaemonTask<Void> generateConfig(@PathVariable String deploymentName) {
+  DaemonTask<Halconfig, Void> generateConfig(@PathVariable String deploymentName) {
     StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
 
     builder.setBuildResponse(() -> {
@@ -85,7 +86,7 @@ public class DeploymentController {
   }
 
   @RequestMapping(value = "/{deploymentName:.+}/deploy/", method = RequestMethod.POST)
-  DaemonTask<Void> deploy(@PathVariable String deploymentName) {
+  DaemonTask<Halconfig, Void> deploy(@PathVariable String deploymentName) {
     StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
 
     builder.setBuildResponse(() -> {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PersistentStorageController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PersistentStorageController.java
@@ -18,12 +18,15 @@ package com.netflix.spinnaker.halyard.controllers.v1;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStorage;
 import com.netflix.spinnaker.halyard.config.services.v1.PersistentStorageService;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,7 +45,7 @@ public class PersistentStorageController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonResponse<PersistentStorage> getPersistentStorage(@PathVariable String deploymentName,
+  DaemonTask<Halconfig, PersistentStorage> getPersistentStorage(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<PersistentStorage> builder = new DaemonResponse.StaticRequestBuilder<>();
@@ -53,11 +56,11 @@ public class PersistentStorageController {
       builder.setValidateResponse(() -> persistentStorageService.validatePersistentStorage(deploymentName, severity));
     }
 
-    return builder.build();
+    return TaskRepository.submitTask(builder::build);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
-  DaemonResponse<Void> setPersistentStorage(@PathVariable String deploymentName,
+  DaemonTask<Halconfig, Void> setPersistentStorage(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
       @RequestBody Object rawPersistentStorage) {
@@ -77,6 +80,6 @@ public class PersistentStorageController {
     builder.setRevert(() -> halconfigParser.undoChanges());
     builder.setSave(() -> halconfigParser.saveConfig());
 
-    return builder.build();
+    return TaskRepository.submitTask(builder::build);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/TaskController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/TaskController.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.halyard.controllers.v1;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -11,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/v1/tasks/")
 public class TaskController {
   @RequestMapping(value = "/{uuid:.+}/", method = RequestMethod.GET)
-  DaemonTask<Void> generateConfig(@PathVariable String uuid) {
+  DaemonTask<Halconfig, Void> generateConfig(@PathVariable String uuid) {
     return TaskRepository.getTask(uuid);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -16,7 +16,10 @@
 
 package com.netflix.spinnaker.halyard.controllers.v1;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
 import com.netflix.spinnaker.halyard.deploy.services.v1.VersionsService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.Versions;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,9 +34,9 @@ public class VersionsController {
   VersionsService versionsService;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonResponse<Versions> config() {
+  DaemonTask<Halconfig, Versions> config() {
     DaemonResponse.StaticRequestBuilder<Versions> builder = new DaemonResponse.StaticRequestBuilder<>();
     builder.setBuildResponse(() -> versionsService.getVersions());
-    return builder.build();
+    return TaskRepository.submitTask(builder::build);
   }
 }


### PR DESCRIPTION
There was a corner case preventing validators from using the lookup
services, since they would implicitly load from disk rather than
validate what had been modified in memory. This was caught in the
edit-storage command which would rely on the account lookup service to
check that the specified account was of the correct type.

This is fixed by making the halconfig thread local to any task or 
operation that needed to edit it. 

@duftler PTAL 