### PR TITLE
style: adds missing word + punctuation

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
@@ -34,7 +34,7 @@ public class ConfigCommand extends NestableCommand {
   private String commandName = "config";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view your halconfig";
+  private String description = "Configure, validate, and view your halconfig.";
 
   ConfigCommand() {
     registerSubcommand(new DeploymentEnvironmentCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/DeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/DeployCommand.java
@@ -30,7 +30,7 @@ public class DeployCommand extends NestableCommand {
 
   @Getter(AccessLevel.PUBLIC)
   private String description = "Manage the deployment of Spinnaker. This includes where it's deployed,"
-      + " what the infrastructure footprint looks, what the currently running deployment looks like, etc...";
+      + " what the infrastructure footprint looks like, what the currently running deployment looks like, etc...";
 
   public DeployCommand() {
     registerSubcommand(new RunDeployCommand());


### PR DESCRIPTION
@lwander 

The line with the added period was the only top-level help description without one.