### PR TITLE
Jenkins config w/o validation

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.*;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.ProviderCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.WebhookCommand;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -41,6 +42,7 @@ public class ConfigCommand extends NestableCommand {
     registerSubcommand(new GenerateCommand());
     registerSubcommand(new PersistentStorageCommand());
     registerSubcommand(new ProviderCommand());
+    registerSubcommand(new WebhookCommand());
     registerSubcommand(new SecurityCommand());
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractMasterCommand.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.AbstractHasMasterCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.DeleteMasterCommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.GetMasterCommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.ListMastersCommandBuilder;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+
+import static com.netflix.spinnaker.halyard.cli.services.v1.Daemon.getCurrentDeployment;
+
+public abstract class AbstractMasterCommand extends AbstractHasMasterCommand {
+  @Override
+  public String getCommandName() {
+    return "master";
+  }
+
+  @Override
+  public String getDescription() {
+    return "Manage and view Spinnaker configuration for the " + getWebhookName() + " webhook's master";
+  }
+
+  protected AbstractMasterCommand() {
+    registerSubcommand(new DeleteMasterCommandBuilder()
+        .setWebhookName(getWebhookName())
+        .build()
+    );
+
+    registerSubcommand(new GetMasterCommandBuilder()
+        .setWebhookName(getWebhookName())
+        .build()
+    );
+
+    registerSubcommand(new ListMastersCommandBuilder()
+        .setWebhookName(getWebhookName())
+        .build()
+    );
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+
+  private Master getMaster(String masterName) {
+    String currentDeployment = getCurrentDeployment();
+    return Daemon.getMaster(currentDeployment, getWebhookName(), masterName, !noValidate);
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractNamedWebhookCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractNamedWebhookCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
+
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
+
+public abstract class AbstractNamedWebhookCommand extends AbstractWebhookCommand {
+  @Override
+  public String getCommandName() {
+    return getWebhookName();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Manage and view Spinnaker configuration for the " + getWebhookName() + " webhook";
+  }
+
+  protected AbstractNamedWebhookCommand() {
+    registerSubcommand(new WebhookEnableDisableCommandBuilder()
+        .setWebhookName(getWebhookName())
+        .setEnable(false)
+        .build()
+    );
+
+    registerSubcommand(new WebhookEnableDisableCommandBuilder()
+        .setWebhookName(getWebhookName())
+        .setEnable(true)
+        .build()
+    );
+  }
+
+  private Webhook getWebhook() {
+    return Daemon.getWebhook(getCurrentDeployment(), getWebhookName(), !noValidate);
+  }
+
+  @Override
+  protected void executeThis() {
+    AnsiUi.success(getWebhook().toString());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractWebhookCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractWebhookCommand.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+
+public abstract class AbstractWebhookCommand extends AbstractConfigCommand {
+  abstract protected String getWebhookName();
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractWebhookEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractWebhookEnableDisableCommand.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AbstractWebhookEnableDisableCommand extends AbstractWebhookCommand {
+  @Override
+  public String getCommandName() {
+    return isEnable() ? "enable" : "disable";
+  }
+
+  private String subjunctivePerfectAction() {
+    return isEnable() ? "enabled" : "disabled";
+  }
+
+  private String indicativePastPerfectAction() {
+    return isEnable() ? "enabled" : "disabled";
+  }
+
+  protected abstract boolean isEnable();
+
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Override
+  public String getDescription() {
+    return "Set the " + getWebhookName() + " webhook as " + subjunctivePerfectAction();
+  }
+
+  private void setEnable() {
+    String currentDeployment = Daemon.getCurrentDeployment();
+    Daemon.setWebhookEnableDisable(currentDeployment, getWebhookName(), !noValidate, isEnable());
+  }
+
+  @Override
+  protected void executeThis() {
+    setEnable();
+    AnsiUi.success("Successfully " + indicativePastPerfectAction() + " " + getWebhookName());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/WebhookCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/WebhookCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.jenkins.JenkinsCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+/**
+ * This is a top-level command for dealing with your halconfig.
+ *
+ * Usage is `$ hal config webhook`
+ */
+@Parameters()
+public class WebhookCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "webhook";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "Configure, validate, and view the specified webhook.";
+
+  public WebhookCommand() {
+    registerSubcommand(new JenkinsCommand());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/WebhookEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/WebhookEnableDisableCommandBuilder.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class WebhookEnableDisableCommandBuilder implements CommandBuilder {
+  @Setter
+  String webhookName;
+
+  @Setter
+  boolean enable;
+
+  @Override
+  public NestableCommand build() {
+    return new WebhookEnableDisableCommand(webhookName, enable);
+  }
+
+  @Parameters()
+  private static class WebhookEnableDisableCommand extends AbstractWebhookEnableDisableCommand {
+    private WebhookEnableDisableCommand(String webhookName, boolean enable) {
+      this.webhookName = webhookName;
+      this.enable = enable;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    boolean enable;
+
+    @Getter(AccessLevel.PROTECTED)
+    private String webhookName;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsAddMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsAddMasterCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.jenkins;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.AbstractAddMasterCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import com.netflix.spinnaker.halyard.config.model.v1.webhooks.jenkins.JenkinsMaster;
+
+@Parameters()
+public class JenkinsAddMasterCommand extends AbstractAddMasterCommand {
+  protected String getWebhookName() {
+    return "jenkins";
+  }
+
+  @Parameter(
+      names = "--address",
+      required = true,
+      description = JenkinsCommandProperties.ADDRESS_DESCRIPTION
+  )
+  private String address;
+
+  @Parameter(
+      names = "--username",
+      description = JenkinsCommandProperties.USERNAME_DESCRIPTION
+  )
+  public String username;
+
+  @Parameter(
+      names = "--password",
+      password = true,
+      description = JenkinsCommandProperties.PASSWORD_DESCRIPTION
+  )
+  public String password;
+
+  @Override
+  protected Master buildMaster(String masterName) {
+    JenkinsMaster master = (JenkinsMaster) new JenkinsMaster().setName(masterName);
+    master.setAddress(address)
+        .setPassword(password)
+        .setUsername(username);
+
+    return master;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsCommand.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.jenkins;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.AbstractNamedWebhookCommand;
+
+/**
+ * Interact with the jenkins webhook
+ */
+@Parameters()
+public class JenkinsCommand extends AbstractNamedWebhookCommand {
+  protected String getWebhookName() {
+    return "jenkins";
+  }
+
+  public JenkinsCommand() {
+    super();
+    registerSubcommand(new JenkinsMasterCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsCommandProperties.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.jenkins;
+
+public class JenkinsCommandProperties {
+  static final String USERNAME_DESCRIPTION = "The username of the jenkins user to authenticate as.";
+
+  static final String PASSWORD_DESCRIPTION = "The password of the jenkins user to authenticate as.";
+
+  static final String ADDRESS_DESCRIPTION = "The address your jenkins master is reachable at.";
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsEditMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsEditMasterCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.jenkins;
+
+import com.beust.jcommander.Parameter;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.AbstractEditMasterCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import com.netflix.spinnaker.halyard.config.model.v1.webhooks.jenkins.JenkinsMaster;
+
+public class JenkinsEditMasterCommand extends AbstractEditMasterCommand<JenkinsMaster> {
+  protected String getWebhookName() {
+    return "jenkins";
+  }
+
+  @Parameter(
+      names = "--address",
+      description = JenkinsCommandProperties.ADDRESS_DESCRIPTION
+  )
+  private String address;
+
+  @Parameter(
+      names = "--username",
+      description = JenkinsCommandProperties.USERNAME_DESCRIPTION
+  )
+  public String username;
+
+  @Parameter(
+      names = "--password",
+      password = true,
+      description = JenkinsCommandProperties.PASSWORD_DESCRIPTION
+  )
+  public String password;
+
+  @Override
+  protected Master editMaster(JenkinsMaster master) {
+    master.setAddress(isSet(address) ? address : master.getAddress());
+    master.setUsername(isSet(username) ? username : master.getUsername());
+    master.setPassword(isSet(password) ? password : master.getPassword());
+
+    return master;
+  }
+
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/jenkins/JenkinsMasterCommand.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.jenkins;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.AbstractMasterCommand;
+
+/**
+ * Interact with the jenkins webhook's masters
+ */
+@Parameters()
+public class JenkinsMasterCommand extends AbstractMasterCommand {
+  protected String getWebhookName() {
+    return "jenkins";
+  }
+
+  public JenkinsMasterCommand() {
+    super();
+    registerSubcommand(new JenkinsAddMasterCommand());
+    registerSubcommand(new JenkinsEditMasterCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractAddMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractAddMasterCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters()
+public abstract class AbstractAddMasterCommand extends AbstractHasMasterCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "add";
+
+  protected abstract Master buildMaster(String masterName);
+
+  public String getDescription() {
+    return "Add a " + getWebhookName() + " master.";
+  }
+
+  @Override
+  protected void executeThis() {
+    String masterName = getMasterName();
+    Master master = buildMaster(masterName);
+    String webhookName = getWebhookName();
+
+    String currentDeployment = Daemon.getCurrentDeployment();
+    Daemon.addMaster(currentDeployment, webhookName, !noValidate, master);
+    AnsiUi.success("Added " + webhookName + " master \"" + masterName + "\"");
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractDeleteMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractDeleteMasterCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Delete a specific PROVIDER master
+ */
+@Parameters()
+public abstract class AbstractDeleteMasterCommand extends AbstractHasMasterCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "delete";
+
+  public String getDescription() {
+    return "Delete a specific " + getWebhookName() + " master by name.";
+  }
+
+  @Override
+  protected void executeThis() {
+    deleteMaster(getMasterName());
+    AnsiUi.success("Deleted " + getMasterName());
+  }
+
+  private void deleteMaster(String masterName) {
+    String currentDeployment = Daemon.getCurrentDeployment();
+    Daemon.deleteMaster(currentDeployment, getWebhookName(), masterName, !noValidate);
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractEditMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractEditMasterCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters()
+public abstract class AbstractEditMasterCommand<T extends Master> extends AbstractHasMasterCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  protected abstract Master editMaster(T master);
+
+  public String getDescription() {
+    return "Edit a " + getWebhookName() + " master.";
+  }
+
+  @Override
+  protected void executeThis() {
+    String masterName = getMasterName();
+    String webhookName = getWebhookName();
+    String currentDeployment = getCurrentDeployment();
+    // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
+    Master master = Daemon.getMaster(currentDeployment, webhookName, masterName, false);
+
+    Daemon.setMaster(currentDeployment, webhookName, masterName, !noValidate, editMaster((T) master));
+    AnsiUi.success("Edited " + webhookName + " master \"" + masterName + "\"");
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractGetMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractGetMasterCommand.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import lombok.Getter;
+
+abstract class AbstractGetMasterCommand extends AbstractHasMasterCommand {
+  public String getDescription() {
+    return "Get the specified master details for the " + getWebhookName() + " webhook.";
+  }
+
+  @Getter
+  private String commandName = "get";
+
+  @Override
+  protected void executeThis() {
+    AnsiUi.success(getMaster(getMasterName()).toString());
+  }
+
+  private Master getMaster(String masterName) {
+    String currentDeployment = getCurrentDeployment();
+    return Daemon.getMaster(currentDeployment, getWebhookName(), masterName, !noValidate);
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractHasMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractHasMasterCommand.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.AbstractWebhookCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An abstract definition for commands that accept MASTER as a main parameter
+ */
+@Parameters()
+public abstract class AbstractHasMasterCommand extends AbstractWebhookCommand {
+  @Parameter(description = "The name of the master to operate on.", arity = 1)
+  List<String> masters = new ArrayList<>();
+
+  @Override
+  public String getMainParameter() {
+    return "master";
+  }
+
+  public String getMasterName() {
+    switch (masters.size()) {
+      case 0:
+        throw new IllegalArgumentException("No master name supplied");
+      case 1:
+        return masters.get(0);
+      default:
+        throw new IllegalArgumentException("More than one master supplied");
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractListMastersCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractListMastersCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.AbstractWebhookCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
+import lombok.Getter;
+
+import java.util.List;
+
+abstract class AbstractListMastersCommand extends AbstractWebhookCommand {
+  public String getDescription() {
+    return "List the master names for the " + getWebhookName() + " webhook.";
+  }
+
+  @Getter
+  private String commandName = "list";
+
+  private Webhook getWebhook() {
+    String currentDeployment = Daemon.getCurrentDeployment();
+    return Daemon.getWebhook(currentDeployment, getWebhookName(), !noValidate);
+  }
+
+  @Override
+  protected void executeThis() {
+    Webhook webhook = getWebhook();
+    List<Master> masters = webhook.getMasters();
+    if (masters.isEmpty()) {
+      AnsiUi.success("No configured masters for " + getWebhookName() + ".");
+    } else {
+      AnsiUi.success("Masters for " + getWebhookName() + ":");
+      masters.forEach(master -> AnsiUi.listItem(master.getName()));
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/DeleteMasterCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/DeleteMasterCommandBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class DeleteMasterCommandBuilder implements CommandBuilder {
+  @Setter
+  String webhookName;
+
+  @Override
+  public NestableCommand build() {
+    return new DeleteMasterCommand(webhookName);
+  }
+
+  @Parameters()
+  private static class DeleteMasterCommand extends AbstractDeleteMasterCommand {
+    private DeleteMasterCommand(String webhookName) {
+      this.webhookName = webhookName;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    private String webhookName;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/GetMasterCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/GetMasterCommandBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class GetMasterCommandBuilder implements CommandBuilder {
+  @Setter
+  String webhookName;
+
+  @Override
+  public NestableCommand build() {
+    return new GetMasterCommand(webhookName);
+  }
+
+  @Parameters()
+  private static class GetMasterCommand extends AbstractGetMasterCommand {
+    private GetMasterCommand(String webhookName) {
+      this.webhookName = webhookName;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    private String webhookName;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/ListMastersCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/ListMastersCommandBuilder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ListMastersCommandBuilder implements CommandBuilder {
+  @Setter
+  String webhookName;
+
+  @Override
+  public NestableCommand build() {
+    return new ListMastersCommand(webhookName);
+  }
+
+  @Parameters()
+  private static class ListMastersCommand extends AbstractListMastersCommand {
+    private ListMastersCommand(String webhookName) {
+      this.webhookName = webhookName;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    private String webhookName;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -110,6 +110,32 @@ public class Daemon {
     ResponseUnwrapper.get(getService().setProviderEnabled(deploymentName, providerName, validate, enable));
   }
 
+  public static Master getMaster(String deploymentName, String webhookName, String masterName, boolean validate) {
+    Object rawMaster = ResponseUnwrapper.get(getService().getMaster(deploymentName, webhookName, masterName, validate));
+    return getObjectMapper().convertValue(rawMaster, Webhooks.translateMasterType(webhookName));
+  }
+
+  public static void addMaster(String deploymentName, String webhookName, boolean validate, Master master) {
+    ResponseUnwrapper.get(getService().addMaster(deploymentName, webhookName, validate, master));
+  }
+
+  public static void setMaster(String deploymentName, String webhookName, String masterName, boolean validate, Master master) {
+    ResponseUnwrapper.get(getService().setMaster(deploymentName, webhookName, masterName, validate, master));
+  }
+
+  public static void deleteMaster(String deploymentName, String webhookName, String masterName, boolean validate) {
+    ResponseUnwrapper.get(getService().deleteMaster(deploymentName, webhookName, masterName, validate));
+  }
+
+  public static Webhook getWebhook(String deploymentName, String webhookName, boolean validate) {
+    Object webhook = ResponseUnwrapper.get(getService().getWebhook(deploymentName, webhookName, validate));
+    return getObjectMapper().convertValue(webhook, Webhooks.translateWebhookType(webhookName));
+  }
+
+  public static void setWebhookEnableDisable(String deploymentName, String webhookName, boolean validate, boolean enable) {
+    ResponseUnwrapper.get(getService().setWebhookEnabled(deploymentName, webhookName, validate, enable));
+  }
+
   public static void generateDeployment(String deploymentName, boolean validate) {
     ResponseUnwrapper.get(getService().generateDeployment(deploymentName, validate, ""));
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -209,6 +209,48 @@ public interface DaemonService {
       @Path("baseImageId") String baseImageId,
       @Query("validate") boolean validate);
 
+  @GET("/v1/config/deployments/{deploymentName}/webhooks/{webhookName}/")
+  DaemonTask<Halconfig, Object> getWebhook(
+      @Path("deploymentName") String deploymentName,
+      @Path("webhookName") String webhookName,
+      @Query("validate") boolean validate);
+
+  @PUT("/v1/config/deployments/{deploymentName}/webhooks/{webhookName}/enabled/")
+  DaemonTask<Halconfig, Void> setWebhookEnabled(
+      @Path("deploymentName") String deploymentName,
+      @Path("webhookName") String webhookName,
+      @Query("validate") boolean validate,
+      @Body boolean enabled);
+
+  @POST("/v1/config/deployments/{deploymentName}/webhooks/{webhookName}/masters/")
+  DaemonTask<Halconfig, Void> addMaster(
+      @Path("deploymentName") String deploymentName,
+      @Path("webhookName") String webhookName,
+      @Query("validate") boolean validate,
+      @Body Master master);
+
+  @GET("/v1/config/deployments/{deploymentName}/webhooks/{webhookName}/masters/{masterName}/")
+  DaemonTask<Halconfig, Object> getMaster(
+      @Path("deploymentName") String deploymentName,
+      @Path("webhookName") String webhookName,
+      @Path("masterName") String masterName,
+      @Query("validate") boolean validate);
+
+  @PUT("/v1/config/deployments/{deploymentName}/webhooks/{webhookName}/masters/{masterName}/")
+  DaemonTask<Halconfig, Void> setMaster(
+      @Path("deploymentName") String deploymentName,
+      @Path("webhookName") String webhookName,
+      @Path("masterName") String masterName,
+      @Query("validate") boolean validate,
+      @Body Master master);
+
+  @DELETE("/v1/config/deployments/{deploymentName}/webhooks/{webhookName}/masters/{masterName}/")
+  DaemonTask<Halconfig, Void> deleteMaster(
+      @Path("deploymentName") String deploymentName,
+      @Path("webhookName") String webhookName,
+      @Path("masterName") String masterName,
+      @Query("validate") boolean validate);
+
   @GET("/v1/versions/")
   DaemonTask<Halconfig, Versions> getVersions();
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
@@ -89,6 +89,11 @@ public class NodeFilter implements Cloneable {
     return this;
   }
 
+  public NodeFilter setMaster(String name) {
+    matchers.add(Node.namedNodeAcceptor(Master.class, name));
+    return this;
+  }
+
   public NodeFilter setFeatures() {
     matchers.add(Node.thisNodeAcceptor(Features.class));
     return this;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Webhooks.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Webhooks.java
@@ -16,14 +16,19 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.model.v1.webhooks.jenkins.JenkinsWebhook;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Optional;
+
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Webhooks extends Node implements Cloneable {
-  String empty = "ignore for now";
+  JenkinsWebhook jenkins = new JenkinsWebhook();
 
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
@@ -38,5 +43,29 @@ public class Webhooks extends Node implements Cloneable {
   @Override
   public NodeIterator getChildren() {
     return NodeIteratorFactory.makeReflectiveIterator(this);
+  }
+
+  public static Class<? extends Webhook> translateWebhookType(String webhookName) {
+    Optional<? extends Class<?>> res = Arrays.stream(Webhooks.class.getDeclaredFields())
+        .filter(f -> f.getName().equals(webhookName))
+        .map(Field::getType)
+        .findFirst();
+
+    if (res.isPresent()) {
+      return (Class<? extends Webhook>)res.get();
+    } else {
+      throw new IllegalArgumentException("No webhook with name \"" + webhookName + "\" handled by halyard");
+    }
+  }
+
+  public static Class<? extends Master> translateMasterType(String webhookName) {
+    Class<? extends Webhook> webhookClass = translateWebhookType(webhookName);
+
+    String masterClassName = webhookClass.getName().replaceAll("Webhook", "Master");
+    try {
+      return (Class<? extends Master>) Class.forName(masterClassName);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("No master for class \"" + masterClassName + "\" found", e);
+    }
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webhooks/jenkins/JenkinsMaster.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webhooks/jenkins/JenkinsMaster.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.webhooks.jenkins;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIterator;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIteratorFactory;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+
+@Data
+public class JenkinsMaster extends Master {
+  @Override
+  public NodeIterator getChildren() {
+    return NodeIteratorFactory.makeEmptyIterator();
+  }
+
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+
+  private String address;
+  private String username;
+  private String password;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webhooks/jenkins/JenkinsWebhook.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webhooks/jenkins/JenkinsWebhook.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.webhooks.jenkins;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+
+public class JenkinsWebhook extends Webhook<JenkinsMaster> {
+  @Override
+  public String getNodeName() {
+    return "jenkins";
+  }
+
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/MasterService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/MasterService.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.services.v1;
+
+import com.netflix.spinnaker.halyard.config.error.v1.ConfigNotFoundException;
+import com.netflix.spinnaker.halyard.config.error.v1.IllegalConfigException;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * This service is meant to be autowired into any service or controller that needs to inspect the current halconfig's
+ * masters.
+ */
+@Component
+public class MasterService {
+  @Autowired
+  private LookupService lookupService;
+
+  @Autowired
+  private WebhookService webhookService;
+
+  @Autowired
+  private ValidateService validateService;
+
+  public List<Master> getAllMasters(String deploymentName, String webhookName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setWebhook(webhookName).withAnyMaster();
+
+    List<Master> matchingMasters = lookupService.getMatchingNodesOfType(filter, Master.class);
+
+    if (matchingMasters.size() == 0) {
+      throw new ConfigNotFoundException(
+          new ConfigProblemBuilder(Severity.FATAL, "No masters could be found").build());
+    } else {
+      return matchingMasters;
+    }
+  }
+
+  private Master getMaster(NodeFilter filter, String masterName) {
+    List<Master> matchingMasters = lookupService.getMatchingNodesOfType(filter, Master.class);
+
+    switch (matchingMasters.size()) {
+      case 0:
+        throw new ConfigNotFoundException(new ConfigProblemBuilder(
+            Severity.FATAL, "No master with name \"" + masterName + "\" was found")
+            .setRemediation("Check if this master was defined in another webhook, or create a new one").build());
+      case 1:
+        return matchingMasters.get(0);
+      default:
+        throw new IllegalConfigException(new ConfigProblemBuilder(
+            Severity.FATAL, "More than one master named \"" + masterName + "\" was found")
+            .setRemediation("Manually delete/rename duplicate masters with name \"" + masterName + "\" in your halconfig file").build());
+    }
+  }
+
+  public Master getWebhookMaster(String deploymentName, String webhookName, String masterName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setWebhook(webhookName).setMaster(masterName);
+    return getMaster(filter, masterName);
+  }
+
+  public Master getAnyWebhookMaster(String deploymentName, String masterName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).withAnyWebhook().setMaster(masterName);
+    return getMaster(filter, masterName);
+  }
+
+  public void setMaster(String deploymentName, String webhookName, String masterName, Master newMaster) {
+    Webhook webhook = webhookService.getWebhook(deploymentName, webhookName);
+
+    for (int i = 0; i < webhook.getMasters().size(); i++) {
+      Master master = (Master) webhook.getMasters().get(i);
+      if (master.getNodeName().equals(masterName)) {
+        webhook.getMasters().set(i, newMaster);
+        return;
+      }
+    }
+
+    throw new HalException(new ConfigProblemBuilder(Severity.FATAL, "Master \"" + masterName + "\" wasn't found").build());
+  }
+
+  public void deleteMaster(String deploymentName, String webhookName, String masterName) {
+    Webhook webhook = webhookService.getWebhook(deploymentName, webhookName);
+    boolean removed = webhook.getMasters().removeIf(master -> ((Master) master).getName().equals(masterName));
+
+    if (!removed) {
+      throw new HalException(
+          new ConfigProblemBuilder(Severity.FATAL, "Master \"" + masterName + "\" wasn't found")
+              .build());
+    }
+  }
+
+  public void addMaster(String deploymentName, String webhookName, Master newMaster) {
+    Webhook webhook = webhookService.getWebhook(deploymentName, webhookName);
+    webhook.getMasters().add(newMaster);
+  }
+
+  public ProblemSet validateMaster(String deploymentName, String webhookName, String masterName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setWebhook(webhookName).setMaster(masterName);
+    return validateService.validateMatchingFilter(filter);
+  }
+
+  public ProblemSet validateAllMasters(String deploymentName, String webhookName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setWebhook(webhookName).withAnyMaster();
+    return validateService.validateMatchingFilter(filter);
+  }
+}

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhooks;
+import com.netflix.spinnaker.halyard.config.services.v1.MasterService;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@RestController
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/webhooks/{webhookName:.+}/masters")
+public class MasterController {
+  @Autowired
+  MasterService masterService;
+
+  @Autowired
+  HalconfigParser halconfigParser;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @RequestMapping(value = "/", method = RequestMethod.GET)
+  DaemonTask<Halconfig, List<Master>> masters(@PathVariable String deploymentName, @PathVariable String webhookName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+    StaticRequestBuilder<List<Master>> builder = new StaticRequestBuilder<>();
+    builder.setBuildResponse(() -> masterService.getAllMasters(deploymentName, webhookName));
+    builder.setSeverity(severity);
+
+    if (validate) {
+      builder.setValidateResponse(() -> masterService.validateAllMasters(deploymentName, webhookName));
+    }
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/{masterName:.+}", method = RequestMethod.GET)
+  DaemonTask<Halconfig, Master> master(
+      @PathVariable String deploymentName,
+      @PathVariable String webhookName,
+      @PathVariable String masterName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+    StaticRequestBuilder<Master> builder = new StaticRequestBuilder<>();
+    builder.setBuildResponse(() -> masterService.getWebhookMaster(deploymentName, webhookName, masterName));
+    builder.setSeverity(severity);
+
+    if (validate) {
+      builder.setValidateResponse(() -> masterService.validateMaster(deploymentName, webhookName, masterName));
+    }
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/{masterName:.+}", method = RequestMethod.DELETE)
+  DaemonTask<Halconfig, Void> deleteMaster(
+      @PathVariable String deploymentName,
+      @PathVariable String webhookName,
+      @PathVariable String masterName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+    UpdateRequestBuilder builder = new UpdateRequestBuilder();
+
+    builder.setUpdate(() -> masterService.deleteMaster(deploymentName, webhookName, masterName));
+    builder.setSeverity(severity);
+
+    Supplier<ProblemSet> doValidate = ProblemSet::new;
+    if (validate) {
+      doValidate = () -> masterService.validateAllMasters(deploymentName, webhookName);
+    }
+
+    builder.setValidate(doValidate);
+    builder.setRevert(() -> halconfigParser.undoChanges());
+    builder.setSave(() -> halconfigParser.saveConfig());
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/{masterName:.+}", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setMaster(
+      @PathVariable String deploymentName,
+      @PathVariable String webhookName,
+      @PathVariable String masterName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestBody Object rawMaster) {
+    Master master = objectMapper.convertValue(
+        rawMaster,
+        Webhooks.translateMasterType(webhookName)
+    );
+
+    UpdateRequestBuilder builder = new UpdateRequestBuilder();
+
+    builder.setUpdate(() -> masterService.setMaster(deploymentName, webhookName, masterName, master));
+    builder.setSeverity(severity);
+
+    Supplier<ProblemSet> doValidate = ProblemSet::new;
+    if (validate) {
+      doValidate = () -> masterService.validateMaster(deploymentName, webhookName, master.getName());
+    }
+
+    builder.setValidate(doValidate);
+    builder.setRevert(() -> halconfigParser.undoChanges());
+    builder.setSave(() -> halconfigParser.saveConfig());
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/", method = RequestMethod.POST)
+  DaemonTask<Halconfig, Void> addMaster(
+      @PathVariable String deploymentName,
+      @PathVariable String webhookName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestBody Object rawMaster) {
+    Master master = objectMapper.convertValue(
+        rawMaster,
+        Webhooks.translateMasterType(webhookName)
+    );
+
+    UpdateRequestBuilder builder = new UpdateRequestBuilder();
+    builder.setSeverity(severity);
+
+    builder.setUpdate(() -> masterService.addMaster(deploymentName, webhookName, master));
+
+    Supplier<ProblemSet> doValidate = ProblemSet::new;
+    if (validate) {
+      doValidate = () -> masterService.validateMaster(deploymentName, webhookName, master.getName());
+    }
+
+    builder.setValidate(doValidate);
+    builder.setRevert(() -> halconfigParser.undoChanges());
+    builder.setSave(() -> halconfigParser.saveConfig());
+
+    return TaskRepository.submitTask(builder::build);
+  }
+}

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
+import com.netflix.spinnaker.halyard.config.services.v1.WebhookService;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+@RestController
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/webhooks")
+public class WebhookController {
+  @Autowired
+  HalconfigParser halconfigParser;
+
+  @Autowired
+  WebhookService webhookService;
+
+  @RequestMapping(value = "/{webhookName:.+}", method = RequestMethod.GET)
+  DaemonTask<Halconfig, Webhook> webhook(
+      @PathVariable String deploymentName,
+      @PathVariable String webhookName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+    StaticRequestBuilder<Webhook> builder = new StaticRequestBuilder<>();
+
+    builder.setBuildResponse(() -> webhookService.getWebhook(deploymentName, webhookName));
+    builder.setSeverity(severity);
+
+    if (validate) {
+      builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName, webhookName));
+    }
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/{webhookName:.+}/enabled", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setEnabled(
+      @PathVariable String deploymentName,
+      @PathVariable String webhookName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestBody boolean enabled) {
+    UpdateRequestBuilder builder = new UpdateRequestBuilder();
+
+    builder.setUpdate(() -> webhookService.setEnabled(deploymentName, webhookName, enabled));
+    builder.setSeverity(severity);
+
+    Supplier<ProblemSet> doValidate = ProblemSet::new;
+    if (validate) {
+      doValidate = () -> webhookService.validateWebhook(deploymentName, webhookName);
+    }
+
+    builder.setValidate(doValidate);
+    builder.setRevert(() -> halconfigParser.undoChanges());
+    builder.setSave(() -> halconfigParser.saveConfig());
+
+    return TaskRepository.submitTask(builder::build);
+  }
+
+  @RequestMapping(value = "/", method = RequestMethod.GET)
+  DaemonTask<Halconfig, List<Webhook>> webhooks(@PathVariable String deploymentName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+    StaticRequestBuilder<List<Webhook>> builder = new StaticRequestBuilder<>();
+
+    builder.setBuildResponse(() -> webhookService.getAllWebhooks(deploymentName));
+    builder.setSeverity(severity);
+
+    if (validate) {
+      builder.setValidateResponse(() -> webhookService.validateAllWebhooks(deploymentName));
+    }
+
+    return TaskRepository.submitTask(builder::build);
+  }
+}


### PR DESCRIPTION
Follows the structure of the provider & account config & commands. This omits validation and config generation, which will come in the next two PRs. It also puts in place the required work for upcoming TravisCI support.