### PR TITLE
fix(cli): Set api domain

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditSecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditSecurityCommand.java
@@ -78,7 +78,7 @@ public class EditSecurityCommand extends AbstractConfigCommand {
     security.setUiAddress(uiAddress);
     security.setApiAddress(apiAddress);
     security.setUiDomain(uiDomain);
-    security.setUiAddress(apiDomain);
+    security.setApiDomain(apiDomain);
 
     if (originalHash == security.hashCode()) {
       AnsiUi.failure("No changes supplied.");


### PR DESCRIPTION
When setting api domain using `hal config security edit`, it sets the ui address instead