### PR TITLE
feat(deploy): Always scale down distributed services on deploy

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -54,7 +54,7 @@ abstract public class ServiceSettings {
   boolean monitored;
   boolean sidecar;
   boolean safeToUpdate;
-  int targetSize;
+  int targetSize = 1;
 
   public ServiceSettings() {}
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/kubernetes/KubernetesDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/kubernetes/KubernetesDistributedService.java
@@ -96,15 +96,15 @@ public interface KubernetesDistributedService<T> extends DistributedService<T, K
   }
 
   @Override
-  default Map<String, Object> buildRollbackPipeline(AccountDeploymentDetails<KubernetesAccount> details) {
-    Map<String, Object> pipeline = DistributedService.super.buildRollbackPipeline(details);
+  default Map<String, Object> buildRollbackPipeline(AccountDeploymentDetails<KubernetesAccount> details, ServiceSettings settings) {
+    Map<String, Object> pipeline = DistributedService.super.buildRollbackPipeline(details, settings);
 
     List<Map<String, Object>> stages = (List<Map<String, Object>>) pipeline.get("stages");
     assert(stages != null && !stages.isEmpty());
 
     for (Map<String, Object> stage : stages) {
       stage.put("namespaces", Collections.singletonList(getNamespace()));
-      stage.put("interestingHealthProviders", Collections.singletonList("KubernetesService"));
+      stage.put("interestingHealthProviderNames", Collections.singletonList("KubernetesService"));
       stage.remove("region");
     }
 


### PR DESCRIPTION
This morning @skim1420 suggested scaling down each subcomponent during a red/black to save on resources. It makes sense & reduces update complexity significantly.