### PR TITLE
fix(deploy): Propagate error from parallel child task

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
@@ -38,10 +38,7 @@ public class DaemonResponse<T> {
   private T responseBody;
 
   @Getter
-  private ProblemSet problemSet;
-
-  @Getter
-  private String jobUuid;
+  private final ProblemSet problemSet;
 
   public DaemonResponse(T responseBody, ProblemSet problemSet) {
     this.responseBody = responseBody;

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/ProblemSet.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/ProblemSet.java
@@ -20,10 +20,7 @@ package com.netflix.spinnaker.halyard.core.problem.v1;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import lombok.Getter;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 /**
  * ProblemSet represents all problems collected when validating the currently loaded/modified halconfig.
@@ -60,6 +57,14 @@ public class ProblemSet {
     this.problems = problems;
   }
 
+  public ProblemSet(ProblemSet other) {
+    addAll(other);
+  }
+
+  public ProblemSet(Problem problem) {
+    add(problem);
+  }
+
   public ProblemSet() { }
 
 
@@ -83,7 +88,7 @@ public class ProblemSet {
    * This is can be used to ignore errors that user deems frivolous.
    *
    * Example: A client's Jenkins instance isn't connecting to Halyard, but they are sure it will connect to Igor, so they
-   * can force halyard to only generate an error if the severity exceeds "FAProblemAL" (which is impossible).
+   * can force halyard to only generate an error if the severity exceeds "FATAL" (which is impossible).
    *
    * @param severity is the severity to compare all errors to that this problem set stores.
    */

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
@@ -88,6 +88,7 @@ public class DaemonTask<C, T> {
     }
 
     log.info("Collected child task " + childTask + " with state " + childTask.getState());
+    assert(childTask.getResponse() != null);
 
     return childTask.getResponse();
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.deploy.deployment.v1;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.RemoteAction;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService.ResolvedConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
@@ -109,7 +110,8 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
     }
 
     DaemonTaskHandler.message("Waiting on red/black pipelines to complete");
-    DaemonTaskHandler.reduceChildren(null, (t1, t2) -> null, (t1, t2) -> null);
+    DaemonTaskHandler.reduceChildren(null, (t1, t2) -> null, (t1, t2) -> null)
+        .getProblemSet().throwifSeverityExceeds(Problem.Severity.WARNING);
 
     reapOrcaServerGroups(deploymentDetails, runtimeSettings, serviceProvider.getDeployableService(SpinnakerService.Type.ORCA));
 


### PR DESCRIPTION
Errors were only being set when task status was retrieved, not when the task completed. Also, the call to  `reduceChildren` was ignored in the parallel deploy.