### PR TITLE
Dedup bash completion

### DIFF
--- a/halyard-cli/src/main/resources/hal-completor-body
+++ b/halyard-cli/src/main/resources/hal-completor-body
@@ -1,10 +1,10 @@
 # halyard-cli command completion
 
 _hal() {
-    local cur prev
+    local cur prev ptr
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
 
 {%body%}
 }

--- a/halyard-cli/src/main/resources/hal-completor-case
+++ b/halyard-cli/src/main/resources/hal-completor-case
@@ -1,14 +1,28 @@
-    if [[ ${prev} == {%command%} ]]; then
-        local flags subcommands
-        flags="{%flags%}"
-        subcommands="{%subcommands%}"
 
-        if [[ ${cur} == -* ]]; then
-            COMPREPLY=( $(compgen -W "${flags}" -- ${cur}) )
+    ptr="${COMP_WORDS[{%depth%}]}"
+
+    if [ "${ptr}" = "{%command%}" ]; then
+
+        if [ "{%next%}" -eq "$COMP_CWORD" ]; then
+
+            local flags subcommands
+
+            flags="{%flags%}"
+            subcommands="{%subcommands%}"
+
+            if [ "${cur}" == "-*" ]; then
+                COMPREPLY=( $(compgen -W "${flags}" -- ${cur}) )
+                return 0
+            fi
+
+            COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
             return 0
+
+        else
+
+        {%recurse%}
+
         fi
 
-        COMPREPLY=( $(compgen -W "${subcommands}" -- ${cur}) )
-        return 0
     fi
 


### PR DESCRIPTION
Now that some commands share names, the bash completion logic needed to
walk the list of commands and recursively match on the NestableCommand
object.

Here's the output https://gist.github.com/lwander/61d934135da10715055b7b13ddc37f56