### PR TITLE
fix(cli): Options were including task output

### DIFF
--- a/halyard-cli/src/main/resources/hal-completor-body
+++ b/halyard-cli/src/main/resources/hal-completor-body
@@ -16,7 +16,7 @@ _hal() {
             sublen=$(($COMP_CWORD - 2))
         fi
 
-        options=$( ${COMP_WORDS[@]:0:$sublen} --options $prev --color false )
+        options=$( ${COMP_WORDS[@]:0:$sublen} --options $prev --color false --quiet )
 
         if [ "$?" = "0" ]; then
             COMPREPLY=( $(compgen -W "${options}" -- ${cur}) )


### PR DESCRIPTION
The child task PR increased task log output that should have been silenced when retrieving field options.