### PR TITLE
Backup generated config

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.config.v1;
+
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@Component
+public class HalconfigDirectoryStructure {
+  @Autowired
+  String halconfigDirectory;
+
+  public Path getUserProfilePath(String deploymentName) {
+    return ensureRelativeHalDirectory(deploymentName, "profiles");
+  }
+
+  public Path getHistoryPath(String deploymentName) {
+    return ensureRelativeHalDirectory(deploymentName, "history");
+  }
+
+  public Path getBackupConfigPath(String deploymentName) {
+    File history = ensureRelativeHalDirectory(deploymentName, "history").toFile();
+    return new File(history, "halconfig").toPath();
+  }
+
+  public Path getGenerateResultPath(String deploymentName) {
+    File history = ensureRelativeHalDirectory(deploymentName, "history").toFile();
+    return new File(history, "generateResult").toPath();
+  }
+
+  private Path ensureRelativeHalDirectory(String deploymentName, String directoryName) {
+    Path path = Paths.get(halconfigDirectory, deploymentName, directoryName);
+    ensureDirectory(path);
+    return path;
+  }
+
+  private void ensureDirectory(Path path) {
+    File file = path.toFile();
+    if (file.exists()) {
+      if (!file.isDirectory()) {
+        throw new HalException(
+            new ConfigProblemBuilder(Problem.Severity.FATAL, "The path " + path + " may not be a file.")
+                .setRemediation("Please backup the file and remove it from your halconfig directory.")
+                .build()
+        );
+      }
+    } else {
+      try {
+        if (!file.mkdirs()) {
+          throw new HalException(
+              new ConfigProblemBuilder(Problem.Severity.FATAL, "Error creating the directory " + path + " with unknown reason.")
+                  .build()
+          );
+        }
+      } catch (Exception e) {
+        throw new HalException(
+            new ConfigProblemBuilder(Problem.Severity.FATAL, "Error creating the directory " + path + ": " + e.getMessage())
+                .build()
+        );
+      }
+    }
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
@@ -42,7 +42,7 @@ public class ResourceConfig {
   String halconfigPath(@Value("${halconfig.directory.halconfig:~/.hal}") String path) {
     return normalizePath(Paths.get(path, "config").toString());
   }
-
+  
   /**
    * Version of halyard.
    *

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/DeployConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/DeployConfig.java
@@ -18,8 +18,12 @@ package com.netflix.spinnaker.halyard.deploy.config.v1;
 
 import com.netflix.spinnaker.halyard.deploy.job.v1.JobExecutor;
 import com.netflix.spinnaker.halyard.deploy.job.v1.JobExecutorLocal;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Component;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 @Component
 public class DeployConfig {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalhostDebianDeployment.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalhostDebianDeployment.java
@@ -67,7 +67,7 @@ public class LocalhostDebianDeployment extends Deployment {
 
     StringBuilder pinContents = new StringBuilder();
 
-    deploymentDetails.getGenerateResult().getArtifactVersion().forEach((k, v) -> {
+    deploymentDetails.getGenerateResult().getArtifactVersions().forEach((k, v) -> {
       pinContents.append(String.format(pinFormat, k.getName(), v));
     });
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/provider/v1/KubernetesProviderInterface.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/provider/v1/KubernetesProviderInterface.java
@@ -94,7 +94,7 @@ public class KubernetesProviderInterface extends ProviderInterface<KubernetesAcc
       case REDIS:
         return "gcr.io/kubernetes-spinnaker/redis-cluster:v2";
       default:
-        String version = details.getGenerateResult().getArtifactVersion().get(artifact);
+        String version = details.getGenerateResult().getArtifactVersions().get(artifact);
 
         // TODO(lwander/jtk54) we need a published store of validated spinnaker images
         // KubernetesImageDescription image = new KubernetesImageDescription(artifact.getName(), version, REGISTRY);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/RunningServiceDetails.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/RunningServiceDetails.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1;
+
+import lombok.Data;
+
+@Data
+public class RunningServiceDetails {
+  int running;
+  int healthy;
+  int enabled;
+  String version;
+  String artifactId;
+  String internalEndpoint;
+  String externalEndpoint;
+
+  public RunningServiceDetails setService(SpinnakerEndpoints.Service service) {
+    internalEndpoint = service.getBaseUrl();
+    return this;
+  }
+
+  public RunningServiceDetails setService(SpinnakerEndpoints.PublicService service) {
+    this.externalEndpoint = service.getPublicEndpoint();
+    return setService((SpinnakerEndpoints.Service) service);
+  }
+}


### PR DESCRIPTION
This enables 2 things:
  1. Diffing when applying new config changes to your installation.
  2. Inspecting your running cluster without recomputing endpoints