### PR TITLE
chore(autocomplete): Adds small Make task for non-installed autocomplete

### DIFF
--- a/halyard-cli/.gitignore
+++ b/halyard-cli/.gitignore
@@ -1,0 +1,1 @@
+complete

--- a/halyard-cli/Makefile
+++ b/halyard-cli/Makefile
@@ -2,5 +2,9 @@ all:
 	../gradlew installDist
 	./hal --docs > ../docs/commands.md
 
+complete:
+	./hal --print-bash-completion > complete
+	@echo 'Run this: source complete && PATH=$$PATH:`pwd`'
+
 clean:
 	../gradlew clean


### PR DESCRIPTION
@lwander  - You were right that you can't modify the parent shell from within Make, so I just printed a command the user can copy/paste to enable autocomplete during development.