### PR TITLE
Add admin support for halyard

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/AdminCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/AdminCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.admin.PublishBomCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.admin.PublishCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.admin.PublishProfileCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+/**
+ */
+@Parameters()
+public class AdminCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "admin";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "This is meant for users building and publishing their own Spinnaker images and config.";
+
+  public AdminCommand() {
+    registerSubcommand(new PublishCommand());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
@@ -40,6 +40,7 @@ public class HalCommand extends NestableCommand {
   private boolean printBashCompletion;
 
   public HalCommand() {
+    registerSubcommand(new AdminCommand());
     registerSubcommand(new ConfigCommand());
     registerSubcommand(new DeployCommand());
     registerSubcommand(new VersionsCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishBomCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishBomCommand.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.admin;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Parameters()
+public class PublishBomCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "bom";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "Publish a Bill of Materials (BOM).";
+
+  @Parameter(
+      names = "--bom-path",
+      required = true,
+      description = "The path to the BOM owning the artifact to publish."
+  )
+  private String bomPath;
+
+
+  @Override
+  protected void executeThis() {
+    Daemon.publishBom(bomPath);
+    AnsiUi.success("Published your BOM.");
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishCommand.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.admin;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters()
+public class PublishCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "publish";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "Publish config artifacts to your configured halconfig bucket.";
+
+  public PublishCommand() {
+    super();
+    registerSubcommand(new PublishBomCommand());
+    registerSubcommand(new PublishProfileCommand());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.admin;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Parameters()
+public class PublishProfileCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "profile";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "Publish a base halconfig profile for a specific Spinnaker artifact.";
+
+  @Parameter(
+      names = "--bom-path",
+      required = true,
+      description = "The path to the BOM owning the artifact to publish."
+  )
+  private String bomPath;
+
+  @Parameter(
+      names = "--profile-path",
+      required = true,
+      description = "The path to the artifact profile to publish."
+  )
+  private String profilePath;
+
+  @Parameter(description = "The name of the artifact whose profile is being published (e.g. clouddriver).", arity = 1)
+  List<String> artifacts = new ArrayList<>();
+
+  @Override
+  public String getMainParameter() {
+    return "artifact-name";
+  }
+
+  public String getArtifactName() {
+    switch (artifacts.size()) {
+      case 0:
+        throw new IllegalArgumentException("No artifact name supplied");
+      case 1:
+        return artifacts.get(0);
+      default:
+        throw new IllegalArgumentException("More than one artifact supplied");
+    }
+  }
+
+  @Override
+  protected void executeThis() {
+    Daemon.publishProfile(bomPath, getArtifactName(), profilePath);
+    AnsiUi.success("Published your profile for " + getArtifactName());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -144,14 +144,23 @@ public class Daemon {
     ResponseUnwrapper.get(getService().setAuthnMethodEnabled(deploymentName, methodName, validate, enabled));
   }
 
-  public static <C, T> DaemonTask<C, T> getTask(String uuid) {
-    return getService().getTask(uuid);
-  }
-
   public static Versions getVersions() {
     Object rawVersions = ResponseUnwrapper.get(getService().getVersions());
     return getObjectMapper().convertValue(rawVersions, Versions.class);
   }
+
+  public static void publishProfile(String bomPath, String artifactName, String profilePath) {
+    ResponseUnwrapper.get(getService().publishProfile(bomPath, artifactName, profilePath, ""));
+  }
+
+  public static void publishBom(String bomPath) {
+    ResponseUnwrapper.get(getService().publishBom(bomPath,""));
+  }
+
+  static <C, T> DaemonTask<C, T> getTask(String uuid) {
+    return getService().getTask(uuid);
+  }
+
 
   private static DaemonService getService() {
     if (service == null) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -209,7 +209,18 @@ public interface DaemonService {
       @Path("baseImageId") String baseImageId,
       @Query("validate") boolean validate);
 
-
   @GET("/v1/versions/")
   DaemonTask<Halconfig, Versions> getVersions();
+
+  @PUT("/v1/admin/publishProfile/{artifactName}")
+  DaemonTask<Halconfig, Void> publishProfile(
+      @Query("bomPath") String bomPath,
+      @Path("artifactName") String artifactName,
+      @Query("profilePath") String profilePath,
+      @Body String _ignore);
+
+  @PUT("/v1/admin/publishBom")
+  DaemonTask<Halconfig, Void> publishBom(
+      @Query("bomPath") String bomPath,
+      @Body String _ignore);
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
@@ -37,6 +37,7 @@ public class ResponseUnwrapper {
   public static <C, T> T get(DaemonTask<C, T> task) {
     PrintCoordinates coords = new PrintCoordinates();
 
+    task = Daemon.getTask(task.getUuid());
     while (!task.getState().isTerminal()) {
       coords = formatStages(task.getStages(), coords);
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerArtifact.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerArtifact.java
@@ -63,4 +63,14 @@ public enum SpinnakerArtifact {
         .map(File::getAbsolutePath)
         .collect(Collectors.toList());
   }
+
+  public static SpinnakerArtifact fromString(String name) {
+    for (SpinnakerArtifact artifact : values()) {
+      if (artifact.getName().equals(name.toLowerCase())) {
+        return artifact;
+      }
+    }
+
+    throw new RuntimeException(name + " is not a valid spinnaker artifact");
+  }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/registry/WriteableProfileRegistry.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/registry/WriteableProfileRegistry.java
@@ -58,16 +58,25 @@ public class WriteableProfileRegistry {
     return credential;
   }
 
+  public void writeBom(String version, String contents) {
+    String name = ProfileRegistry.bomPath(version);
+    writeTextObject(name, contents);
+  }
+
   public void writeArtifactConfig(BillOfMaterials bom, SpinnakerArtifact artifact, String profileName, String contents) {
     String version = bom.getServices().getArtifactVersion(artifact);
     String name = ProfileRegistry.profilePath(artifact, version, profileName);
+    writeTextObject(name, contents);
+  }
+
+  private void writeTextObject(String name, String contents) {
     try {
       byte[] bytes = contents.getBytes();
       StorageObject object = new StorageObject()
           .setBucket(spinconfigBucket)
           .setName(name);
 
-      ByteArrayContent content = new ByteArrayContent("text", bytes);
+      ByteArrayContent content = new ByteArrayContent("application/text", bytes);
       storage.objects().insert(spinconfigBucket, object, content).execute();
     } catch (IOException e) {
       log.error("Failed to write new object " + name, e);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/registry/WriteableProfileRegistryConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/registry/WriteableProfileRegistryConfig.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-@ConditionalOnExpression("${spinnaker.config.input.writer:false}")
+@ConditionalOnExpression("${spinnaker.config.input.writerEnabled:false}")
 @EnableConfigurationProperties(WriteableProfileRegistryProperties.class)
 @Slf4j
 public class WriteableProfileRegistryConfig {

--- a/halyard-web/config/halyard.yaml
+++ b/halyard-web/config/halyard.yaml
@@ -1,6 +1,0 @@
-server:
-  port: 8064
-
-halconfig:
-  filesystem:
-    path: ~/.hal/config

--- a/halyard-web/config/halyard.yml
+++ b/halyard-web/config/halyard.yml
@@ -1,0 +1,12 @@
+server:
+  port: 8064
+
+halconfig:
+  filesystem:
+    path: ~/.hal/config
+
+spinnaker:
+  config:
+    input:
+      writerEnabled: false
+      bucket: halconfig

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AdminController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AdminController.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
+import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/admin")
+public class AdminController {
+  @Autowired
+  ArtifactService artifactService;
+
+  @RequestMapping(value = "/publishBom", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> publishBom(
+      @RequestParam String bomPath,
+      @RequestBody String _ignored) {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
+    builder.setBuildResponse(() -> {
+      artifactService.writeBom(bomPath);
+      return null;
+    });
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/publishProfile/{artifactName:.+}", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> publishProfile(
+      @RequestParam String bomPath,
+      @PathVariable String artifactName,
+      @RequestParam String profilePath,
+      @RequestBody String _ignored) {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
+    builder.setBuildResponse(() -> {
+      artifactService.writeArtifactConfig(bomPath, artifactName, profilePath);
+      return null;
+    });
+
+    return TaskRepository.submitTask(builder::build);
+  }
+}


### PR DESCRIPTION
With the following spring config:

```yaml
spinnaker:
  config:
    input:
      writer: true
      bucket: halconfig
```

Halyard can now do the following:

```
$ hal admin publish bom --bom-path /a/b/c/bom.yml
$ hal admin publish profile clouddriver --bom-path /a/b/c/bom.yml --profile-path /x/y/z/profile.yml
```