### PR TITLE
feat(cli): Add -o for output formatting

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -206,6 +206,7 @@ hal [parameters] [subcommands]
  * `-d, --debug`: Show detailed network traffic with halyard daemon.
  * `-h, --help`: (*Default*: `false`) Display help text about this command.
  * `-l, --log`: Set the log level of the CLI.
+ * `-o, --output`: Format the CLIs output.
  * `-q, --quiet`: Show no task information or messages.
 #### Parameters
  * `--docs`: (*Default*: `false`) Print markdown docs for the hal CLI.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import lombok.Data;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,8 @@ public class GlobalOptions {
   private String options;
 
   private Level log;
+
+  private AnsiFormatUtils.Format output;
 
   private static GlobalOptions globalOptions = null;
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterDescription;
 import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.FormatConverter;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LogLevelConverter;
 import com.netflix.spinnaker.halyard.cli.services.v1.ExpectedDaemonFailureException;
 import com.netflix.spinnaker.halyard.cli.ui.v1.*;
@@ -45,6 +46,11 @@ public abstract class NestableCommand {
 
   @Parameter(names = { "-h", "--help" }, help = true, description = "Display help text about this command.")
   private boolean help;
+
+  @Parameter(names = { "-o", "--output" }, converter = FormatConverter.class, help = true, description = "Format the CLIs output.")
+  public void setOutput(AnsiFormatUtils.Format output) {
+    GlobalOptions.getGlobalOptions().setOutput(output);
+  }
 
   @Parameter(names = { "--options" }, help = true, description = "Get options for the specified field name.")
   private String options;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
@@ -45,6 +45,7 @@ public class DeploymentEnvironmentCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to get your deployment environment.")
         .setSuccessMessage("Retrieved configured deployment environment.")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setOperation(Daemon.getDeploymentEnvironment(currentDeployment, !noValidate))
         .get();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/FeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/FeaturesCommand.java
@@ -43,6 +43,7 @@ public class FeaturesCommand extends AbstractConfigCommand {
     new OperationHandler<Features>()
         .setOperation(Daemon.getFeatures(currentDeployment, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setSuccessMessage("Configured features: ")
         .setFailureMesssage("Failed to load features.")
         .get();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/MetricStoresCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/MetricStoresCommand.java
@@ -54,6 +54,7 @@ public class MetricStoresCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to configure metric stores.")
         .setSuccessMessage("Configured metric stores: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
@@ -52,6 +52,7 @@ public class PersistentStorageCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to load persistent storage.")
         .setSuccessMessage("Configured persistent storage: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
@@ -53,6 +53,7 @@ public class SecurityCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to load security settings.")
         .setSuccessMessage("Configured security settings: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/VersionConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/VersionConfigCommand.java
@@ -43,6 +43,7 @@ public class VersionConfigCommand extends AbstractConfigCommand {
         .setOperation(Daemon.getVersion(currentDeployment, !noValidate))
         .setFailureMesssage("Failed to load version of Spinnaker.")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractNamedCiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractNamedCiCommand.java
@@ -56,6 +56,7 @@ public abstract class AbstractNamedCiCommand extends AbstractCiCommand {
     new OperationHandler<Ci>()
         .setOperation(Daemon.getCi(currentDeployment, ciName, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setSuccessMessage("Configured " + ciName + " ci: ")
         .setFailureMesssage("Failed to load ci " + ciName + ".")
         .get();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractGetMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractGetMasterCommand.java
@@ -42,6 +42,7 @@ abstract class AbstractGetMasterCommand extends AbstractHasMasterCommand {
         .setOperation(Daemon.getMaster(currentDeployment, ciName, masterName, !noValidate))
         .setFailureMesssage("Failed to get " + masterName + " under " + ciName + ".")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/MetricStoreCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/MetricStoreCommand.java
@@ -59,6 +59,7 @@ abstract public class MetricStoreCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to get " + metricStoreType + " method.")
         .setSuccessMessage("Configured " + metricStoreType + " method: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/AbstractNamedPersistentStoreCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/AbstractNamedPersistentStoreCommand.java
@@ -41,6 +41,7 @@ public abstract class AbstractNamedPersistentStoreCommand extends AbstractPersis
         .setSuccessMessage("Successfully got persistent store \"" + persistentStoreType + "\".")
         .setOperation(Daemon.getPersistentStore(currentDeployment, persistentStoreType, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractNamedProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractNamedProviderCommand.java
@@ -62,6 +62,7 @@ public abstract class AbstractNamedProviderCommand extends AbstractProviderComma
         .setFailureMesssage("Failed to get provider " + providerName + ".")
         .setSuccessMessage("Successfully got provider " + providerName + ".")
         .setFormat(STRING)
+        .setUserFormatted(true)
         .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
         .get();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
@@ -44,6 +44,9 @@ abstract class AbstractGetAccountCommand extends AbstractHasAccountCommand {
     String providerName = getProviderName();
     return new OperationHandler<Account>()
         .setFailureMesssage("Failed to get account " + accountName + " for provider " + providerName + ".")
+        .setSuccessMessage("Account " + accountName + ": ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setOperation(Daemon.getAccount(currentDeployment, providerName, accountName, false))
         .get();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractGetBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractGetBaseImageCommand.java
@@ -42,6 +42,7 @@ abstract class AbstractGetBaseImageCommand extends AbstractHasBaseImageCommand {
         .setFailureMesssage("Failed to get base image " + baseImageId + " in" + providerName + "'s bakery.")
         .setSuccessMessage("Settings for " + baseImageId + " in" + providerName + "'s bakery:")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setOperation(Daemon.getBaseImage(currentDeployment, providerName, baseImageId, false))
         .get();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/ApiSecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/ApiSecurityCommand.java
@@ -48,6 +48,7 @@ public class ApiSecurityCommand extends AbstractConfigCommand {
     new OperationHandler<ApiSecurity>()
         .setOperation(Daemon.getApiSecurity(currentDeployment, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setFailureMesssage("Failed to load API security settings.")
         .setSuccessMessage("Successfully loaded API security settings.")
         .get();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/SpringSslCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/SpringSslCommand.java
@@ -54,6 +54,7 @@ public class SpringSslCommand extends AbstractConfigCommand {
     new OperationHandler<SpringSsl>()
         .setOperation(Daemon.getSpringSsl(currentDeployment, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setFailureMesssage("Failed to load API SSL settings.")
         .setSuccessMessage("Successfully loaded API SSL settings.")
         .get();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodCommand.java
@@ -58,6 +58,7 @@ abstract public class AuthnMethodCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to get " + authnMethodName + " method.")
         .setSuccessMessage("Configured " + authnMethodName + " method: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/GoogleRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/GoogleRoleProviderCommand.java
@@ -44,5 +44,6 @@ public class GoogleRoleProviderCommand extends AbstractRoleProviderCommand {
         .setFailureMesssage("Failed to get " + roleProviderType + " configuration.")
         .setSuccessMessage("Configured " + roleProviderType + " role provider:")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();  }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/RolesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/RolesCommand.java
@@ -60,6 +60,7 @@ public class RolesCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed to get configured roles.")
         .setSuccessMessage("Configured roles: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/ui/ApacheSslCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/ui/ApacheSslCommand.java
@@ -52,6 +52,7 @@ public class ApacheSslCommand extends AbstractConfigCommand {
     new OperationHandler<ApacheSsl>()
         .setOperation(Daemon.getApacheSsl(currentDeployment, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setFailureMesssage("Failed to load UI SSL settings.")
         .setSuccessMessage("Successfully loaded UI SSL settings.")
         .get();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/converter/FormatConverter.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/converter/FormatConverter.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.converter;
+
+import com.beust.jcommander.IStringConverter;
+import com.beust.jcommander.ParameterException;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+
+public class FormatConverter implements IStringConverter<AnsiFormatUtils.Format> {
+  @Override
+  public AnsiFormatUtils.Format convert(String value) {
+    try {
+      return AnsiFormatUtils.Format.fromString(value);
+    } catch (IllegalArgumentException e) {
+      throw new ParameterException(e.getMessage(), e);
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DetailsDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DetailsDeployCommand.java
@@ -50,6 +50,7 @@ public class DetailsDeployCommand extends AbstractConfigCommand {
         .setFailureMesssage("Failed load service details for service " + serviceName + ".")
         .setOperation(Daemon.getServiceDetails(deploymentName, serviceName, !noValidate))
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.versions;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
@@ -85,7 +86,11 @@ public class BomVersionCommand extends AbstractConfigCommand {
 
     String result;
     if (artifactName == null) {
-      result = AnsiFormatUtils.format(AnsiFormatUtils.Format.YAML, bom);
+      AnsiFormatUtils.Format format = GlobalOptions.getGlobalOptions().getOutput();
+      if (format == null) {
+        format = AnsiFormatUtils.Format.YAML;
+      }
+      result = AnsiFormatUtils.format(format, bom);
     } else {
       result = bom.getArtifactVersion(artifactName);
     }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/LatestVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/LatestVersionCommand.java
@@ -41,6 +41,7 @@ public class LatestVersionCommand extends NestableCommand {
     new OperationHandler<String>()
         .setOperation(Daemon.getLatest())
         .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .setFailureMesssage("Failed to get the latest version of Spinnaker.")
         .get();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/ListVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/ListVersionCommand.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.halyard.cli.command.v1.versions.BomVersionCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.versions.LatestVersionCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import lombok.AccessLevel;
@@ -49,13 +50,9 @@ public class ListVersionCommand extends NestableCommand {
     Versions versions = new OperationHandler<Versions>()
         .setOperation(Daemon.getVersions())
         .setFailureMesssage("Failed to load available Spinnaker versions.")
+        .setSuccessMessage("The following versions are available: ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
         .get();
-
-    if (versions.getVersions().isEmpty()) {
-      AnsiUi.success("No stable versions published at this time.");
-    } else {
-      AnsiUi.success("The following versions are available: ");
-      versions.getVersions().forEach(v -> AnsiUi.listItem(v.toString()));
-    }
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/OperationHandler.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/OperationHandler.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.cli.services.v1;
 
+import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiPrinter;
@@ -33,6 +34,7 @@ public class OperationHandler<T> implements Supplier<T> {
   String failureMesssage;
   Supplier<T> operation;
   Format format = NONE;
+  boolean userFormatted = false;
 
   @Override
   public T get() {
@@ -43,8 +45,15 @@ public class OperationHandler<T> implements Supplier<T> {
       throw new ExpectedDaemonFailureException(failureMesssage, e.getCause());
     }
 
-    if (successMessage != null) {
+    if (successMessage != null && !GlobalOptions.getGlobalOptions().isQuiet()) {
       AnsiUi.success(successMessage);
+    }
+
+    if (userFormatted) {
+      Format userFormat = GlobalOptions.getGlobalOptions().getOutput();
+      if (userFormat != null) {
+        format = userFormat;
+      }
     }
 
     String result = AnsiFormatUtils.format(format, res);

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
@@ -38,4 +38,18 @@ public class Versions {
 
   String latest;
   List<Version> versions = new ArrayList<>();
+
+  @Override
+  public String toString() {
+    if (versions.isEmpty()) {
+      return "No stable versions published at this time.";
+    }
+
+    StringBuilder result = new StringBuilder();
+    for (Version version : versions) {
+      result.append(String.format(" - %s\n", version.toString()));
+    }
+
+    return result.toString();
+  }
 }


### PR DESCRIPTION
This is needed for our nightly image cleanup, since we need to parse which images don't belong to any released, stable version of Spinnaker.