### PR TITLE
A step towards s3 front50 support

### DIFF
--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -5,6 +5,8 @@ dependencies {
   compile spinnaker.dependency('clouddriverAppengine')
   compile spinnaker.dependency('clouddriverAzure')
   compile spinnaker.dependency('front50Gcs')
+  compile spinnaker.dependency('front50S3')
+
 
   compile project(':halyard-core')
 }


### PR DESCRIPTION
Unfortunately I got stuck on spinnaker's AWS credentials handling. Nonetheless, it sets up the pattern for validating front50 s3 config, as well as the pattern for other providers. 
