### PR TITLE
feat(deploy): Configure vault secret storage

### DIFF
--- a/InstallHalyard.sh
+++ b/InstallHalyard.sh
@@ -3,11 +3,13 @@
 # This script installs Halyard.
 # See http://www.spinnaker.io/docs/creating-a-spinnaker-instance
 
-
 set -e
 set -o pipefail
 
 REPOSITORY_URL="https://dl.bintray.com/spinnaker-team/spinnakerbuild"
+
+VAULT_VERSION=0.7.0
+VAULT_ARCH=linux_amd64
 
 # We can only currently support limited releases
 # First guess what sort of operating system
@@ -258,11 +260,20 @@ if [ -n "$DOWNLOAD"]; then
   add_apt_repositories
 fi
 
-TEMPDIR=$(mktemp -d installhalyard.XXXX)
-
 echo "$(tput bold)Installing Java 8...$(tput sgr0)"
 
 install_java
+
+apt-get install -y unzip
+
+TEMPDIR=$(mktemp -d installhalyard.XXXX)
+
+mkdir $TEMPDIR/vault && pushd $TEMPDIR/vault
+wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${VAULT_ARCH}.zip
+unzip -u -o -q vault_${VAULT_VERSION}_${VAULT_ARCH}.zip -d /usr/bin
+popd
+
+rm -rf $TEMPDIR
 
 if [ -n "$DEPENDENCIES_ONLY" ]; then
   exit 0
@@ -289,8 +300,6 @@ fi
 
 configure_halyard_defaults
 configure_bash_completion
-
-rm -rf $TEMPDIR
 
 start halyard
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -51,6 +51,20 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
   )
   private DeploymentType type;
 
+  @Parameter(
+      names = "--consul-address",
+      description = "The address of a running Consul cluster. See https://www.consul.io/.\n"
+          + "This is only required when Spinnaker is being deployed in non-Kubernetes clustered configuration."
+  )
+  private String consulAddress;
+
+  @Parameter(
+      names = "--vault-address",
+      description = "The address of a running Vault datastore. See https://www.vaultproject.io/."
+          + "This is only required when Spinnaker is being deployed in non-Kubernetes clustered configuration."
+  )
+  private String vaultAddress;
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -64,6 +78,8 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
 
     deploymentEnvironment.setAccountName(isSet(accountName) ? accountName : deploymentEnvironment.getAccountName());
     deploymentEnvironment.setType(type != null ? type : deploymentEnvironment.getType());
+    deploymentEnvironment.setConsulAddress(isSet(consulAddress) ? consulAddress : deploymentEnvironment.getConsulAddress());
+    deploymentEnvironment.setVaultAddress(isSet(vaultAddress) ? vaultAddress : deploymentEnvironment.getVaultAddress());
 
     if (originalHash == deploymentEnvironment.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -90,4 +90,6 @@ public class DeploymentEnvironment extends Node {
   private Size size = Size.LARGE;
   private DeploymentType type = DeploymentType.LocalhostDebian;
   private String accountName;
+  private String vaultAddress;
+  private String consulAddress;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
@@ -78,9 +78,7 @@ public class DeployService {
 
   public RemoteAction installSpinnaker(String deploymentName) {
     DeploymentConfiguration deploymentConfiguration = deploymentService.getDeploymentConfiguration(deploymentName);
-
     Deployment deployment = deploymentFactory.create(deploymentConfiguration, null);
-
     RemoteAction result = deployment.install(spinnakerOutputPath);
 
     String script = result.getScript();

--- a/services/vault/config/vault.hcl
+++ b/services/vault/config/vault.hcl
@@ -1,0 +1,8 @@
+listener "tcp" {
+    address     = "0.0.0.0:8200"
+    tls_disable = 1
+}
+
+storage "file" {
+    path = "/var/vault/storage"
+}

--- a/services/vault/install/install.sh
+++ b/services/vault/install/install.sh
@@ -1,0 +1,37 @@
+#! /bin/bash
+
+VAULT_VERSION=0.7.0
+VAULT_ARCH=linux_amd64
+
+apt-get update
+apt-get install unzip -y
+
+# Download & unzip specified vault binary
+wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${VAULT_ARCH}.zip
+unzip -u -o -q vault_${VAULT_VERSION}_${VAULT_ARCH}.zip -d /usr/bin
+
+rm vault_${VAULT_VERSION}_${VAULT_ARCH}.zip
+
+mv vault /usr/bin
+
+# Create directory for running vault
+
+mkdir -p /etc/vault.d/
+mkdir -p /var/vault
+
+adduser vault
+
+# Setup config
+
+cp -r config/vault.hcl /etc/vault.d/vault.hcl
+
+# Enable mlock
+
+setcap cap_ipc_lock=+ep $(readlink -f $(which vault))
+
+# Setup upstart
+
+cp upstart/vault.conf /etc/init/
+
+chown -R vault:vault /var/vault
+chown -R vault:vault /etc/vault.d

--- a/services/vault/policies/halyard.hcl
+++ b/services/vault/policies/halyard.hcl
@@ -1,0 +1,3 @@
+path "secret/spinnaker/*" {
+    policy = "sudo"
+}

--- a/services/vault/policies/spinnaker.hcl
+++ b/services/vault/policies/spinnaker.hcl
@@ -1,0 +1,3 @@
+path "secret/spinnaker/*" {
+    policy = "read"
+}

--- a/services/vault/startup/read-config.py
+++ b/services/vault/startup/read-config.py
@@ -1,0 +1,71 @@
+#!/bin/python
+
+import subprocess
+import json
+import logging
+import base64
+import argparse
+import sys
+
+def read_secret(address, name):
+    try:
+        secret_data = json.loads(subprocess.check_output(["vault", "read", 
+            "-address", address, 
+            "-format", "json",
+            "secret/spinnaker/{}".format(name)])
+        )
+    except Error as err:
+        log.critical("Failed to load secret {name}: {err}".format(
+            name=name,
+            err=err)
+        )
+        sys.exit(1)
+
+    logging.info("Retrieved secret {name} with request_id {rid}".format(
+        name=name,
+        rid=secret_data["request_id"])
+    )
+
+    warning = secret_data.get("warnings", None)
+
+    if not warning is None:
+        logging.warning("Warning: {}".format(warning))
+
+    return secret_data["data"]
+
+def main():
+    parser = argparse.ArgumentParser(
+            description="Download secrets for Spinnaker stored by Halyard"
+    )
+
+    parser.add_argument("--address", 
+            type=str, 
+            help="Vault server's address.",
+            required=True
+    )
+
+    parser.add_argument("--secret", 
+            type=str, 
+            help="The secret name this instance config can be found in.",
+            required=True
+    )
+
+    args = parser.parse_args()
+
+    config_mount = read_secret(args.address, args.secret)
+
+    for config in config_mount["configs"]:
+        secret_id = "{secret}/{name}".format(secret=args.secret, name=config)
+        mount = read_secret(args.address, secret_id)
+
+        file_name = mount["file"]
+        contents = base64.b64decode(mount["contents"])
+        with open(file_name, "w") as f:
+            logging.info("Writing config to {}".format(file_name))
+
+            f.write(contents)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/services/vault/upstart/vault.conf
+++ b/services/vault/upstart/vault.conf
@@ -1,0 +1,11 @@
+description "Vault server"
+
+start on (local-filesystems and net-device-up IFACE=eth0)
+stop on runlevel [!12345]
+
+respawn
+
+setuid vault
+setgid vault
+
+exec vault server -config /etc/vault.d/vault.hcl 


### PR DESCRIPTION
This does the following:

1. Install the vault binary alongside Halyard.
2. Provides instances a startupscript to pull config into their filesystem.
3. Provides a sample vault + policy setup.