### PR TITLE
refactor(cli): Standardize on CLI output

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -102,7 +102,7 @@ public abstract class NestableCommand {
       AnsiUi.remediation("Try the command again with the --debug flag.");
       System.exit(1);
     } catch (ExpectedDaemonFailureException e) {
-      AnsiUi.error("Operation failed. See above errors for details.");
+      AnsiUi.failure(e.getMessage());
       System.exit(1);
     } catch (Exception e) {
       if (GlobalOptions.getGlobalOptions().isDebug()) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/VersionsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/VersionsCommand.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.versions.BomVersionCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.versions.LatestVersionCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import lombok.AccessLevel;
@@ -40,7 +41,10 @@ public class VersionsCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    Versions versions = Daemon.getVersions();
+    Versions versions = new OperationHandler<Versions>()
+        .setOperation(Daemon.getVersions())
+        .setFailureMesssage("Failed to load available Spinnaker versions.")
+        .get();
 
     AnsiUi.success("The following versions are available: ");
     versions.getVersions().forEach(v -> AnsiUi.listItem(v.toString()));

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishBomCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishBomCommand.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -48,7 +49,10 @@ public class PublishBomCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    Daemon.publishBom(bomPath);
-    AnsiUi.success("Published your BOM.");
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to publish your BOM.")
+        .setSuccessMessage("Successfully published your BOM.")
+        .setOperation(Daemon.publishBom(bomPath))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
@@ -22,6 +22,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -74,7 +75,10 @@ public class PublishProfileCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    Daemon.publishProfile(bomPath, getArtifactName(), profilePath);
-    AnsiUi.success("Published your profile for " + getArtifactName());
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to publish your profile for artifact " + getArtifactName() + ".")
+        .setSuccessMessage("Successfully published your profile for artifact " + getArtifactName() + ".")
+        .setOperation(Daemon.publishProfile(bomPath, getArtifactName(), profilePath))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/AbstractConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/AbstractConfigCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 import com.beust.jcommander.Parameter;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -28,7 +29,10 @@ abstract public class AbstractConfigCommand extends NestableCommand {
   public boolean noValidate = false;
 
   protected String getCurrentDeployment() {
-    return Daemon.getCurrentDeployment();
+    return new OperationHandler<String>()
+        .setFailureMesssage("Failed to get deployment name.")
+        .setOperation(Daemon.getCurrentDeployment())
+        .get();
   }
 
   protected static boolean isSet(String s) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
 import lombok.AccessLevel;
@@ -40,9 +42,11 @@ public class DeploymentEnvironmentCommand extends AbstractConfigCommand {
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
 
-    DeploymentEnvironment deploymentEnvironment = Daemon.getDeploymentEnvironment(currentDeployment, !noValidate);
-
-    AnsiUi.success("Configured deployment:");
-    AnsiUi.raw(deploymentEnvironment.toString());
+    new OperationHandler<DeploymentEnvironment>()
+        .setFailureMesssage("Failed to get your deployment environment.")
+        .setSuccessMessage("Retrieved configured deployment environment.")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setOperation(Daemon.getDeploymentEnvironment(currentDeployment, !noValidate))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditVersionCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameter;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -40,8 +41,12 @@ public class EditVersionCommand extends AbstractConfigCommand {
 
   @Override
   protected void executeThis() {
-    Daemon.setVersion(getCurrentDeployment(), !noValidate, version);
-    AnsiUi.success("Spinnaker has been configured to update/install version \"" + version + "\". "
-        + "This will be put into effect during the installation or next update of Spinnaker using Halyard.");
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setVersion(currentDeployment, !noValidate, version))
+        .setFailureMesssage("Spinnaker has been configured to update/install version \"" + version + "\". "
+            + "This will be put into effect during the installation or next update of Spinnaker using Halyard.")
+        .setFailureMesssage("Failed to update version.")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/FeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/FeaturesCommand.java
@@ -18,7 +18,8 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -39,9 +40,11 @@ public class FeaturesCommand extends AbstractConfigCommand {
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
 
-    Features features = Daemon.getFeatures(currentDeployment, !noValidate);
-
-    AnsiUi.success("Configure feature flags: ");
-    AnsiUi.raw(features.toString());
+    new OperationHandler<Features>()
+        .setOperation(Daemon.getFeatures(currentDeployment, !noValidate))
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setSuccessMessage("Configured features: ")
+        .setFailureMesssage("Failed to load features.")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/GenerateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/GenerateCommand.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -29,7 +30,11 @@ public class GenerateCommand extends AbstractConfigCommand {
 
   @Override
   protected void executeThis() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.generateDeployment(currentDeployment, !noValidate);
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.generateDeployment(currentDeployment, !noValidate))
+        .setFailureMesssage("Failed to generate config.")
+        .setSuccessMessage("Successfully generated config.")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStorage;
 import lombok.AccessLevel;
@@ -39,9 +41,11 @@ public class PersistentStorageCommand extends AbstractConfigCommand {
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
 
-    PersistentStorage persistentStorage = Daemon.getPersistentStorage(currentDeployment, !noValidate);
-
-    AnsiUi.success("Configure storage options:");
-    AnsiUi.raw(persistentStorage.toString());
+    new OperationHandler<PersistentStorage>()
+        .setOperation(Daemon.getPersistentStorage(currentDeployment, !noValidate))
+        .setFailureMesssage("Failed to load persistent storage.")
+        .setSuccessMessage("Configured persistent storage options: ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
@@ -20,7 +20,8 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.OAuth2Command;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -41,9 +42,11 @@ public class SecurityCommand extends AbstractConfigCommand {
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
 
-    Security security = Daemon.getSecurity(currentDeployment, !noValidate);
-
-    AnsiUi.success("Configured security settings: ");
-    AnsiUi.raw(security.toString());
+    new OperationHandler<Security>()
+        .setOperation(Daemon.getSecurity(currentDeployment, !noValidate))
+        .setFailureMesssage("Failed to load security settings.")
+        .setSuccessMessage("Configured security settings: ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/VersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/VersionCommand.java
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -35,6 +37,11 @@ public class VersionCommand extends AbstractConfigCommand {
 
   @Override
   protected void executeThis() {
-    AnsiUi.raw(Daemon.getVersion(getCurrentDeployment(), !noValidate));
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<String>()
+        .setOperation(Daemon.getVersion(currentDeployment, !noValidate))
+        .setFailureMesssage("Failed to load version of Spinnaker.")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractAccountCommand.java
@@ -58,9 +58,4 @@ public abstract class AbstractAccountCommand extends AbstractHasAccountCommand {
   protected void executeThis() {
     showHelp();
   }
-
-  private Account getAccount(String accountName) {
-    String currentDeployment = getCurrentDeployment();
-    return Daemon.getAccount(currentDeployment, getProviderName(), accountName, !noValidate);
-  }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractNamedProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractNamedProviderCommand.java
@@ -17,9 +17,10 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+
+import static com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format.STRING;
 
 public abstract class AbstractNamedProviderCommand extends AbstractProviderCommand {
   @Override
@@ -46,12 +47,15 @@ public abstract class AbstractNamedProviderCommand extends AbstractProviderComma
     );
   }
 
-  private Provider getProvider() {
-    return Daemon.getProvider(getCurrentDeployment(), getProviderName(), !noValidate);
-  }
-
   @Override
   protected void executeThis() {
-    AnsiUi.success(AnsiFormatUtils.format(getProvider()));
+    String currentDeployment = getCurrentDeployment();
+    String providerName = getProviderName();
+    new OperationHandler<Provider>()
+        .setFailureMesssage("Failed to get provider " + providerName + ".")
+        .setSuccessMessage("Successfully got provider " + providerName + ".")
+        .setFormat(STRING)
+        .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractProviderEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractProviderEnableDisableCommand.java
@@ -18,11 +18,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
-import java.util.HashMap;
-import java.util.Map;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import lombok.AccessLevel;
 import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public abstract class AbstractProviderEnableDisableCommand extends AbstractProviderCommand {
   @Override
@@ -49,13 +50,17 @@ public abstract class AbstractProviderEnableDisableCommand extends AbstractProvi
   }
 
   private void setEnable() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.setProviderEnableDisable(currentDeployment, getProviderName(), !noValidate, isEnable());
   }
 
   @Override
   protected void executeThis() {
-    setEnable();
-    AnsiUi.success("Successfully " + indicativePastPerfectAction() + " " + getProviderName());
+    String currentDeployment = getCurrentDeployment();
+    String providerName = getProviderName();
+    boolean enable = isEnable();
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " " + providerName)
+        .setFailureMesssage("Failed to " + getCommandName() + " " + getProviderName())
+        .setOperation(Daemon.setProviderEnableDisable(currentDeployment, providerName, !noValidate, enable))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
@@ -20,12 +20,13 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Parameters()
 public abstract class AbstractAddAccountCommand extends AbstractHasAccountCommand {
@@ -47,8 +48,11 @@ public abstract class AbstractAddAccountCommand extends AbstractHasAccountComman
     Account account = buildAccount(accountName);
     String providerName = getProviderName();
 
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.addAccount(currentDeployment, providerName, !noValidate, account);
-    AnsiUi.success("Added " + providerName + " account \"" + accountName + "\"");
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to add account " + accountName + " for provider " + providerName + ".")
+        .setSuccessMessage("Successfully added account " + accountName + " for provider " + providerName + ".")
+        .setOperation(Daemon.addAccount(currentDeployment, providerName, !noValidate, account))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractDeleteAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractDeleteAccountCommand.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import java.util.HashMap;
 import java.util.Map;
@@ -44,11 +45,15 @@ public abstract class AbstractDeleteAccountCommand extends AbstractHasAccountCom
   @Override
   protected void executeThis() {
     deleteAccount(getAccountName());
-    AnsiUi.success("Deleted " + getAccountName());
   }
 
   private void deleteAccount(String accountName) {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.deleteAccount(currentDeployment, getProviderName(), accountName, !noValidate);
+    String currentDeployment = getCurrentDeployment();
+    String providerName = getProviderName();
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to delete account " + accountName + " for provider " + providerName + ".")
+        .setSuccessMessage("Successfully deleted account " + accountName + " for provider " + providerName + ".")
+        .setOperation(Daemon.deleteAccount(currentDeployment, providerName, accountName, !noValidate))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
@@ -38,6 +39,10 @@ abstract class AbstractGetAccountCommand extends AbstractHasAccountCommand {
 
   private Account getAccount(String accountName) {
     String currentDeployment = getCurrentDeployment();
-    return Daemon.getAccount(currentDeployment, getProviderName(), accountName, !noValidate);
+    String providerName = getProviderName();
+    return new OperationHandler<Account>()
+        .setFailureMesssage("Failed to get account " + accountName + " for provider " + providerName + ".")
+        .setOperation(Daemon.getAccount(currentDeployment, providerName, accountName, false))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractListAccountsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractListAccountsCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
@@ -35,8 +36,12 @@ abstract class AbstractListAccountsCommand extends AbstractProviderCommand {
   private String commandName = "list";
 
   private Provider getProvider() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    return Daemon.getProvider(currentDeployment, getProviderName(), !noValidate);
+    String currentDeployment = getCurrentDeployment();
+    String providerName = getProviderName();
+    return new OperationHandler<Provider>()
+        .setFailureMesssage("Failed to get provider " + providerName + ".")
+        .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+        .get();
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractAddBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractAddBaseImageCommand.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.node.BaseImage;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -84,9 +84,12 @@ public abstract class AbstractAddBaseImageCommand extends AbstractHasBaseImageCo
     imageSettings.setTemplateFile(templateFile);
 
     String providerName = getProviderName();
+    String currentDeployment = getCurrentDeployment();
 
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.addBaseImage(currentDeployment, providerName, !noValidate, baseImage);
-    AnsiUi.success("Added " + providerName + " base image \"" + baseImageId + "\"");
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully added base image " + baseImageId + " to " + providerName + "'s bakery.")
+        .setFailureMesssage("Failed to add base image " + baseImageId + " to " + providerName + "'s bakery.")
+        .setOperation(Daemon.addBaseImage(currentDeployment, providerName, !noValidate, baseImage))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractBaseImageCommand.java
@@ -53,9 +53,4 @@ public abstract class AbstractBaseImageCommand extends AbstractProviderCommand {
   protected void executeThis() {
     showHelp();
   }
-
-  private BaseImage getBaseImage(String baseImageId) {
-    String currentDeployment = getCurrentDeployment();
-    return Daemon.getBaseImage(currentDeployment, getProviderName(), baseImageId, !noValidate);
-  }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractDeleteBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractDeleteBaseImageCommand.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.bakery;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -44,12 +45,13 @@ public abstract class AbstractDeleteBaseImageCommand extends AbstractHasBaseImag
 
   @Override
   protected void executeThis() {
-    deleteBaseImage(getBaseImageId());
-    AnsiUi.success("Deleted " + getBaseImageId());
-  }
-
-  private void deleteBaseImage(String baseImageId) {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.deleteBaseImage(currentDeployment, getProviderName(), baseImageId, !noValidate);
+    String currentDeployment = getCurrentDeployment();
+    String providerName = getProviderName();
+    String baseImageId = getBaseImageId();
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully deleted base image " + baseImageId + " from " + providerName + "'s bakery.")
+        .setFailureMesssage("Failed to delete base image " + baseImageId + " from " + providerName + "'s bakery.")
+        .setOperation(Daemon.deleteBaseImage(currentDeployment, providerName, baseImageId, !noValidate))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractEditBakeryDefaultsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractEditBakeryDefaultsCommand.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.node.BakeryDefaults;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -48,9 +48,15 @@ public abstract class AbstractEditBakeryDefaultsCommand<T extends BakeryDefaults
     String providerName = getProviderName();
     String currentDeployment = getCurrentDeployment();
     // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
-    BakeryDefaults defaults = Daemon.getBakeryDefaults(currentDeployment, providerName, false);
+    BakeryDefaults defaults = new OperationHandler<BakeryDefaults>()
+        .setFailureMesssage("Failed to get bakery defaults for " + providerName + "'s bakery.")
+        .setOperation(Daemon.getBakeryDefaults(currentDeployment, providerName, false))
+        .get();
 
-    Daemon.setBakeryDefaults(currentDeployment, providerName, !noValidate, editBakeryDefaults((T) defaults));
-    AnsiUi.success("Edited " + providerName + "'s bakery defaults");
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully edited bakery defaults for " + providerName + "'s bakery.")
+        .setFailureMesssage("Failed to edit bakery defaults for " + providerName + "'s bakery.")
+        .setOperation(Daemon.setBakeryDefaults(currentDeployment, providerName, !noValidate, editBakeryDefaults((T) defaults)))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractGetBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractGetBaseImageCommand.java
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.bakery;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.BaseImage;
 import lombok.Getter;
@@ -32,11 +34,14 @@ abstract class AbstractGetBaseImageCommand extends AbstractHasBaseImageCommand {
 
   @Override
   protected void executeThis() {
-    AnsiUi.success(getBaseImage(getBaseImageId()).toString());
-  }
-
-  private BaseImage getBaseImage(String baseImageName) {
     String currentDeployment = getCurrentDeployment();
-    return Daemon.getBaseImage(currentDeployment, getProviderName(), baseImageName, !noValidate);
+    String providerName = getProviderName();
+    String baseImageId = getBaseImageId();
+    new OperationHandler<BaseImage>()
+        .setFailureMesssage("Failed to get base image " + baseImageId + " in" + providerName + "'s bakery.")
+        .setSuccessMessage("Settings for " + baseImageId + " in" + providerName + "'s bakery:")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setOperation(Daemon.getBaseImage(currentDeployment, providerName, baseImageId, false))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractListBaseImagesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractListBaseImagesCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.bakery;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.BakeryDefaults;
 import com.netflix.spinnaker.halyard.config.model.v1.node.BaseImage;
@@ -35,17 +36,15 @@ abstract class AbstractListBaseImagesCommand extends AbstractProviderCommand {
   @Getter
   private String commandName = "list";
 
-  private Provider getProvider() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    return Daemon.getProvider(currentDeployment, getProviderName(), !noValidate);
-  }
-
   @Override
   protected void executeThis() {
     String providerName = getProviderName();
-    String deploymentName = getCurrentDeployment();
+    String currentDeployment = getCurrentDeployment();
 
-    BakeryDefaults bakeryDefaults = Daemon.getBakeryDefaults(deploymentName, providerName, !noValidate);
+    BakeryDefaults bakeryDefaults = new OperationHandler<BakeryDefaults>()
+        .setFailureMesssage("Failed to get bakery defaults for " + providerName + "'s bakery.")
+        .setOperation(Daemon.getBakeryDefaults(currentDeployment, providerName, !noValidate))
+        .get();
     List<BaseImage> baseImages = bakeryDefaults.getBaseImages();
 
     if (baseImages.isEmpty()) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/AbstractAuthnMethodEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/AbstractAuthnMethodEnableDisableCommand.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -51,16 +51,15 @@ public abstract class AbstractAuthnMethodEnableDisableCommand extends AbstractAu
     return "Set the " + methodName + " method as " + subjunctivePerfectAction();
   }
 
-  private void setEnable() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    String methodName = getMethod().id;
-    Daemon.setAuthnMethodEnabled(currentDeployment, methodName, !noValidate, isEnable());
-  }
-
   @Override
   protected void executeThis() {
-    setEnable();
+    String currentDeployment = getCurrentDeployment();
     String methodName = getMethod().id;
-    AnsiUi.success("Successfully " + indicativePastPerfectAction() + " " + methodName);
+    boolean enable = isEnable();
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " " + methodName)
+        .setFailureMesssage("Failed to " + getCommandName() + " " + methodName)
+        .setOperation(Daemon.setAuthnMethodEnabled(currentDeployment, methodName, !noValidate, enable))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/AbstractEditAuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/AbstractEditAuthnMethodCommand.java
@@ -20,7 +20,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -47,9 +47,15 @@ public abstract class AbstractEditAuthnMethodCommand<T extends AuthnMethod> exte
     String currentDeployment = getCurrentDeployment();
     String authnMethodName = getMethod().id;
     // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
-    AuthnMethod authnMethod = Daemon.getAuthnMethod(currentDeployment, authnMethodName, false);
+    AuthnMethod authnMethod = new OperationHandler<AuthnMethod>()
+        .setOperation(Daemon.getAuthnMethod(currentDeployment, authnMethodName, false))
+        .setFailureMesssage("Failed to get " + authnMethodName + " method.")
+        .get();
 
-    Daemon.setAuthnMethod(currentDeployment, authnMethodName, !noValidate, editAuthnMethod((T) authnMethod));
-    AnsiUi.success("Edited \"" + authnMethodName + "\" config.");
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setAuthnMethod(currentDeployment, authnMethodName, !noValidate, editAuthnMethod((T) authnMethod)))
+        .setFailureMesssage("Failed to edit " + authnMethodName + " method.")
+        .setSuccessMessage("Successfully edited " + authnMethodName + " method.")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/AuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/AuthnMethodCommand.java
@@ -19,7 +19,8 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
 
 abstract public class AuthnMethodCommand extends AbstractConfigCommand {
@@ -48,10 +49,13 @@ abstract public class AuthnMethodCommand extends AbstractConfigCommand {
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
+    String authnMethodName = getMethod().id;
 
-    AuthnMethod authnMethod = Daemon.getAuthnMethod(currentDeployment, getMethod().id, !noValidate);
-
-    AnsiUi.success("Configured " + getMethod().id + " settings: ");
-    AnsiUi.raw(authnMethod.toString());
+    new OperationHandler<AuthnMethod>()
+        .setOperation(Daemon.getAuthnMethod(currentDeployment, authnMethodName, false))
+        .setFailureMesssage("Failed to get " + authnMethodName + " method.")
+        .setSuccessMessage("Configured " + authnMethodName + " method: ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractMasterCommand.java
@@ -21,10 +21,6 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.Abstr
 import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.DeleteMasterCommandBuilder;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.GetMasterCommandBuilder;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master.ListMastersCommandBuilder;
-import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
-
-import static com.netflix.spinnaker.halyard.cli.services.v1.Daemon.getCurrentDeployment;
 
 public abstract class AbstractMasterCommand extends AbstractHasMasterCommand {
   @Override
@@ -57,10 +53,5 @@ public abstract class AbstractMasterCommand extends AbstractHasMasterCommand {
   @Override
   protected void executeThis() {
     showHelp();
-  }
-
-  private Master getMaster(String masterName) {
-    String currentDeployment = getCurrentDeployment();
-    return Daemon.getMaster(currentDeployment, getWebhookName(), masterName, !noValidate);
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractNamedWebhookCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractNamedWebhookCommand.java
@@ -18,8 +18,8 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
 
 public abstract class AbstractNamedWebhookCommand extends AbstractWebhookCommand {
@@ -47,12 +47,15 @@ public abstract class AbstractNamedWebhookCommand extends AbstractWebhookCommand
     );
   }
 
-  private Webhook getWebhook() {
-    return Daemon.getWebhook(getCurrentDeployment(), getWebhookName(), !noValidate);
-  }
-
   @Override
   protected void executeThis() {
-    AnsiUi.success(getWebhook().toString());
+    String currentDeployment = getCurrentDeployment();
+    String webhookName = getWebhookName();
+    new OperationHandler<Webhook>()
+        .setOperation(Daemon.getWebhook(currentDeployment, webhookName, !noValidate))
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setSuccessMessage("Configured " + webhookName + " webhook: ")
+        .setFailureMesssage("Failed to load webhook " + webhookName + ".")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractWebhookEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/AbstractWebhookEnableDisableCommand.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -50,14 +50,15 @@ public abstract class AbstractWebhookEnableDisableCommand extends AbstractWebhoo
     return "Set the " + getWebhookName() + " webhook as " + subjunctivePerfectAction();
   }
 
-  private void setEnable() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.setWebhookEnableDisable(currentDeployment, getWebhookName(), !noValidate, isEnable());
-  }
-
   @Override
   protected void executeThis() {
-    setEnable();
-    AnsiUi.success("Successfully " + indicativePastPerfectAction() + " " + getWebhookName());
+    String currentDeployment = getCurrentDeployment();
+    String webhookName = getWebhookName();
+    boolean enable = isEnable();
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " " + webhookName)
+        .setFailureMesssage("Failed to " + getCommandName() + " " + webhookName)
+        .setOperation(Daemon.setWebhookEnableDisable(currentDeployment, webhookName, !noValidate, enable))
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractAddMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractAddMasterCommand.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
 import lombok.AccessLevel;
@@ -48,8 +49,11 @@ public abstract class AbstractAddMasterCommand extends AbstractHasMasterCommand 
     Master master = buildMaster(masterName);
     String webhookName = getWebhookName();
 
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.addMaster(currentDeployment, webhookName, !noValidate, master);
-    AnsiUi.success("Added " + webhookName + " master \"" + masterName + "\"");
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.addMaster(currentDeployment, webhookName, !noValidate, master))
+        .setSuccessMessage("Added " + masterName + " webhook for " + webhookName + ".")
+        .setFailureMesssage("Failed to add " + masterName + " webhook for " + webhookName + ".")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractDeleteMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractDeleteMasterCommand.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -49,7 +50,12 @@ public abstract class AbstractDeleteMasterCommand extends AbstractHasMasterComma
   }
 
   private void deleteMaster(String masterName) {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    Daemon.deleteMaster(currentDeployment, getWebhookName(), masterName, !noValidate);
+    String currentDeployment = getCurrentDeployment();
+    String webhookName = getWebhookName();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.deleteMaster(currentDeployment, webhookName, masterName, !noValidate))
+        .setSuccessMessage("Deleted " + masterName + " webhook for " + webhookName + ".")
+        .setFailureMesssage("Failed to delete " + masterName + " webhook for " + webhookName + ".")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractGetMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractGetMasterCommand.java
@@ -18,7 +18,8 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
 
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
 import lombok.Getter;
 
@@ -32,11 +33,13 @@ abstract class AbstractGetMasterCommand extends AbstractHasMasterCommand {
 
   @Override
   protected void executeThis() {
-    AnsiUi.success(getMaster(getMasterName()).toString());
-  }
-
-  private Master getMaster(String masterName) {
     String currentDeployment = getCurrentDeployment();
-    return Daemon.getMaster(currentDeployment, getWebhookName(), masterName, !noValidate);
+    String masterName = getMasterName();
+    String webhookName = getWebhookName();
+    new OperationHandler<Master>()
+        .setOperation(Daemon.getMaster(currentDeployment, webhookName, masterName, !noValidate))
+        .setFailureMesssage("Failed to get " + masterName + " webhook for " + webhookName + ".")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractListMastersCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhooks/master/AbstractListMastersCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.master;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.config.webhooks.AbstractWebhookCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
@@ -35,8 +36,12 @@ abstract class AbstractListMastersCommand extends AbstractWebhookCommand {
   private String commandName = "list";
 
   private Webhook getWebhook() {
-    String currentDeployment = Daemon.getCurrentDeployment();
-    return Daemon.getWebhook(currentDeployment, getWebhookName(), !noValidate);
+    String currentDeployment = getCurrentDeployment();
+    String webhookName = getCurrentDeployment();
+    return new OperationHandler<Webhook>()
+        .setOperation(Daemon.getWebhook(currentDeployment, webhookName, !noValidate))
+        .setFailureMesssage("Failed to get " + webhookName + " wehbook.")
+        .get();
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DetailsDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DetailsDeployCommand.java
@@ -20,13 +20,17 @@ package com.netflix.spinnaker.halyard.cli.command.v1.deploy;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import lombok.AccessLevel;
 import lombok.Getter;
 
 @Parameters()
-public class DetailsDeployCommand extends NestableCommand {
+public class DetailsDeployCommand extends AbstractConfigCommand {
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "details";
 
@@ -42,8 +46,12 @@ public class DetailsDeployCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    String deploymentName = Daemon.getCurrentDeployment();
+    String deploymentName = getCurrentDeployment();
 
-    AnsiUi.raw(Daemon.getServiceDetails(deploymentName, serviceName, false).toString());
+    new OperationHandler<RunningServiceDetails>()
+        .setFailureMesssage("Failed load service details for service " + serviceName + ".")
+        .setOperation(Daemon.getServiceDetails(deploymentName, serviceName, !noValidate))
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/RunDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/RunDeployCommand.java
@@ -20,7 +20,9 @@ package com.netflix.spinnaker.halyard.cli.command.v1.deploy;
 import com.amazonaws.util.StringUtils;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.*;
 import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
 import com.netflix.spinnaker.halyard.core.job.v1.JobRequest;
@@ -34,7 +36,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 @Parameters()
-public class RunDeployCommand extends NestableCommand {
+public class RunDeployCommand extends AbstractConfigCommand {
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "run";
 
@@ -43,9 +45,11 @@ public class RunDeployCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    String deploymentName = Daemon.getCurrentDeployment();
+    Deployment.DeployResult result = new OperationHandler<Deployment.DeployResult>()
+        .setFailureMesssage("Failed to deploy Spinnaker.")
+        .setOperation(Daemon.deployDeployment(getCurrentDeployment(), !noValidate))
+        .get();
 
-    Deployment.DeployResult result = Daemon.deployDeployment(deploymentName, true);
     AnsiStoryBuilder storyBuilder = new AnsiStoryBuilder();
     AnsiParagraphBuilder paragraphBuilder = storyBuilder.addParagraph();
     paragraphBuilder.addSnippet(result.getPostInstallMessage());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
@@ -21,8 +21,9 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -58,6 +59,10 @@ public class BomVersionCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    AnsiUi.raw(AnsiFormatUtils.formatYaml(Daemon.getBillOfMaterials(getVersion())));
+    new OperationHandler<BillOfMaterials>()
+        .setFormat(AnsiFormatUtils.Format.YAML)
+        .setOperation(Daemon.getBillOfMaterials(getVersion()))
+        .setFailureMesssage("Failed to get Bill of Materials for version " + getVersion())
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/LatestVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/LatestVersionCommand.java
@@ -20,6 +20,8 @@ package com.netflix.spinnaker.halyard.cli.command.v1.versions;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,6 +36,10 @@ public class LatestVersionCommand extends NestableCommand {
 
   @Override
   protected void executeThis() {
-    AnsiUi.raw(Daemon.getLatest());
+    new OperationHandler<String>()
+        .setOperation(Daemon.getLatest())
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setFailureMesssage("Failed to get the latest version of Spinnaker.")
+        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -29,186 +29,286 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import retrofit.RestAdapter;
 import retrofit.client.OkClient;
 
+import java.util.function.Supplier;
+
 public class Daemon {
-  public static String getCurrentDeployment() {
-    return ResponseUnwrapper.get(getService().getCurrentDeployment());
+  public static Supplier<String> getCurrentDeployment() {
+    return () -> ResponseUnwrapper.get(getService().getCurrentDeployment());
   }
 
-  public static DeploymentEnvironment getDeploymentEnvironment(String deploymentName, boolean validate) {
-    Object rawDeploymentEnvironment = ResponseUnwrapper.get(getService().getDeploymentEnvironment(deploymentName, validate));
-    return getObjectMapper().convertValue(rawDeploymentEnvironment, DeploymentEnvironment.class);
+  public static Supplier<DeploymentEnvironment> getDeploymentEnvironment(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawDeploymentEnvironment = ResponseUnwrapper.get(getService().getDeploymentEnvironment(deploymentName, validate));
+      return getObjectMapper().convertValue(rawDeploymentEnvironment, DeploymentEnvironment.class);
+    };
   }
 
-  public static void setDeploymentEnvironment(String deploymentName, boolean validate, DeploymentEnvironment deploymentEnvironment) {
-    ResponseUnwrapper.get(getService().setDeploymentEnvironment(deploymentName, validate, deploymentEnvironment));
+  public static Supplier<Void> setDeploymentEnvironment(String deploymentName, boolean validate, DeploymentEnvironment deploymentEnvironment) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setDeploymentEnvironment(deploymentName, validate, deploymentEnvironment));
+      return null;
+    };
   }
 
-  public static BakeryDefaults getBakeryDefaults(String deploymentName, String providerName, boolean validate) {
-    Object rawBakeryDefaults = ResponseUnwrapper.get(getService().getBakeryDefaults(deploymentName, providerName, validate));
-    return getObjectMapper().convertValue(rawBakeryDefaults, Providers.translateBakeryDefaultsType(providerName));
+  public static Supplier<BakeryDefaults> getBakeryDefaults(String deploymentName, String providerName, boolean validate) {
+    return () -> {
+      Object rawBakeryDefaults = ResponseUnwrapper.get(getService().getBakeryDefaults(deploymentName, providerName, validate));
+      return getObjectMapper().convertValue(rawBakeryDefaults, Providers.translateBakeryDefaultsType(providerName));
+    };
   }
 
-  public static void setBakeryDefaults(String deploymentName, String providerName, boolean validate, BakeryDefaults bakeryDefaults) {
-    ResponseUnwrapper.get(getService().setBakeryDefaults(deploymentName, providerName, validate, bakeryDefaults));
+  public static Supplier<Void> setBakeryDefaults(String deploymentName, String providerName, boolean validate, BakeryDefaults bakeryDefaults) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setBakeryDefaults(deploymentName, providerName, validate, bakeryDefaults));
+      return null;
+    };
   }
 
-  public static Features getFeatures(String deploymentName, boolean validate) {
-    Object rawFeatures = ResponseUnwrapper.get(getService().getFeatures(deploymentName, validate));
-    return getObjectMapper().convertValue(rawFeatures, Features.class);
+  public static Supplier<Features> getFeatures(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawFeatures = ResponseUnwrapper.get(getService().getFeatures(deploymentName, validate));
+      return getObjectMapper().convertValue(rawFeatures, Features.class);
+    };
   }
 
-  public static void setFeatures(String deploymentName, boolean validate, Features features) {
-    ResponseUnwrapper.get(getService().setFeatures(deploymentName, validate, features));
+  public static Supplier<Void> setFeatures(String deploymentName, boolean validate, Features features) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setFeatures(deploymentName, validate, features));
+      return null;
+    };
   }
 
-  public static PersistentStorage getPersistentStorage(String deploymentName, boolean validate) {
-    Object rawStorage = ResponseUnwrapper.get(getService().getPersistentStorage(deploymentName, validate));
-    return getObjectMapper().convertValue(rawStorage, PersistentStorage.class);
+  public static Supplier<PersistentStorage> getPersistentStorage(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawStorage = ResponseUnwrapper.get(getService().getPersistentStorage(deploymentName, validate));
+      return getObjectMapper().convertValue(rawStorage, PersistentStorage.class);
+    };
   }
 
-  public static void setPersistentStorage(String deploymentName, boolean validate, PersistentStorage persistentStorage) {
-    ResponseUnwrapper.get(getService().setPersistentStorage(deploymentName, validate, persistentStorage));
+  public static Supplier<Void> setPersistentStorage(String deploymentName, boolean validate, PersistentStorage persistentStorage) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setPersistentStorage(deploymentName, validate, persistentStorage));
+      return null;
+    };
   }
 
-  public static BaseImage getBaseImage(String deploymentName, String providerName, String baseImageId, boolean validate) {
-    Object rawBaseImage = ResponseUnwrapper.get(getService().getBaseImage(deploymentName, providerName, baseImageId, validate));
-    return getObjectMapper().convertValue(rawBaseImage, Providers.translateBaseImageType(providerName));
+  public static Supplier<BaseImage> getBaseImage(String deploymentName, String providerName, String baseImageId, boolean validate) {
+    return () -> {
+      Object rawBaseImage = ResponseUnwrapper.get(getService().getBaseImage(deploymentName, providerName, baseImageId, validate));
+      return getObjectMapper().convertValue(rawBaseImage, Providers.translateBaseImageType(providerName));
+    };
   }
 
-  public static void addBaseImage(String deploymentName, String providerName, boolean validate, BaseImage baseImage) {
-    ResponseUnwrapper.get(getService().addBaseImage(deploymentName, providerName, validate, baseImage));
+  public static Supplier<Void> addBaseImage(String deploymentName, String providerName, boolean validate, BaseImage baseImage) {
+    return () -> {
+      ResponseUnwrapper.get(getService().addBaseImage(deploymentName, providerName, validate, baseImage));
+      return null;
+    };
   }
 
-  public static void setBaseImage(String deploymentName, String providerName, String baseImageId, boolean validate, BaseImage baseImage) {
-    ResponseUnwrapper.get(getService().setBaseImage(deploymentName, providerName, baseImageId, validate, baseImage));
+  public static Supplier<Void> setBaseImage(String deploymentName, String providerName, String baseImageId, boolean validate, BaseImage baseImage) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setBaseImage(deploymentName, providerName, baseImageId, validate, baseImage));
+      return null;
+    };
   }
 
-  public static void deleteBaseImage(String deploymentName, String providerName, String baseImageId, boolean validate) {
-    ResponseUnwrapper.get(getService().deleteBaseImage(deploymentName, providerName, baseImageId, validate));
+  public static Supplier<Void> deleteBaseImage(String deploymentName, String providerName, String baseImageId, boolean validate) {
+    return () -> {
+      ResponseUnwrapper.get(getService().deleteBaseImage(deploymentName, providerName, baseImageId, validate));
+      return null;
+    };
   }
 
-  public static Account getAccount(String deploymentName, String providerName, String accountName, boolean validate) {
-    Object rawAccount = ResponseUnwrapper.get(getService().getAccount(deploymentName, providerName, accountName, validate));
-    return getObjectMapper().convertValue(rawAccount, Providers.translateAccountType(providerName));
+  public static Supplier<Account> getAccount(String deploymentName, String providerName, String accountName, boolean validate) {
+    return () -> {
+      Object rawAccount = ResponseUnwrapper.get(getService().getAccount(deploymentName, providerName, accountName, validate));
+      return getObjectMapper().convertValue(rawAccount, Providers.translateAccountType(providerName));
+    };
   }
 
-  public static void addAccount(String deploymentName, String providerName, boolean validate, Account account) {
-    ResponseUnwrapper.get(getService().addAccount(deploymentName, providerName, validate, account));
+  public static Supplier<Void> addAccount(String deploymentName, String providerName, boolean validate, Account account) {
+    return () -> {
+      ResponseUnwrapper.get(getService().addAccount(deploymentName, providerName, validate, account));
+      return null;
+    };
   }
 
-  public static void setAccount(String deploymentName, String providerName, String accountName, boolean validate, Account account) {
-    ResponseUnwrapper.get(getService().setAccount(deploymentName, providerName, accountName, validate, account));
+  public static Supplier<Void> setAccount(String deploymentName, String providerName, String accountName, boolean validate, Account account) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setAccount(deploymentName, providerName, accountName, validate, account));
+      return null;
+    };
   }
 
-  public static void deleteAccount(String deploymentName, String providerName, String accountName, boolean validate) {
-    ResponseUnwrapper.get(getService().deleteAccount(deploymentName, providerName, accountName, validate));
+  public static Supplier<Void> deleteAccount(String deploymentName, String providerName, String accountName, boolean validate) {
+    return () -> {
+      ResponseUnwrapper.get(getService().deleteAccount(deploymentName, providerName, accountName, validate));
+      return null;
+    };
   }
 
-  public static Provider getProvider(String deploymentName, String providerName, boolean validate) {
-    Object provider = ResponseUnwrapper.get(getService().getProvider(deploymentName, providerName, validate));
-    return getObjectMapper().convertValue(provider, Providers.translateProviderType(providerName));
+  public static Supplier<Provider> getProvider(String deploymentName, String providerName, boolean validate) {
+    return () -> {
+      Object provider = ResponseUnwrapper.get(getService().getProvider(deploymentName, providerName, validate));
+      return getObjectMapper().convertValue(provider, Providers.translateProviderType(providerName));
+    };
   }
 
-  public static void setProviderEnableDisable(String deploymentName, String providerName, boolean validate, boolean enable) {
-    ResponseUnwrapper.get(getService().setProviderEnabled(deploymentName, providerName, validate, enable));
+  public static Supplier<Void> setProviderEnableDisable(String deploymentName, String providerName, boolean validate, boolean enable) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setProviderEnabled(deploymentName, providerName, validate, enable));
+      return null;
+    };
   }
 
-  public static Master getMaster(String deploymentName, String webhookName, String masterName, boolean validate) {
-    Object rawMaster = ResponseUnwrapper.get(getService().getMaster(deploymentName, webhookName, masterName, validate));
-    return getObjectMapper().convertValue(rawMaster, Webhooks.translateMasterType(webhookName));
+  public static Supplier<Master> getMaster(String deploymentName, String webhookName, String masterName, boolean validate) {
+    return () -> {
+      Object rawMaster = ResponseUnwrapper.get(getService().getMaster(deploymentName, webhookName, masterName, validate));
+      return getObjectMapper().convertValue(rawMaster, Webhooks.translateMasterType(webhookName));
+    };
   }
 
-  public static void addMaster(String deploymentName, String webhookName, boolean validate, Master master) {
-    ResponseUnwrapper.get(getService().addMaster(deploymentName, webhookName, validate, master));
+  public static Supplier<Void> addMaster(String deploymentName, String webhookName, boolean validate, Master master) {
+    return () -> {
+      ResponseUnwrapper.get(getService().addMaster(deploymentName, webhookName, validate, master));
+      return null;
+    };
   }
 
-  public static void setMaster(String deploymentName, String webhookName, String masterName, boolean validate, Master master) {
-    ResponseUnwrapper.get(getService().setMaster(deploymentName, webhookName, masterName, validate, master));
+  public static Supplier<Void> setMaster(String deploymentName, String webhookName, String masterName, boolean validate, Master master) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setMaster(deploymentName, webhookName, masterName, validate, master));
+      return null;
+    };
   }
 
-  public static void deleteMaster(String deploymentName, String webhookName, String masterName, boolean validate) {
-    ResponseUnwrapper.get(getService().deleteMaster(deploymentName, webhookName, masterName, validate));
+  public static Supplier<Void> deleteMaster(String deploymentName, String webhookName, String masterName, boolean validate) {
+    return () -> {
+      ResponseUnwrapper.get(getService().deleteMaster(deploymentName, webhookName, masterName, validate));
+      return null;
+    };
   }
 
-  public static Webhook getWebhook(String deploymentName, String webhookName, boolean validate) {
-    Object webhook = ResponseUnwrapper.get(getService().getWebhook(deploymentName, webhookName, validate));
-    return getObjectMapper().convertValue(webhook, Webhooks.translateWebhookType(webhookName));
+  public static Supplier<Webhook> getWebhook(String deploymentName, String webhookName, boolean validate) {
+    return () -> {
+      Object webhook = ResponseUnwrapper.get(getService().getWebhook(deploymentName, webhookName, validate));
+      return getObjectMapper().convertValue(webhook, Webhooks.translateWebhookType(webhookName));
+    };
   }
 
-  public static void setWebhookEnableDisable(String deploymentName, String webhookName, boolean validate, boolean enable) {
-    ResponseUnwrapper.get(getService().setWebhookEnabled(deploymentName, webhookName, validate, enable));
+  public static Supplier<Void> setWebhookEnableDisable(String deploymentName, String webhookName, boolean validate, boolean enable) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setWebhookEnabled(deploymentName, webhookName, validate, enable));
+      return null;
+    };
   }
 
-  public static void generateDeployment(String deploymentName, boolean validate) {
-    ResponseUnwrapper.get(getService().generateDeployment(deploymentName, validate, ""));
+  public static Supplier<Void> generateDeployment(String deploymentName, boolean validate) {
+    return () -> {
+      ResponseUnwrapper.get(getService().generateDeployment(deploymentName, validate, ""));
+      return null;
+    };
   }
 
-  public static Deployment.DeployResult deployDeployment(String deploymentName, boolean validate) {
-    Object rawDeployResult = ResponseUnwrapper.get(getService().deployDeployment(deploymentName, validate, ""));
-    return getObjectMapper().convertValue(rawDeployResult, Deployment.DeployResult.class);
+  public static Supplier<Deployment.DeployResult> deployDeployment(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawDeployResult = ResponseUnwrapper.get(getService().deployDeployment(deploymentName, validate, ""));
+      return getObjectMapper().convertValue(rawDeployResult, Deployment.DeployResult.class);
+    };
   }
 
-  public static NodeDiff configDiff(String deploymentName, boolean validate) {
-    Object rawDiff = ResponseUnwrapper.get(getService().configDiff(deploymentName, validate));
-    return getObjectMapper().convertValue(rawDiff, NodeDiff.class);
+  public static Supplier<NodeDiff> configDiff(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawDiff = ResponseUnwrapper.get(getService().configDiff(deploymentName, validate));
+      return getObjectMapper().convertValue(rawDiff, NodeDiff.class);
+    };
   }
 
-  public static Security getSecurity(String deploymentName, boolean validate) {
-    Object rawSecurity = ResponseUnwrapper.get(getService().getSecurity(deploymentName, validate));
-    return getObjectMapper().convertValue(rawSecurity, Security.class);
+  public static Supplier<Security> getSecurity(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawSecurity = ResponseUnwrapper.get(getService().getSecurity(deploymentName, validate));
+      return getObjectMapper().convertValue(rawSecurity, Security.class);
+    };
   }
 
-  public static void setSecurity(String deploymentName, boolean validate, Security security) {
-    ResponseUnwrapper.get(getService().setSecurity(deploymentName, validate, security));
+  public static Supplier<Void> setSecurity(String deploymentName, boolean validate, Security security) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setSecurity(deploymentName, validate, security));
+      return null;
+    };
   }
 
-  public static AuthnMethod getAuthnMethod(String deploymentName, String methodName, boolean validate) {
-    Object rawOAuth2 = ResponseUnwrapper.get(getService().getAuthnMethod(deploymentName, methodName, validate));
-    return getObjectMapper().convertValue(rawOAuth2, AuthnMethod.translateAuthnMethodName(methodName));
+  public static Supplier<AuthnMethod> getAuthnMethod(String deploymentName, String methodName, boolean validate) {
+    return () -> {
+      Object rawOAuth2 = ResponseUnwrapper.get(getService().getAuthnMethod(deploymentName, methodName, validate));
+      return getObjectMapper().convertValue(rawOAuth2, AuthnMethod.translateAuthnMethodName(methodName));
+    };
   }
 
-  public static void setAuthnMethod(String deploymentName, String methodName, boolean validate, AuthnMethod authnMethod) {
-    ResponseUnwrapper.get(getService().setAuthnMethod(deploymentName, methodName, validate, authnMethod));
+  public static Supplier<Void> setAuthnMethod(String deploymentName, String methodName, boolean validate, AuthnMethod authnMethod) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setAuthnMethod(deploymentName, methodName, validate, authnMethod));
+      return null;
+    };
   }
 
-  public static void setAuthnMethodEnabled(String deploymentName, String methodName, boolean validate, boolean enabled) {
-    ResponseUnwrapper.get(getService().setAuthnMethodEnabled(deploymentName, methodName, validate, enabled));
+  public static Supplier<Void> setAuthnMethodEnabled(String deploymentName, String methodName, boolean validate, boolean enabled) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setAuthnMethodEnabled(deploymentName, methodName, validate, enabled));
+      return null;
+    };
   }
 
-  public static Versions getVersions() {
-    Object rawVersions = ResponseUnwrapper.get(getService().getVersions());
-    return getObjectMapper().convertValue(rawVersions, Versions.class);
+  public static Supplier<Versions> getVersions() {
+    return () -> {
+      Object rawVersions = ResponseUnwrapper.get(getService().getVersions());
+      return getObjectMapper().convertValue(rawVersions, Versions.class);
+    };
   }
 
-  public static String getLatest() {
-    return ResponseUnwrapper.get(getService().getLatest());
+  public static Supplier<String> getLatest() {
+    return () -> ResponseUnwrapper.get(getService().getLatest());
   }
 
-  public static RunningServiceDetails getServiceDetails(String deploymentName, String serviceName, boolean validate) {
-    Object rawDetails = ResponseUnwrapper.get(getService().getServiceDetails(deploymentName, serviceName, validate));
-    return getObjectMapper().convertValue(rawDetails, RunningServiceDetails.class);
+  public static Supplier<RunningServiceDetails> getServiceDetails(String deploymentName, String serviceName, boolean validate) {
+    return () -> {
+      Object rawDetails = ResponseUnwrapper.get(getService().getServiceDetails(deploymentName, serviceName, validate));
+      return getObjectMapper().convertValue(rawDetails, RunningServiceDetails.class);
+    };
   }
 
-  public static BillOfMaterials getBillOfMaterials(String version) {
-    Object rawBillOfMaterials = ResponseUnwrapper.get(getService().getBillOfMaterials(version));
-    return getObjectMapper().convertValue(rawBillOfMaterials, BillOfMaterials.class);
+  public static Supplier<BillOfMaterials> getBillOfMaterials(String version) {
+    return () -> {
+      Object rawBillOfMaterials = ResponseUnwrapper.get(getService().getBillOfMaterials(version));
+      return getObjectMapper().convertValue(rawBillOfMaterials, BillOfMaterials.class);
+    };
   }
 
-  public static void publishProfile(String bomPath, String artifactName, String profilePath) {
-    ResponseUnwrapper.get(getService().publishProfile(bomPath, artifactName, profilePath, ""));
+  public static Supplier<Void> publishProfile(String bomPath, String artifactName, String profilePath) {
+    return () -> {
+      ResponseUnwrapper.get(getService().publishProfile(bomPath, artifactName, profilePath, ""));
+      return null;
+    };
   }
 
-  public static void publishBom(String bomPath) {
-    ResponseUnwrapper.get(getService().publishBom(bomPath,""));
+  public static Supplier<Void> publishBom(String bomPath) {
+    return () -> {
+      ResponseUnwrapper.get(getService().publishBom(bomPath,""));
+      return null;
+    };
   }
 
-  public static String getVersion(String deploymentName, boolean validate) {
-    return ResponseUnwrapper.get(getService().getVersion(deploymentName, validate));
+  public static Supplier<String> getVersion(String deploymentName, boolean validate) {
+    return () -> ResponseUnwrapper.get(getService().getVersion(deploymentName, validate));
   }
 
-  public static void setVersion(String deploymentName, boolean validate, String versionName) {
-    Versions.Version version = new Versions.Version().setVersion(versionName);
-    ResponseUnwrapper.get(getService().setVersion(deploymentName, validate, version));
+  public static Supplier<Void> setVersion(String deploymentName, boolean validate, String versionName) {
+    return () -> {
+      Versions.Version version = new Versions.Version().setVersion(versionName);
+      ResponseUnwrapper.get(getService().setVersion(deploymentName, validate, version));
+      return null;
+    };
   }
 
   static <C, T> DaemonTask<C, T> getTask(String uuid) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ExpectedDaemonFailureException.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ExpectedDaemonFailureException.java
@@ -25,7 +25,11 @@ package com.netflix.spinnaker.halyard.cli.services.v1;
  * Non-examples include: The CLI encountered an NPE.
  */
 public class ExpectedDaemonFailureException extends RuntimeException {
-  ExpectedDaemonFailureException() {
-    super();
+  ExpectedDaemonFailureException(Throwable cause) {
+    super(cause);
+  }
+
+  ExpectedDaemonFailureException(String msg, Throwable cause) {
+    super(msg, cause);
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/OperationHandler.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/OperationHandler.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.services.v1;
+
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiPrinter;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import lombok.Data;
+
+import java.util.function.Supplier;
+
+import static com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format.NONE;
+
+@Data
+public class OperationHandler<T> implements Supplier<T> {
+  String successMessage;
+  String failureMesssage;
+  Supplier<T> operation;
+  Format format = NONE;
+
+  @Override
+  public T get() {
+    T res;
+    try {
+      res = operation.get();
+    } catch (ExpectedDaemonFailureException e) {
+      throw new ExpectedDaemonFailureException(failureMesssage, e.getCause());
+    }
+
+    if (successMessage != null) {
+      AnsiUi.success(successMessage);
+    }
+
+    String result = AnsiFormatUtils.format(format, res);
+    if (!result.isEmpty()) {
+      AnsiPrinter.println(result);
+    }
+
+    return res;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
@@ -56,7 +56,12 @@ public class ResponseUnwrapper {
     DaemonResponse<T> response = task.getResponse();
     formatProblemSet(response.getProblemSet());
     if (task.getState() == DaemonTask.State.FATAL) {
-      throw new ExpectedDaemonFailureException();
+      Exception fatal = task.getFatalError();
+      if (fatal == null) {
+        throw new RuntimeException("Task failed without reason. This is a bug.");
+      } else {
+        throw new ExpectedDaemonFailureException(fatal);
+      }
     }
 
     return response.getResponseBody();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiFormatUtils.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiFormatUtils.java
@@ -30,6 +30,12 @@ public class AnsiFormatUtils {
   private static Yaml yamlParser = null;
   private static ObjectMapper objectMapper = null;
 
+  public enum Format  {
+    YAML,
+    STRING,
+    NONE
+  }
+
   private static Yaml getYamlParser() {
     if (yamlParser == null) {
       DumperOptions options = new DumperOptions();
@@ -52,6 +58,23 @@ public class AnsiFormatUtils {
 
   public static String formatYaml(Object yaml) {
     return getYamlParser().dump(getObjectMapper().convertValue(yaml, Map.class));
+  }
+
+  public static String format(Format format, Object o) {
+    if (o == null) {
+      return "";
+    }
+
+    switch (format) {
+      case NONE:
+        return "";
+      case STRING:
+        return o.toString();
+      case YAML:
+        return formatYaml(o);
+      default:
+        throw new RuntimeException("Unknown format: " + format);
+    }
   }
 
   public static String format(Account account) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiUi.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiUi.java
@@ -107,4 +107,18 @@ public class AnsiUi {
 
     AnsiPrinter.println(builder.toString());
   }
+
+  public static void failure(String message) {
+    AnsiParagraphBuilder builder = new AnsiParagraphBuilder()
+        .setIndentFirstLine(false)
+        .setIndentWidth(2);
+
+    builder.addSnippet("- ")
+        .setForegroundColor(AnsiForegroundColor.RED)
+        .addStyle(AnsiStyle.BOLD);
+
+    builder.addSnippet(message);
+
+    AnsiPrinter.println(builder.toString());
+  }
 }


### PR DESCRIPTION
This ensures each operation will display success/failure similarly, and will allow us in the future to append an output formatting paramter (like yaml or json) for the larger structures halyard manipulates. 