### PR TITLE
chore(oauth): Change command from oauth2 to 'oauth' for simplicity

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -124,10 +124,10 @@
  * [**hal config security api ssl edit**](#hal-config-security-api-ssl-edit)
  * [**hal config security api ssl enable**](#hal-config-security-api-ssl-enable)
  * [**hal config security authn**](#hal-config-security-authn)
- * [**hal config security authn oauth2**](#hal-config-security-authn-oauth2)
- * [**hal config security authn oauth2 disable**](#hal-config-security-authn-oauth2-disable)
- * [**hal config security authn oauth2 edit**](#hal-config-security-authn-oauth2-edit)
- * [**hal config security authn oauth2 enable**](#hal-config-security-authn-oauth2-enable)
+ * [**hal config security authn oauth**](#hal-config-security-authn-oauth)
+ * [**hal config security authn oauth disable**](#hal-config-security-authn-oauth-disable)
+ * [**hal config security authn oauth edit**](#hal-config-security-authn-oauth-edit)
+ * [**hal config security authn oauth enable**](#hal-config-security-authn-oauth-enable)
  * [**hal config security authn saml**](#hal-config-security-authn-saml)
  * [**hal config security authn saml disable**](#hal-config-security-authn-saml-disable)
  * [**hal config security authn saml edit**](#hal-config-security-authn-saml-edit)
@@ -169,7 +169,7 @@
 
 A tool for configuring, installing, and updating Spinnaker.
 
-  Version: 1.0.0-SNAPSHOT
+  Version: 0.21.0-SNAPSHOT
 
 If this is your first time using Halyard to install Spinnaker we recommend that you skim the documentation on www.spinnaker.io/docs for some familiarity with the product. If at any point you get stuck using 'hal', every command can be suffixed with '--help' for usage information. Once you are ready, these are the steps you need to follow to get an initial configuration of Spinnaker up and running:
 
@@ -2149,45 +2149,45 @@ hal config security authn [parameters] [subcommands]
 #### Parameters
  * `--no-validate`: (*Default*: `false`) Skip validation.
 #### Subcommands
- * `oauth2`: Configure the oauth2 method for authenticating.
+ * `oauth`: Configure the oauth method for authenticating.
  * `saml`: Configure the saml method for authenticating.
 
 ---
-## hal config security authn oauth2
+## hal config security authn oauth
 
-Configure the oauth2 method for authenticating.
+Configure the oauth method for authenticating.
 
 #### Usage
 ```
-hal config security authn oauth2 [parameters] [subcommands]
+hal config security authn oauth [parameters] [subcommands]
 ```
 #### Parameters
  * `--no-validate`: (*Default*: `false`) Skip validation.
 #### Subcommands
- * `disable`: Set the oauth2 method as disabled
- * `edit`: Edit the oauth2 authentication method.
- * `enable`: Set the oauth2 method as enabled
+ * `disable`: Set the oauth method as disabled
+ * `edit`: Edit the oauth authentication method.
+ * `enable`: Set the oauth method as enabled
 
 ---
-## hal config security authn oauth2 disable
+## hal config security authn oauth disable
 
-Set the oauth2 method as disabled
+Set the oauth method as disabled
 
 #### Usage
 ```
-hal config security authn oauth2 disable [parameters]
+hal config security authn oauth disable [parameters]
 ```
 #### Parameters
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 ---
-## hal config security authn oauth2 edit
+## hal config security authn oauth edit
 
-Edit the oauth2 authentication method.
+Edit the oauth authentication method.
 
 #### Usage
 ```
-hal config security authn oauth2 edit [parameters]
+hal config security authn oauth edit [parameters]
 ```
 #### Parameters
  * `--client-id`: The OAuth client ID you have configured with your OAuth provider.
@@ -2198,13 +2198,13 @@ hal config security authn oauth2 edit [parameters]
  * `--userInfoRequirements`: (*Default*: `(empty)`) The map of requirements the userInfo request must have. This is used to restrict user login to specific domains or having a specific attribute. Use equal signs between key and value, and additional key/value pairs need to repeat the flag. Example: '--userInfoRequirements foo=bar --userInfoRequirements baz=qux'.
 
 ---
-## hal config security authn oauth2 enable
+## hal config security authn oauth enable
 
-Set the oauth2 method as enabled
+Set the oauth method as enabled
 
 #### Usage
 ```
-hal config security authn oauth2 enable [parameters]
+hal config security authn oauth enable [parameters]
 ```
 #### Parameters
  * `--no-validate`: (*Default*: `false`) Skip validation.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnCommand.java
@@ -19,7 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.oauth2.OAuth2Command;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.oauth.OAuthCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.saml.SamlCommand;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -41,7 +41,7 @@ public class AuthnCommand extends AbstractConfigCommand {
   }
 
   public AuthnCommand() {
-    registerSubcommand(new OAuth2Command());
+    registerSubcommand(new OAuthCommand());
     registerSubcommand(new SamlCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth/EditOAuthCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth/EditOAuthCommand.java
@@ -14,21 +14,32 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.oauth2;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.oauth;
 
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.AbstractEditAuthnMethodCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.converter.OAuth2ProviderTypeConverter;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.OAuthProviderTypeConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
-import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth2;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
 import lombok.Getter;
 
 @Parameters(separators = "=")
-public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
+public class EditOAuthCommand extends AbstractEditAuthnMethodCommand<OAuth> {
   @Getter
-  private AuthnMethod.Method method = AuthnMethod.Method.OAuth2;
+  private AuthnMethod.Method method = AuthnMethod.Method.OAuth;
+
+  @Getter
+  private String shortDescription = "Configure authentication using a OAuth 2.0 identity provider.";
+
+  @Getter
+  private String longDescription = String.join(" ",
+     "The OAuth 2.0 workflow uses the authentication code workflow (commonly known as the",
+     "three-legged workflow) to allow third parties (in this case, Spinnaker's API Gateway,",
+     "Gate) to access user data (in this case, the user's email address for authentication).",
+     "Learn more at https://spinnaker.io/setup/security/authentication/"
+  );
 
   @Parameter(
       names = "--client-id",
@@ -45,9 +56,9 @@ public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
   @Parameter(
       names = "--provider",
       description = "The OAuth provider handling authentication. The supported options are Google, GitHub, and Azure",
-      converter = OAuth2ProviderTypeConverter.class
+      converter = OAuthProviderTypeConverter.class
   )
-  private OAuth2.Provider provider;
+  private OAuth.Provider provider;
 
   @Parameter(
       names = "--preEstablishedRedirectUri",
@@ -64,11 +75,11 @@ public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
           "signs between key and value, and additional key/value pairs need to repeat the " +
           "flag. Example: '--userInfoRequirements foo=bar --userInfoRequirements baz=qux'."
   )
-  private OAuth2.UserInfoRequirements userInfoRequirements = new OAuth2.UserInfoRequirements();
+  private OAuth.UserInfoRequirements userInfoRequirements = new OAuth.UserInfoRequirements();
 
   @Override
-  protected AuthnMethod editAuthnMethod(OAuth2 authnMethod) {
-    OAuth2.Client client = authnMethod.getClient();
+  protected AuthnMethod editAuthnMethod(OAuth authnMethod) {
+    OAuth.Client client = authnMethod.getClient();
     client.setClientId(isSet(clientId) ? clientId : client.getClientId());
     client.setClientSecret(isSet(clientSecret) ? clientSecret : client.getClientSecret());
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth/OAuthCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth/OAuthCommand.java
@@ -14,20 +14,20 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.oauth2;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.oauth;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.AuthnMethodCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
 
 @Parameters(separators = "=")
-public class OAuth2Command extends AuthnMethodCommand {
+public class OAuthCommand extends AuthnMethodCommand {
   public AuthnMethod.Method getMethod() {
-    return AuthnMethod.Method.OAuth2;
+    return AuthnMethod.Method.OAuth;
   }
 
-  public OAuth2Command() {
+  public OAuthCommand() {
     super();
-    registerSubcommand(new EditOAuth2Command());
+    registerSubcommand(new EditOAuthCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/converter/OAuthProviderTypeConverter.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/converter/OAuthProviderTypeConverter.java
@@ -19,13 +19,14 @@ package com.netflix.spinnaker.halyard.cli.command.v1.converter;
 
 import com.beust.jcommander.IStringConverter;
 import com.beust.jcommander.ParameterException;
-import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth2;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
 
-public class OAuth2ProviderTypeConverter implements IStringConverter<OAuth2.Provider> {
+public class OAuthProviderTypeConverter implements IStringConverter<OAuth.Provider> {
   @Override
-  public OAuth2.Provider convert(String value) {
+  public OAuth.Provider convert(String value) {
     try {
-      return OAuth2.Provider.fromString(value);
+      return OAuth.Provider.fromString(value);
     } catch (IllegalArgumentException e) {
       throw new ParameterException(e.getMessage(), e);
     }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -395,8 +395,8 @@ public class Daemon {
 
   public static Supplier<AuthnMethod> getAuthnMethod(String deploymentName, String methodName, boolean validate) {
     return () -> {
-      Object rawOAuth2 = ResponseUnwrapper.get(getService().getAuthnMethod(deploymentName, methodName, validate));
-      return getObjectMapper().convertValue(rawOAuth2, AuthnMethod.translateAuthnMethodName(methodName));
+      Object rawOAuth = ResponseUnwrapper.get(getService().getAuthnMethod(deploymentName, methodName, validate));
+      return getObjectMapper().convertValue(rawOAuth, AuthnMethod.translateAuthnMethodName(methodName));
     };
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authn.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Authn.java
@@ -42,12 +42,12 @@ public class Authn extends Node {
     return NodeIteratorFactory.makeReflectiveIterator(this);
   }
 
-  private OAuth2 oauth2 = new OAuth2();
+  private OAuth oauth = new OAuth();
   private Saml saml = new Saml();
   private boolean enabled;
 
   public boolean isEnabled() {
-    return getOauth2().isEnabled() || getSaml().isEnabled();
+    return this.getOauth().isEnabled() || getSaml().isEnabled();
   }
 
   public void setEnabled(boolean _ignored) {}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/AuthnMethod.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/AuthnMethod.java
@@ -62,7 +62,7 @@ abstract public class AuthnMethod extends Node {
   }
 
   public enum Method {
-    OAuth2("oauth2"),
+    OAuth("oauth"),
     SAML("saml");
 
     public final String id;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
-public class OAuth2 extends AuthnMethod {
+public class OAuth extends AuthnMethod {
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
     v.validate(psBuilder, this);
@@ -37,7 +37,7 @@ public class OAuth2 extends AuthnMethod {
 
   @Override
   public String getNodeName() {
-    return "oauth2";
+    return "oauth";
   }
 
   @Override
@@ -47,7 +47,7 @@ public class OAuth2 extends AuthnMethod {
 
   @Override
   public Method getMethod() {
-    return Method.OAuth2;
+    return Method.OAuth;
   }
 
   private Client client = new Client();
@@ -73,11 +73,11 @@ public class OAuth2 extends AuthnMethod {
 
     switch (provider) {
       case GOOGLE:
-        newClient.setAccessTokenUri("https://www.googleapis.com/oauth2/v4/token");
-        newClient.setUserAuthorizationUri("https://accounts.google.com/o/oauth2/v2/auth");
+        newClient.setAccessTokenUri("https://www.googleapis.com/oauth/v4/token");
+        newClient.setUserAuthorizationUri("https://accounts.google.com/o/oauth/v2/auth");
         newClient.setScope("profile email");
 
-        newResource.setUserInfoUri("https://www.googleapis.com/oauth2/v3/userinfo");
+        newResource.setUserInfoUri("https://www.googleapis.com/oauth/v3/userinfo");
 
         newUserInfoMapping.setEmail("email");
         newUserInfoMapping.setFirstName("given_name");
@@ -96,8 +96,8 @@ public class OAuth2 extends AuthnMethod {
         newUserInfoMapping.setUsername("login");
         break;
       case AZURE:
-        newClient.setAccessTokenUri("https://login.microsoftonline.com/${azureTenantId}/oauth2/token");
-        newClient.setUserAuthorizationUri("https://login.microsoftonline.com/${azureTenantId}/oauth2/authorize?resource=https://graph.windows.net");
+        newClient.setAccessTokenUri("https://login.microsoftonline.com/${azureTenantId}/oauth/token");
+        newClient.setUserAuthorizationUri("https://login.microsoftonline.com/${azureTenantId}/oauth/authorize?resource=https://graph.windows.net");
         newClient.setScope("profile");
         newClient.setClientAuthenticationScheme("query");
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/SecurityService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/SecurityService.java
@@ -201,8 +201,8 @@ public class SecurityService {
   public void setAuthnMethod(String deploymentName, AuthnMethod method) {
     Authn authn = getAuthn(deploymentName);
     switch (method.getMethod()) {
-      case OAuth2:
-        authn.setOauth2((OAuth2) method);
+      case OAuth:
+        authn.setOauth((OAuth) method);
         break;
       case SAML:
         authn.setSaml((Saml) method);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/OAuthValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/OAuthValidator.java
@@ -18,15 +18,16 @@
 package com.netflix.spinnaker.halyard.config.validate.v1.security;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
-import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth2;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import org.springframework.stereotype.Component;
 
 @Component
-public class OAuth2Validator extends Validator<OAuth2> {
+public class OAuthValidator extends Validator<OAuth> {
   @Override
-  public void validate(ConfigProblemSetBuilder p, OAuth2 n) {
+  public void validate(ConfigProblemSetBuilder p, OAuth n) {
     if (!n.isEnabled()) {
       return;
     }
@@ -39,7 +40,7 @@ public class OAuth2Validator extends Validator<OAuth2> {
       p.addProblem(Problem.Severity.ERROR, "No OAuth2 client secret was supplied");
     }
 
-    if (n.getProvider() == OAuth2.Provider.GOOGLE &&
+    if (n.getProvider() == OAuth.Provider.GOOGLE &&
         (n.getUserInfoRequirements() == null || !n.getUserInfoRequirements().containsKey("hd"))) {
       p.addProblem(Problem.Severity.WARNING, "Missing 'hd' field within " +
           "userInfoRequirements of Google OAuth provider. This could expose your Spinnaker " +

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
@@ -61,7 +61,7 @@ public class GateProfileFactory extends SpringProfileFactory {
       super(gate);
       server.ssl = security.getApiSecurity().getSsl();
 
-      if (security.getAuthn().getOauth2().isEnabled()) {
+      if (security.getAuthn().getOauth().isEnabled()) {
         this.spring = new SpringConfig(security);
       } else if (security.getAuthn().getSaml().isEnabled()) {
         this.saml = new SamlConfig(security);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringConfig.java
@@ -17,7 +17,8 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
-import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth2;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
+import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -25,12 +26,12 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = false)
 @Data
 class SpringConfig {
-  OAuth2 oauth2;
+  OAuth oauth;
 
   SpringConfig(Security security) {
-    OAuth2 oauth2 = security.getAuthn().getOauth2();
-    if (oauth2.isEnabled()) {
-      this.oauth2 = oauth2;
+    OAuth oauth = security.getAuthn().getOauth();
+    if (oauth.isEnabled()) {
+      this.oauth = oauth;
     }
   }
 }


### PR DESCRIPTION
I left references to "OAuth 2.0" in the doc lines.