### PR TITLE
Remove packer installation, provide install with config path

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployment.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployment.java
@@ -51,7 +51,7 @@ abstract public class Deployment {
    * Deploy a fresh install of Spinnaker. This will fail if Spinnaker is already
    * running.
    */
-  abstract public DeployResult deploy();
+  abstract public DeployResult deploy(String spinnakerOutputPath);
 
   @Data
   public static class DeployResult {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/FlotillaDeployment.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/FlotillaDeployment.java
@@ -48,7 +48,7 @@ abstract public class FlotillaDeployment<T extends Account> extends Deployment {
   private AccountDeploymentDetails<T> deploymentDetails;
 
   @Override
-  public DeployResult deploy() {
+  public DeployResult deploy(String spinnakerOutputPath) {
     SpinnakerEndpoints.Services services = getEndpoints().getServices();
     DaemonTaskHandler.newStage("Deploying Spinnaker services and dependencies");
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalhostDebianDeployment.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalhostDebianDeployment.java
@@ -60,7 +60,7 @@ public class LocalhostDebianDeployment extends Deployment {
   }
 
   @Override
-  public DeployResult deploy() {
+  public DeployResult deploy(String spinnakerOutputPath) {
     DaemonTaskHandler.newStage("Generating install file for Spinnaker debians");
 
     String pinFiles = "";
@@ -87,7 +87,7 @@ public class LocalhostDebianDeployment extends Deployment {
 
     JarResource etcInitResource = new JarResource("/debian/init.sh");
     Map<String, String> bindings = new HashMap<>();
-    bindings.put("spinnaker-artifacts", artifacts);
+    bindings.put("spinnaker-artifacts", artifacts.replace("deck", "apache2"));
     String etcInit = etcInitResource.setBindings(bindings).toString();
 
     DaemonTaskHandler.log("Writing installation file");
@@ -98,7 +98,7 @@ public class LocalhostDebianDeployment extends Deployment {
     bindings.put("install-redis", "true");
     bindings.put("install-spinnaker", "true");
     bindings.put("etc-init", etcInit);
-    bindings.put("packer-version", "0.12.2"); // TODO(lwander) get this from the BOM dependencies
+    bindings.put("config-dir", spinnakerOutputPath);
 
     DeployResult result = new DeployResult();
     result.setPostInstallScript(installScript.setBindings(bindings).toString());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
@@ -90,7 +90,7 @@ public class DeployService {
 
     generateService.atomicWrite(path, generateService.yamlToString(deployment.getEndpoints()));
 
-    Deployment.DeployResult result = deployment.deploy();
+    Deployment.DeployResult result = deployment.deploy(spinnakerOutputPath);
 
     if (!StringUtils.isNullOrEmpty(result.getPostInstallScript())) {
       Path installPath = halconfigDirectoryStructure.getInstallScriptPath(deploymentName);

--- a/halyard-deploy/src/main/resources/debian/install.sh
+++ b/halyard-deploy/src/main/resources/debian/install.sh
@@ -8,7 +8,6 @@ set -o pipefail
 INSTALL_REDIS="{%install-redis%}"
 INSTALL_SPINNAKER="{%install-spinnaker%}"
 SPINNAKER_ARTIFACTS=({%spinnaker-artifacts%})
-PACKER_VERSION="{%packer-version%}"
 CONFIG_DIR="{%config-dir%}"
 
 REPOSITORY_URL="https://dl.bintray.com/spinnaker-team/spinnakerbuild"
@@ -127,17 +126,6 @@ function install_apache2() {
   service apache2 start
 }
 
-function install_packer() {
-  TEMPDIR=$(mktemp -d installspinnaker.XXXX)
-
-  mkdir $TEMPDIR/packer && pushd $TEMPDIR/packer
-  curl -s -L -O https://releases.hashicorp.com/packer/${PACKER_VERSION}/packer_${PACKER_VERSION}_linux_amd64.zip
-  unzip -u -o -q packer_${PACKER_VERSION}_linux_amd64.zip -d /usr/bin
-  popd
-
-  rm -rf $TEMPDIR
-}
-
 echo "Updating apt package lists..."
 
 if [ -n "$INSTALL_REDIS" ]; then
@@ -171,9 +159,5 @@ if [ -n "$INSTALL_SPINNAKER" ]; then
 
   if contains "${SPINNAKER_ARTIFACTS[@]}" "deck"; then
     install_apache2
-  fi
-
-  if contains "${SPINNAKER_ARTIFACTS[@]}" "rosco"; then
-    install_packer
   fi
 fi


### PR DESCRIPTION
Packer installation is now handled by rosco debian. Config path is needed to configure apache.