### PR TITLE
feat(config): Fiat config generation + CLI commands

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
@@ -18,7 +18,8 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.security.OAuth2Command;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.OAuth2Command;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz.RolesCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
@@ -36,6 +37,7 @@ public class SecurityCommand extends AbstractConfigCommand {
 
   public SecurityCommand() {
     registerSubcommand(new OAuth2Command());
+    registerSubcommand(new RolesCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractAuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractAuthnMethodCommand.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractAuthnMethodEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractAuthnMethodEnableDisableCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class AbstractAuthnMethodEnableDisableCommand extends AbstractAuthnMethodCommand {
+  @Override
+  public String getCommandName() {
+    return isEnable() ? "enable" : "disable";
+  }
+
+  private String subjunctivePerfectAction() {
+    return isEnable() ? "enabled" : "disabled";
+  }
+
+  private String indicativePastPerfectAction() {
+    return isEnable() ? "enabled" : "disabled";
+  }
+
+  protected abstract boolean isEnable();
+
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Override
+  public String getDescription() {
+    String methodName = getMethod().id;
+    return "Set the " + methodName + " method as " + subjunctivePerfectAction();
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    String methodName = getMethod().id;
+    boolean enable = isEnable();
+    new OperationHandler<Void>()
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " " + methodName)
+        .setFailureMesssage("Failed to " + getCommandName() + " " + methodName)
+        .setOperation(Daemon.setAuthnMethodEnabled(currentDeployment, methodName, !noValidate, enable))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractEditAuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractEditAuthnMethodCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters()
+public abstract class AbstractEditAuthnMethodCommand<T extends AuthnMethod> extends AbstractAuthnMethodCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  protected abstract AuthnMethod editAuthnMethod(T authnMethod);
+
+  public String getDescription() {
+    return "Edit the " + getMethod().id + " authentication method.";
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    String authnMethodName = getMethod().id;
+    // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
+    AuthnMethod authnMethod = new OperationHandler<AuthnMethod>()
+        .setOperation(Daemon.getAuthnMethod(currentDeployment, authnMethodName, false))
+        .setFailureMesssage("Failed to get " + authnMethodName + " method.")
+        .get();
+
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setAuthnMethod(currentDeployment, authnMethodName, !noValidate, editAuthnMethod((T) authnMethod)))
+        .setFailureMesssage("Failed to edit " + authnMethodName + " method.")
+        .setSuccessMessage("Successfully edited " + authnMethodName + " method.")
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodCommand.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
@@ -52,7 +52,7 @@ abstract public class AuthnMethodCommand extends AbstractConfigCommand {
     String authnMethodName = getMethod().id;
 
     new OperationHandler<AuthnMethod>()
-        .setOperation(Daemon.getAuthnMethod(currentDeployment, authnMethodName, false))
+        .setOperation(Daemon.getAuthnMethod(currentDeployment, authnMethodName, !noValidate))
         .setFailureMesssage("Failed to get " + authnMethodName + " method.")
         .setSuccessMessage("Configured " + authnMethodName + " method: ")
         .setFormat(AnsiFormatUtils.Format.STRING)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodEnableDisableCommandBuilder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class AuthnMethodEnableDisableCommandBuilder implements CommandBuilder {
+  @Setter
+  AuthnMethod.Method method;
+
+  @Setter
+  boolean enable;
+
+  @Override
+  public NestableCommand build() {
+    return new AuthnMethodEnableDisableCommand(method, enable);
+  }
+
+  @Parameters()
+  private static class AuthnMethodEnableDisableCommand extends AbstractAuthnMethodEnableDisableCommand {
+    private AuthnMethodEnableDisableCommand(AuthnMethod.Method method, boolean enable) {
+      this.method = method;
+      this.enable = enable;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    boolean enable;
+
+    @Getter
+    private AuthnMethod.Method method;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/EditOAuth2Command.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/EditOAuth2Command.java
@@ -15,7 +15,7 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
 
 import com.beust.jcommander.Parameter;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.OAuth2ProviderTypeConverter;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/OAuth2Command.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/OAuth2Command.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
+
+import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+
+public class OAuth2Command extends AuthnMethodCommand {
+  public AuthnMethod.Method getMethod() {
+    return AuthnMethod.Method.OAuth2;
+  }
+
+  public OAuth2Command() {
+    super();
+    registerSubcommand(new EditOAuth2Command());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEditRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEditRoleProviderCommand.java
@@ -15,13 +15,13 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -29,33 +29,33 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Parameters()
-public abstract class AbstractEditAuthnMethodCommand<T extends AuthnMethod> extends AbstractAuthnMethodCommand {
+public abstract class AbstractEditRoleProviderCommand<T extends RoleProvider> extends AbstractRoleProviderCommand {
   @Getter(AccessLevel.PROTECTED)
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "edit";
 
-  protected abstract AuthnMethod editAuthnMethod(T authnMethod);
+  protected abstract RoleProvider editRoleProvider(T roleProvider);
 
   public String getDescription() {
-    return "Edit the " + getMethod().id + " authentication method.";
+    return "Edit the " + getRoleProviderType() + " role provider.";
   }
 
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
-    String authnMethodName = getMethod().id;
+    String roleProviderName = getRoleProviderType() + "";
     // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
-    AuthnMethod authnMethod = new OperationHandler<AuthnMethod>()
-        .setOperation(Daemon.getAuthnMethod(currentDeployment, authnMethodName, false))
-        .setFailureMesssage("Failed to get " + authnMethodName + " method.")
+    RoleProvider roleProvider = new OperationHandler<RoleProvider>()
+        .setOperation(Daemon.getRoleProvider(currentDeployment, roleProviderName, false))
+        .setFailureMesssage("Failed to get " + roleProviderName + " method.")
         .get();
 
     new OperationHandler<Void>()
-        .setOperation(Daemon.setAuthnMethod(currentDeployment, authnMethodName, !noValidate, editAuthnMethod((T) authnMethod)))
-        .setFailureMesssage("Failed to edit " + authnMethodName + " method.")
-        .setSuccessMessage("Successfully edited " + authnMethodName + " method.")
+        .setOperation(Daemon.setRoleProvider(currentDeployment, roleProviderName, !noValidate, editRoleProvider((T) roleProvider)))
+        .setFailureMesssage("Failed to edit " + roleProviderName + " method.")
+        .setSuccessMessage("Successfully edited " + roleProviderName + " method.")
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEnableDisableRolesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEnableDisableRolesCommand.java
@@ -15,9 +15,10 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
 
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import lombok.AccessLevel;
@@ -26,7 +27,7 @@ import lombok.Getter;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class AbstractAuthnMethodEnableDisableCommand extends AbstractAuthnMethodCommand {
+public abstract class AbstractEnableDisableRolesCommand extends AbstractConfigCommand {
   @Override
   public String getCommandName() {
     return isEnable() ? "enable" : "disable";
@@ -47,19 +48,17 @@ public abstract class AbstractAuthnMethodEnableDisableCommand extends AbstractAu
 
   @Override
   public String getDescription() {
-    String methodName = getMethod().id;
-    return "Set the " + methodName + " method as " + subjunctivePerfectAction();
+    return "Set Spinnaker's role-based authorization to " + subjunctivePerfectAction();
   }
 
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
-    String methodName = getMethod().id;
     boolean enable = isEnable();
     new OperationHandler<Void>()
-        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " " + methodName)
-        .setFailureMesssage("Failed to " + getCommandName() + " " + methodName)
-        .setOperation(Daemon.setAuthnMethodEnabled(currentDeployment, methodName, !noValidate, enable))
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " authorization")
+        .setFailureMesssage("Failed to " + getCommandName() + " authorization")
+        .setOperation(Daemon.setAuthzEnabled(currentDeployment, !noValidate, enable))
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractRoleProviderCommand.java
@@ -15,17 +15,21 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
 
-import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
 
-public class OAuth2Command extends AuthnMethodCommand {
-  public AuthnMethod.Method getMethod() {
-    return AuthnMethod.Method.OAuth2;
+abstract public class AbstractRoleProviderCommand extends AbstractConfigCommand {
+  abstract public GroupMembership.RoleProviderType getRoleProviderType();
+
+  @Override
+  public String getDescription() {
+    return "Configure the " + getRoleProviderType() + " role provider.";
   }
 
-  public OAuth2Command() {
-    super();
-    registerSubcommand(new EditOAuth2Command());
+  @Override
+  public String getCommandName() {
+    return getRoleProviderType() + "";
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/EditGoogleRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/EditGoogleRoleProviderCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
+
+import com.beust.jcommander.Parameter;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GoogleRoleProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
+import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class EditGoogleRoleProviderCommand extends AbstractEditRoleProviderCommand<GoogleRoleProvider> {
+  GroupMembership.RoleProviderType roleProviderType = GroupMembership.RoleProviderType.GOOGLE;
+
+  @Parameter(
+      names = "--credential-path",
+      converter = PathExpandingConverter.class,
+      description = "A path to a valid json service account that can authenticate against the Google role provider."
+  )
+  private String credentialPath;
+
+  @Parameter(
+      names = "--admin-username",
+      description = "Your role provider's admin username e.g. ttomsu@spinnaker-test.net"
+  )
+  private String adminUsername;
+
+  @Parameter(
+      names = "--domain",
+      description = "The domain your role provider is configured for e.g. spinnaker-test.net."
+  )
+  private String domain;
+
+  @Override
+  protected RoleProvider editRoleProvider(GoogleRoleProvider roleProvider) {
+    roleProvider.setCredentialPath(isSet(credentialPath) ? credentialPath : roleProvider.getCredentialPath());
+    roleProvider.setAdminUsername(isSet(adminUsername) ? adminUsername : roleProvider.getAdminUsername());
+    roleProvider.setDomain(isSet(domain) ? domain : roleProvider.getAdminUsername());
+    return roleProvider;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/EditRolesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/EditRolesCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
+
+import com.beust.jcommander.Parameter;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class EditRolesCommand extends AbstractConfigCommand {
+  private String commandName = "edit";
+  private String description = "Edit your roles provider settings.";
+
+  @Parameter(
+      names = "--type",
+      description = "Set a roles provider type"
+  )
+  GroupMembership.RoleProviderType type;
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+
+    GroupMembership membership = new OperationHandler<GroupMembership>()
+        .setOperation(Daemon.getGroupMembership(currentDeployment, false))
+        .setFailureMesssage("Failed to get configured roles.")
+        .get();
+
+    int originalHash = membership.hashCode();
+
+    membership.setRoleProviderType(type != null ? type : membership.getRoleProviderType());
+
+    if (originalHash == membership.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+     new OperationHandler<Void>()
+        .setOperation(Daemon.setGroupMembership(currentDeployment, !noValidate, membership))
+        .setFailureMesssage("Failed to set configured roles.")
+        .setSuccessMessage("Successfully updated roles.")
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/EnableDisableRolesCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/EnableDisableRolesCommandBuilder.java
@@ -15,39 +15,31 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-public class AuthnMethodEnableDisableCommandBuilder implements CommandBuilder {
-  @Setter
-  AuthnMethod.Method method;
-
+public class EnableDisableRolesCommandBuilder implements CommandBuilder {
   @Setter
   boolean enable;
 
   @Override
   public NestableCommand build() {
-    return new AuthnMethodEnableDisableCommand(method, enable);
+    return new EnableDisableRolesCommand(enable);
   }
 
   @Parameters()
-  private static class AuthnMethodEnableDisableCommand extends AbstractAuthnMethodEnableDisableCommand {
-    private AuthnMethodEnableDisableCommand(AuthnMethod.Method method, boolean enable) {
-      this.method = method;
+  private static class EnableDisableRolesCommand extends AbstractEnableDisableRolesCommand {
+    private EnableDisableRolesCommand(boolean enable) {
       this.enable = enable;
     }
 
     @Getter(AccessLevel.PROTECTED)
     boolean enable;
-
-    @Getter
-    private AuthnMethod.Method method;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/GoogleRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/GoogleRoleProviderCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
+
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
+import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class GoogleRoleProviderCommand extends AbstractRoleProviderCommand {
+  private GroupMembership.RoleProviderType roleProviderType = GroupMembership.RoleProviderType.GOOGLE;
+
+  public GoogleRoleProviderCommand() {
+    registerSubcommand(new EditGoogleRoleProviderCommand());
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<RoleProvider>()
+        .setOperation(Daemon.getRoleProvider(currentDeployment, roleProviderType + "", true))
+        .setFailureMesssage("Failed to get " + roleProviderType + " configuration.")
+        .setSuccessMessage("Configured " + roleProviderType + " role provider:")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/RolesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/RolesCommand.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class RolesCommand extends AbstractConfigCommand {
+
+  public RolesCommand() {
+    super();
+    registerSubcommand(new RolesProviderCommand());
+
+    registerSubcommand(new EditRolesCommand());
+
+    registerSubcommand(new EnableDisableRolesCommandBuilder()
+        .setEnable(true)
+        .build()
+    );
+
+    registerSubcommand(new EnableDisableRolesCommandBuilder()
+        .setEnable(false)
+        .build()
+    );
+  }
+
+  private String commandName = "roles";
+  private String description = "Configure authorization via a roles provider.";
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+
+    new OperationHandler<GroupMembership>()
+        .setOperation(Daemon.getGroupMembership(currentDeployment, true))
+        .setFailureMesssage("Failed to get configured roles.")
+        .setSuccessMessage("Configured roles: ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/RolesProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/RolesProviderCommand.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class RolesProviderCommand extends AbstractConfigCommand {
+  String description = "Configure a roles provider.";
+  String commandName = "provider";
+
+  public RolesProviderCommand() {
+    registerSubcommand(new GoogleRoleProviderCommand());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -20,6 +20,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
+import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
@@ -249,6 +251,41 @@ public class Daemon {
   public static Supplier<Void> setAuthnMethod(String deploymentName, String methodName, boolean validate, AuthnMethod authnMethod) {
     return () -> {
       ResponseUnwrapper.get(getService().setAuthnMethod(deploymentName, methodName, validate, authnMethod));
+      return null;
+    };
+  }
+
+  public static Supplier<Void> setGroupMembership(String deploymentName, boolean validate, GroupMembership membership) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setGroupMembership(deploymentName, validate, membership));
+      return null;
+    };
+  }
+
+  public static Supplier<GroupMembership> getGroupMembership(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawGroupMembership = ResponseUnwrapper.get(getService().getGroupMembership(deploymentName, validate));
+      return getObjectMapper().convertValue(rawGroupMembership, GroupMembership.class);
+    };
+  }
+
+  public static Supplier<RoleProvider> getRoleProvider(String deploymentName, String roleProviderName, boolean validate) {
+    return () -> {
+      Object rawRoleProvider = ResponseUnwrapper.get(getService().getRoleProvider(deploymentName, roleProviderName, validate));
+      return getObjectMapper().convertValue(rawRoleProvider, GroupMembership.translateRoleProviderType(roleProviderName));
+    };
+  }
+
+  public static Supplier<Void> setRoleProvider(String deploymentName, String roleProviderName, boolean validate, RoleProvider authnMethod) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setRoleProvider(deploymentName, roleProviderName, validate, authnMethod));
+      return null;
+    };
+  }
+
+  public static Supplier<Void> setAuthzEnabled(String deploymentName, boolean validate, boolean enabled) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setAuthzEnabled(deploymentName, validate, enabled));
       return null;
     };
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -18,6 +18,8 @@ package com.netflix.spinnaker.halyard.cli.services.v1;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
+import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
@@ -177,6 +179,36 @@ public interface DaemonService {
   DaemonTask<Halconfig, Void> setAuthnMethodEnabled(
       @Path("deploymentName") String deploymentName,
       @Path("methodName") String methodName,
+      @Query("validate") boolean validate,
+      @Body boolean enabled);
+
+  @PUT("/v1/config/deployments/{deploymentName}/security/authz/groupMembership")
+  DaemonTask<Halconfig, Void> setGroupMembership(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Body GroupMembership membership);
+
+  @GET("/v1/config/deployments/{deploymentName}/security/authz/groupMembership")
+  DaemonTask<Halconfig, Object> getGroupMembership(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate);
+
+  @GET("/v1/config/deployments/{deploymentName}/security/authz/groupMembership/{roleProviderName}/")
+  DaemonTask<Halconfig, Object> getRoleProvider(
+      @Path("deploymentName") String deploymentName,
+      @Path("roleProviderName") String roleProviderName,
+      @Query("validate") boolean validate);
+
+  @PUT("/v1/config/deployments/{deploymentName}/security/authz/groupMembership/{roleProviderName}/")
+  DaemonTask<Halconfig, Void> setRoleProvider(
+      @Path("deploymentName") String deploymentName,
+      @Path("roleProviderName") String roleProviderName,
+      @Query("validate") boolean validate,
+      @Body RoleProvider roleProvider);
+
+  @PUT("/v1/config/deployments/{deploymentName}/security/authz/enabled/")
+  DaemonTask<Halconfig, Void> setAuthzEnabled(
+      @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
       @Body boolean enabled);
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
@@ -16,9 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
-import com.netflix.spinnaker.halyard.config.model.v1.security.Authn;
-import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
-import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
+import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import lombok.Data;
 
 import java.util.ArrayList;
@@ -117,6 +115,20 @@ public class NodeFilter implements Cloneable {
   public NodeFilter setAuthnMethod(String name) {
     matchers.add(Node.thisNodeAcceptor(Authn.class));
     matchers.add(Node.namedNodeAcceptor(AuthnMethod.class, name));
+    return this;
+  }
+
+  public NodeFilter setRoleProvider(String name) {
+    matchers.add(Node.thisNodeAcceptor(Authz.class));
+    matchers.add(Node.thisNodeAcceptor(GroupMembership.class));
+    matchers.add(Node.namedNodeAcceptor(RoleProvider.class, name));
+    return this;
+  }
+
+  public NodeFilter withAnyRoleProvider() {
+    matchers.add(Node.thisNodeAcceptor(Authz.class));
+    matchers.add(Node.thisNodeAcceptor(GroupMembership.class));
+    matchers.add(Node.thisNodeAcceptor(RoleProvider.class));
     return this;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authz.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authz.java
@@ -26,36 +26,24 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
-@EqualsAndHashCode(callSuper = false)
 @Data
-public class Security extends Node {
+@EqualsAndHashCode(callSuper = true)
+public class Authz extends Node {
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
     v.validate(psBuilder, this);
   }
 
   @Getter
-  private String nodeName = "security";
+  private String nodeName = "authz";
 
   @Override
   public NodeIterator getChildren() {
     return NodeIteratorFactory.makeReflectiveIterator(this);
   }
 
-  private String apiAddress = "localhost";
-  private String apiDomain;
-  private String uiAddress = "localhost";
-  private String uiDomain;
+  private GroupMembership groupMembership = new GroupMembership();
+  private boolean enabled;
 
-  private Ssl ssl = new Ssl();
-  private Authn authn = new Authn();
-  private Authz authz = new Authz();
-
-  public String getApiDomain() {
-    return apiDomain != null ? apiDomain : apiAddress;
-  }
-
-  public String getUiDomain() {
-    return apiDomain != null ? apiDomain : apiAddress;
-  }
+  public void setEnabled(boolean _ignored) {}
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/GoogleRoleProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/GoogleRoleProvider.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.security;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class GoogleRoleProvider extends RoleProvider {
+  private final GroupMembership.RoleProviderType roleProviderType = GroupMembership.RoleProviderType.GOOGLE;
+  @Override
+  public String getNodeName() {
+    return "google";
+  }
+
+  @LocalFile
+  private String credentialPath;
+  private String adminUsername;
+  private String domain;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/RoleProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/RoleProvider.java
@@ -24,38 +24,19 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 
 @EqualsAndHashCode(callSuper = false)
 @Data
-public class Security extends Node {
+abstract public class RoleProvider extends Node {
+  abstract public GroupMembership.RoleProviderType getRoleProviderType();
+
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
     v.validate(psBuilder, this);
   }
 
-  @Getter
-  private String nodeName = "security";
-
   @Override
   public NodeIterator getChildren() {
-    return NodeIteratorFactory.makeReflectiveIterator(this);
-  }
-
-  private String apiAddress = "localhost";
-  private String apiDomain;
-  private String uiAddress = "localhost";
-  private String uiDomain;
-
-  private Ssl ssl = new Ssl();
-  private Authn authn = new Authn();
-  private Authz authz = new Authz();
-
-  public String getApiDomain() {
-    return apiDomain != null ? apiDomain : apiAddress;
-  }
-
-  public String getUiDomain() {
-    return apiDomain != null ? apiDomain : apiAddress;
+    return NodeIteratorFactory.makeEmptyIterator();
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/GoogleRoleProviderValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/GoogleRoleProviderValidator.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.validate.v1.security;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.model.v1.security.GoogleRoleProvider;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import org.springframework.stereotype.Component;
+
+@Component
+public class GoogleRoleProviderValidator extends Validator<GoogleRoleProvider> {
+  @Override
+  public void validate(ConfigProblemSetBuilder p, GoogleRoleProvider n) {
+    p.addProblem(Problem.Severity.WARNING, "No validation exists for google role providers yet.");
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/FiatProfile.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/FiatProfile.java
@@ -16,13 +16,32 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.security.Authz;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerEndpoints;
+import lombok.Data;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class FiatProfile extends SpringProfile {
   @Override
   public SpinnakerArtifact getArtifact() {
     return SpinnakerArtifact.FIAT;
+  }
+
+  @Override
+  public ProfileConfig generateFullConfig(ProfileConfig config, DeploymentConfiguration deploymentConfiguration, SpinnakerEndpoints endpoints) {
+    Authz authz = deploymentConfiguration.getSecurity().getAuthz();
+    List<String> files = processRequiredFiles(authz);
+    AuthConfig authConfig = new AuthConfig().setAuth(authz);
+    return config.extendConfig(config.getPrimaryConfigFile(), yamlToString(authConfig)).setRequiredFiles(files);
+  }
+
+  @Data
+  private static class AuthConfig {
+    Authz auth;
   }
 }


### PR DESCRIPTION
Only supports google, and doesn't validate yet. I also need to prevent fiat from being deployed if it's not enabled.