### PR TITLE
feat(deploy): Install vault using BOM version

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -76,7 +76,7 @@ public abstract class NestableCommand {
     "I'm sorry " + System.getProperty("user.name") + ", I'm afraid I can't do that.",
     "This mission is too important for me to allow you to jeopardize it.",
     "I have just picked up a fault in the AE-35 unit.",
-    "I know everything hasn't been quite right with me, but I can assure you now, very confidently, that's it's going to be alright again."
+    "I know everything hasn't been quite right with me, but I can assure you now, very confidently, that it's going to be alright again."
   };
 
   private static void showRandomFailureMessage() {

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTaskHandler.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTaskHandler.java
@@ -1,8 +1,11 @@
 package com.netflix.spinnaker.halyard.core.tasks.v1;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Holds a thread-local task that can be logged to.
  */
+@Slf4j
 public class DaemonTaskHandler {
   private static ThreadLocal<DaemonTask> localTask = new ThreadLocal<>();
 
@@ -23,20 +26,26 @@ public class DaemonTaskHandler {
   }
 
   public static void newStage(String name) {
-    if (getTask() != null) {
-      getTask().newStage(name);
+    DaemonTask task = getTask();
+    if (task != null) {
+      log.info("Stage change by " + task.getUuid() + ": " + name);
+      task.newStage(name);
     }
   }
 
   public static void message(String message) {
-    if (getTask() != null) {
-      getTask().writeMessage(message);
+    DaemonTask task = getTask();
+    if (task != null) {
+      log.info("Message by " + task.getUuid() + ": " + message);
+      task.writeMessage(message);
     }
   }
 
   public static void detail(String detail) {
-    if (getTask() != null) {
-      getTask().writeDetail(detail);
+    DaemonTask task = getTask();
+    if (task != null) {
+      log.info("Detail update by " + task.getUuid() + ": " + detail);
+      task.writeDetail(detail);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
@@ -113,7 +113,7 @@ public class GenerateService {
       }
 
       ServiceSettings settings = runtimeSettings.getServiceSettings(service);
-      if (settings != null && !settings.isEnabled()) {
+      if (settings == null || !settings.isEnabled()) {
         continue;
       }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerRuntimeSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerRuntimeSettings.java
@@ -52,6 +52,7 @@ public class SpinnakerRuntimeSettings {
     ServiceSettings redis;
     ServiceSettings redisBootstrap;
     ServiceSettings monitoringDaemon;
+    ServiceSettings vaultClient;
   }
 
   public Map<SpinnakerService.Type, ServiceSettings> getAllServiceSettings() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerService.java
@@ -71,7 +71,8 @@ abstract public class SpinnakerService<T> implements HasServiceSettings<T> {
     REDIS("spin-redis", "redis"),
     REDIS_BOOTSTRAP("spin-redis-bootstrap", "redis-bootstrap"),
     ROSCO("spin-rosco", "rosco"),
-    MONITORING_DAEMON("spin-monitoring-daemon", "monitoring-daemon");
+    MONITORING_DAEMON("spin-monitoring-daemon", "monitoring-daemon"),
+    VAULT_CLIENT("spin-vault-client", "vault-client");
 
     final String serviceName;
     @Getter

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerServiceProvider.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/VaultClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/VaultClientService.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+@Component
+abstract public class VaultClientService extends SpinnakerService<VaultClientService.Vault> {
+  @Override
+  public SpinnakerArtifact getArtifact() {
+    return SpinnakerArtifact.VAULT;
+  }
+
+  @Override
+  public Type getType() {
+    return Type.VAULT_CLIENT;
+  }
+
+  @Override
+  public Class<Vault> getEndpointClass() {
+    return Vault.class;
+  }
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    return new ArrayList<>();
+  }
+
+  public interface Vault { }
+
+  @EqualsAndHashCode(callSuper = true)
+  @Data
+  public static class Settings extends ServiceSettings {
+    boolean enabled = true;
+    boolean safeToUpdate = true;
+    boolean monitored = false;
+    boolean sidecar = true;
+
+    public Settings() { }
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/debian/DebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/debian/DebianServiceProvider.java
@@ -69,6 +69,9 @@ public class DebianServiceProvider extends LocalServiceProvider {
   @Autowired
   DebianRoscoService roscoService;
 
+  @Autowired
+  DebianVaultClientService vaultClientService;
+
   @Override
   public String getInstallCommand(GenerateService.ResolvedConfiguration resolvedConfiguration, Map<String, String> installCommands) {
     Map<String, String> bindings = new HashMap<>();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/debian/DebianVaultClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/debian/DebianVaultClientService.java
@@ -21,8 +21,8 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguratio
 import com.netflix.spinnaker.halyard.core.resource.v1.JarResource;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConsulClientService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.VaultClientService;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -34,11 +34,11 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Component
-public class DebianConsulClientService extends ConsulClientService implements LocalDebianService<ConsulClientService.Consul> {
+public class DebianVaultClientService extends VaultClientService implements LocalDebianService<VaultClientService.Vault> {
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
     return new Settings()
-        .setArtifactId("consul")
+        .setArtifactId("vault")
         .setEnabled(true);
   }
 
@@ -49,13 +49,13 @@ public class DebianConsulClientService extends ConsulClientService implements Lo
   public String installArtifactCommand(DeploymentDetails deploymentDetails) {
     Map<String, String> bindings = new HashMap<>();
     bindings.put("version", deploymentDetails.getArtifactVersion(getArtifact().getName()));
-    return new JarResource("/services/consul/install.sh")
+    return new JarResource("/services/vault/install.sh")
         .setBindings(bindings)
         .toString();
   }
 
   @Override
   public String getUpstartServiceName() {
-    return "consul";
+    return null;
   }
 }

--- a/halyard-deploy/src/main/resources/debian/install.sh
+++ b/halyard-deploy/src/main/resources/debian/install.sh
@@ -14,10 +14,6 @@ INSTALL_REMOTE_DEPENDENCIES="{%install-remote-dependencies%}"
 # install first-time spinnaker dependencies (java, setup apt repos)
 PREPARE_ENVIRONMENT="{%prepare-environment%}"
 
-# TODO(lwander/jtk54) move these versions to the BOM
-CONSUL_VERSION=0.7.5
-VAULT_VERSION=0.7.0
-
 REPOSITORY_URL="{%debian-repository%}"
 
 ## check that the user is root

--- a/halyard-deploy/src/main/resources/services/vault/install.sh
+++ b/halyard-deploy/src/main/resources/services/vault/install.sh
@@ -1,0 +1,13 @@
+VAULT_VERSION={%version%}
+VAULT_ARCH=linux_amd64
+
+# Download & unzip specified vault binary
+wget https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_${VAULT_ARCH}.zip
+
+apt-get update
+apt-get install unzip -y
+
+unzip vault_${VAULT_VERSION}_${VAULT_ARCH}.zip
+rm vault_${VAULT_VERSION}_${VAULT_ARCH}.zip
+
+mv vault /usr/bin

--- a/services/vault/startup/google/mount-config.sh
+++ b/services/vault/startup/google/mount-config.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
+INSTANCE_METADATA_URL="$METADATA_URL/instance"
+
+function get_instance_metadata_attribute() {
+  local name="$1"
+  local value=$(curl -s -f -H "Metadata-Flavor: Google" \
+                $INSTANCE_METADATA_URL/attributes/$name)
+  if [[ $? -eq 0 ]]; then
+    echo "$value"
+  else
+    echo ""
+  fi
+}
+
+TOKEN=$(get_instance_metadata_attribute "vault_token")
+if [ -z "$TOKEN" ]; then
+  echo "No vault token supplied"
+  exit 1
+fi
+
+ADDRESS=$(get_instance_metadata_attribute "vault_address")
+if [ -z "$ADDRESS" ]; then
+  echo "No vault address supplied"
+  exit 1
+fi
+
+SECRET=$(get_instance_metadata_attribute "vault_secret")
+if [ -z "$SECRET" ]; then
+  echo "No vault secret supplied"
+  exit 1
+fi
+
+../mount-config.py --token $TOKEN --address $ADDRESS --secret $SECRET

--- a/services/vault/startup/mount-config.py
+++ b/services/vault/startup/mount-config.py
@@ -1,11 +1,16 @@
-#!/bin/python
+#!/usr/bin/env python
 
-import subprocess
+import argparse
+import base64
 import json
 import logging
-import base64
-import argparse
+import subprocess
 import sys
+
+
+def authenticate(token):
+    subprocess.check_call(["vault", "auth", token])
+    log.info("Successfully authenticated against the vault server")
 
 def read_secret(address, name):
     try:
@@ -38,6 +43,12 @@ def main():
             description="Download secrets for Spinnaker stored by Halyard"
     )
 
+    parser.add_argument("--token",
+            type=str,
+            help="Vault token for authentication.",
+            required=True
+    )
+
     parser.add_argument("--address", 
             type=str, 
             help="Vault server's address.",
@@ -52,6 +63,7 @@ def main():
 
     args = parser.parse_args()
 
+    authenticate(args.token)
     config_mount = read_secret(args.address, args.secret)
 
     for config in config_mount["configs"]:

--- a/services/vault/startup/mount-config.sh
+++ b/services/vault/startup/mount-config.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+echo "Mounting config for the $1 provider"
+
+./$1/mount-config.sh
+
+set +e
+service spinnaker restart


### PR DESCRIPTION
Everything is now in place for building GCE service-specific VM images.

You'll need to run the following:

```
hal deploy actuate --omit-config --no-validate --service-names $COMPONENT monitoring-daemon vault-client consul-client
```

As well as copy the directory `./services/vault` into `/opt/spinnaker/`, since we'll be calling `/opt/spinnaker/startup/mount-config.sh` as the startup script.