### PR TITLE
feat(bake): Bake top-level startupscript into VM images

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/BakeService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/BakeService.java
@@ -31,6 +31,7 @@ public interface BakeService<T> extends HasServiceSettings<T> {
   String getSpinnakerStagingPath();
   String installArtifactCommand(DeploymentDetails deploymentDetails);
   StartupPriority getPriority();
+  String getStartupCommand();
 
   default String stageStartupScripts(GenerateService.ResolvedConfiguration resolvedConfiguration) {
     Map<String, Profile> profiles = resolvedConfiguration.getProfilesForService(getService().getType());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/BakeServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/BakeServiceProvider.java
@@ -50,13 +50,16 @@ abstract public class BakeServiceProvider extends SpinnakerServiceProvider {
   }
 
   // TODO(lwander) move from string to something like RemoteAction
-  abstract public String getInstallCommand(GenerateService.ResolvedConfiguration resolvedConfiguration, Map<String, String> installCommands);
+  abstract public String getInstallCommand(GenerateService.ResolvedConfiguration resolvedConfiguration, Map<String, String> installCommands, String startupCommand);
 
-  public List<BakeService> getBakeableServices(List<String> serviceNames) {
-    return getFieldsOfType(BakeService.class)
+  public List<BakeService> getPrioritizedBakeableServices(List<String> serviceNames) {
+    List<BakeService> result = getFieldsOfType(BakeService.class)
         .stream()
         .filter(s -> serviceNames.contains(s.getService().getCanonicalName()))
         .collect(Collectors.toList());
+
+    result.sort((a, b) -> b.getPriority().compareTo(a.getPriority()));
+    return result;
   }
 }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianService.java
@@ -32,6 +32,15 @@ public interface BakeDebianService<T> extends BakeService<T> {
   ArtifactService getArtifactService();
   String getUpstartServiceName();
 
+  @Override
+  default String getStartupCommand() {
+    if (getUpstartServiceName() != null) {
+      return "service " + getUpstartServiceName() + " start";
+    }
+
+    return null;
+  }
+
   default String getArtifactId(String deploymentName) {
     SpinnakerArtifact artifact = getArtifact();
     String version = getArtifactService().getArtifactVersion(deploymentName, artifact);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianVaultClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianVaultClientService.java
@@ -70,6 +70,11 @@ public class BakeDebianVaultClientService extends VaultClientService implements 
   }
 
   @Override
+  public String getStartupCommand() {
+    return Paths.get(startupScriptPath, "startup-vault.sh").toString() + " $@";
+  }
+
+  @Override
   public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     List<Profile> result = new ArrayList<>();
     String name = "mount-config.py";

--- a/halyard-deploy/src/main/resources/debian/pre-bake.sh
+++ b/halyard-deploy/src/main/resources/debian/pre-bake.sh
@@ -102,4 +102,12 @@ if [ -z "$(getent passwd spinnaker)" ]; then
   useradd --gid spinnaker -m --home-dir $homebase/spinnaker spinnaker
 fi
 
+cat > {%startup-file%} <<EOL
+#!/usr/bin/env bash
+
+{%startup-command%}
+EOL
+
+chmod +x {%startup-file%}
+
 {%install-commands%}


### PR DESCRIPTION
This ensures services are started in order of priority (e.g. vault, then consul, then component). No changes needed on your part @jtk54 