### PR TITLE
feat(halyard) Debian-only install

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -2006,6 +2006,7 @@ Deploy the currently configured instance of Spinnaker to a selected environment.
 hal deploy run [parameters]
 ```
 #### Parameters
+ * `--install-only`: (*Default*: `false`) Download the Spinnaker artifacts without configuring them. This does not work for remote deployments of Spinnaker
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -23,18 +23,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
 import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
 import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
+import com.netflix.spinnaker.halyard.core.RemoteAction;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
-import com.netflix.spinnaker.halyard.deploy.deployment.v1.Deployment;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import lombok.extern.slf4j.Slf4j;
 import retrofit.RestAdapter;
-import retrofit.RetrofitError;
 import retrofit.client.OkClient;
 
 import java.util.List;
-import java.util.Map;
 import java.util.function.Supplier;
 
 @Slf4j
@@ -226,10 +224,10 @@ public class Daemon {
     };
   }
 
-  public static Supplier<Deployment.DeployResult> deployDeployment(String deploymentName, boolean validate) {
+  public static Supplier<RemoteAction> deployDeployment(String deploymentName, boolean validate, boolean installOnly) {
     return () -> {
-      Object rawDeployResult = ResponseUnwrapper.get(getService().deployDeployment(deploymentName, validate, ""));
-      return getObjectMapper().convertValue(rawDeployResult, Deployment.DeployResult.class);
+      Object rawDeployResult = ResponseUnwrapper.get(getService().deployDeployment(deploymentName, validate, installOnly, ""));
+      return getObjectMapper().convertValue(rawDeployResult, RemoteAction.class);
     };
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -64,6 +64,7 @@ public interface DaemonService {
   DaemonTask<Halconfig, Object> deployDeployment(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
+      @Query("installOnly") boolean installOnly,
       @Body String _ignore);
 
   @GET("/v1/config/deployments/{deploymentName}/configDiff/")

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/RemoteAction.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/RemoteAction.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.core;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+
+@Data
+public class RemoteAction {
+  @JsonIgnore
+  private String script;
+  private String scriptPath;
+  private String scriptDescription;
+  private boolean autoRun;
+}

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/BillOfMaterials.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/BillOfMaterials.java
@@ -48,7 +48,13 @@ public class BillOfMaterials {
     Artifact monitoringDaemon;
     Artifact spinnaker;
 
-    public String getArtifactVersion(String artifactName) {
+    @Data
+    static class Artifact {
+      String version;
+      // TODO(lwander) dependencies will go here.
+    }
+
+    String getArtifactVersion(String artifactName) {
       Optional<Field> field = Arrays.stream(Artifacts.class.getDeclaredFields())
           .filter(f -> {
             boolean nameMatches = f.getName().equals(artifactName);
@@ -66,18 +72,16 @@ public class BillOfMaterials {
       }
 
       try {
-        return ((Artifact) field.get().get(this)).getVersion();
+        return ((Artifacts.Artifact) field.get().get(this)).getVersion();
       } catch (IllegalAccessException e) {
         throw new RuntimeException(e);
       } catch (NullPointerException e) {
         throw new RuntimeException("Spinnaker artifact " + artifactName + " is not listed in the BOM");
       }
     }
+  }
 
-    @Data
-    static class Artifact {
-      String version;
-      // TODO(lwander) dependencies will go here.
-    }
+  public String getArtifactVersion(String artifactName) {
+    return services.getArtifactVersion(artifactName);
   }
 }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/WriteableProfileRegistry.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/WriteableProfileRegistry.java
@@ -79,7 +79,7 @@ public class WriteableProfileRegistry {
   }
 
   public void writeArtifactConfig(BillOfMaterials bom, String artifactName, String profileName, String contents) {
-    String version = bom.getServices().getArtifactVersion(artifactName);
+    String version = bom.getArtifactVersion(artifactName);
     String name = ProfileRegistry.profilePath(artifactName, version, profileName);
     writeTextObject(name, contents);
   }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/TemplatedResource.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/TemplatedResource.java
@@ -30,6 +30,11 @@ abstract public class TemplatedResource {
   @Setter
   Map<String, String> bindings = new HashMap<>();
 
+  public TemplatedResource extendBindings(Map<String, String> bindings) {
+    this.bindings.putAll(bindings);
+    return this;
+  }
+
   protected String formatKey(String key) {
     return "{%" + key + "%}";
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployment.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployment.java
@@ -16,13 +16,14 @@
 
 package com.netflix.spinnaker.halyard.deploy.deployment.v1;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment.DeploymentType;
+import com.netflix.spinnaker.halyard.core.RemoteAction;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerEndpoints;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.Setter;
 
 /**
@@ -52,18 +53,10 @@ abstract public class Deployment {
    * Deploy a fresh install of Spinnaker. This will fail if Spinnaker is already
    * running.
    */
-  abstract public DeployResult deploy(String spinnakerOutputPath);
+  abstract public RemoteAction deploy(String spinnakerOutputPath);
 
-  @Data
-  public static class DeployResult {
-    @JsonIgnore
-    String postInstallScript;
-    @JsonIgnore
-    String connectScript;
-    String scriptDescription;
-    String postInstallScriptPath;
-    String connectScriptPath;
-
-    String postInstallMessage;
-  }
+  /**
+   * Install Spinnaker w/o config. This generally only work on local deployments.
+   */
+  abstract public RemoteAction install(String spinnakerOutputPath);
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentDetails.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentDetails.java
@@ -17,7 +17,7 @@
 package com.netflix.spinnaker.halyard.deploy.deployment.v1;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService.GenerateResult;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerEndpoints;
 import lombok.Data;
@@ -27,6 +27,7 @@ public class DeploymentDetails {
   String deploymentName;
   DeploymentConfiguration deploymentConfiguration;
   GenerateResult generateResult;
+  BillOfMaterials billOfMaterials;
 
   public SpinnakerEndpoints getEndpoints() {
     return generateResult.getEndpoints();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentFactory.java
@@ -21,13 +21,14 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguratio
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment.DeploymentType;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
-import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.kubernetes.KubernetesFlotillaDeployment;
 import com.netflix.spinnaker.halyard.deploy.provider.v1.kubernetes.KubernetesProviderInterface;
+import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService.GenerateResult;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,9 @@ public class DeploymentFactory {
   AccountService accountService;
 
   @Autowired
+  ArtifactService artifactService;
+
+  @Autowired
   KubernetesProviderInterface kubernetesProviderInterface;
 
   @Value("${spinnaker.artifacts.debian:https://dl.bintray.com/spinnaker-team/spinnakerbuild}")
@@ -52,9 +56,11 @@ public class DeploymentFactory {
 
   public Deployment create(DeploymentConfiguration deploymentConfiguration, GenerateResult generateResult) {
     DeploymentType type = deploymentConfiguration.getDeploymentEnvironment().getType();
+    String deploymentName = deploymentConfiguration.getName();
     DeploymentDetails deploymentDetails = new DeploymentDetails()
         .setGenerateResult(generateResult)
-        .setDeploymentName(deploymentConfiguration.getName())
+        .setDeploymentName(deploymentName)
+        .setBillOfMaterials(artifactService.getBillOfMaterials(deploymentName))
         .setDeploymentConfiguration(deploymentConfiguration);
 
     switch (type) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/provider/v1/kubernetes/KubernetesProviderInterface.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/provider/v1/kubernetes/KubernetesProviderInterface.java
@@ -122,7 +122,7 @@ public class KubernetesProviderInterface extends ProviderInterface<KubernetesAcc
       case REDIS:
         return "gcr.io/kubernetes-spinnaker/redis-cluster:v2";
       default:
-        String version = details.getGenerateResult().getArtifactVersions().get(artifact);
+        String version = details.getBillOfMaterials().getArtifactVersion(artifact.getName());
 
         KubernetesImageDescription image = new KubernetesImageDescription(artifact.getName(), version, REGISTRY);
         return KubernetesUtil.getImageId(image);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/ArtifactService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/ArtifactService.java
@@ -61,7 +61,7 @@ public class ArtifactService {
   }
 
   public String getArtifactVersion(String deploymentName, SpinnakerArtifact artifact) {
-    return getBillOfMaterials(deploymentName).getServices().getArtifactVersion(artifact.getName());
+    return getBillOfMaterials(deploymentName).getArtifactVersion(artifact.getName());
   }
 
   public void writeBom(String bomPath) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.config.services.v1.DeploymentService;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
+import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.deploy.config.v1.ConfigParser;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.EndpointFactory;
@@ -68,6 +69,9 @@ public class GenerateService {
   @Autowired
   private ConfigParser configParser;
 
+  @Autowired
+  private ArtifactService artifactService;
+
   /**
    * Generate config for a given deployment.
    *
@@ -104,7 +108,6 @@ public class GenerateService {
     // Step 2.
     DaemonTaskHandler.newStage("Generating all Spinnaker profile files");
     Map<String, Set<String>> profileRequirements = new HashMap<>();
-    Map<SpinnakerArtifact, String> artifactVersions = new HashMap<>();
     FileSystem defaultFileSystem = FileSystems.getDefault();
     Path path;
     for (SpinnakerProfile profile : spinnakerProfiles) {
@@ -122,8 +125,6 @@ public class GenerateService {
 
       Set<String> currentRequirements = profileRequirements.getOrDefault(artifactName, new HashSet<>());
       currentRequirements.addAll(config.getRequiredFiles());
-      profileRequirements.put(artifactName, currentRequirements);
-      artifactVersions.put(profile.getArtifact(), config.getVersion());
     }
 
     // Step 3.
@@ -150,7 +151,6 @@ public class GenerateService {
 
     // Step 4.
     GenerateResult result = new GenerateResult()
-        .setArtifactVersions(artifactVersions)
         .setProfileRequirements(profileRequirements)
         .setEndpoints(endpoints);
 
@@ -160,11 +160,6 @@ public class GenerateService {
   @Data
   public static class GenerateResult {
     private Map<String, Set<String>> profileRequirements = new HashMap<>();
-    private Map<SpinnakerArtifact, String> artifactVersions = new HashMap<>();
     SpinnakerEndpoints endpoints;
-
-    public String getArtifactVersion(SpinnakerArtifact artifact) {
-      return artifactVersions.get(artifact);
-    }
   }
 }


### PR DESCRIPTION
@ttomsu This will let you install all the spinnaker components without configuring them, for the purpose of baking images. You just need to run

`sudo hal deploy run --no-validate --install-only`

after picking a valid version.