### PR TITLE
Fix halyard init entry to run as root

### DIFF
--- a/halyard-web/etc/init/halyard.conf
+++ b/halyard-web/etc/init/halyard.conf
@@ -4,6 +4,4 @@ start on filesystem or runlevel [2345]
 
 expect fork
 
-stop on stopping spinnaker
-
-exec sudo -u spinnaker -g spinnaker /opt/halyard/bin/halyard 2>&1 > /var/log/spinnaker/halyard/halyard.log &
+exec sudo /opt/halyard/bin/halyard 2>&1 > /var/log/spinnaker/halyard/halyard.log &


### PR DESCRIPTION
This is (unfortunately) needed for halyard to install debians on behalf of the user.