### PR TITLE
feat(backup): Support for config backups

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,6 +8,8 @@
  * [**hal admin publish latest**](#hal-admin-publish-latest)
  * [**hal admin publish profile**](#hal-admin-publish-profile)
  * [**hal admin publish version**](#hal-admin-publish-version)
+ * [**hal backup**](#hal-backup)
+ * [**hal backup create**](#hal-backup-create)
  * [**hal config**](#hal-config)
  * [**hal config ci**](#hal-config-ci)
  * [**hal config ci jenkins**](#hal-config-ci-jenkins)
@@ -208,6 +210,7 @@ hal [parameters] [subcommands]
  * `--version, -v`: (*Default*: `false`) Version of Halyard.
 #### Subcommands
  * `admin`: This is meant for users building and publishing their own Spinnaker images and config.
+ * `backup`: Backup and restore (remote or local) copies of your halconfig and all required files.
  * `config`: Configure, validate, and view your halconfig.
  * `deploy`: Manage the deployment of Spinnaker. This includes where it's deployed, what the infrastructure footprint looks like, what the currently running deployment looks like, etc...
  * `task`: This set of commands exposes utilities of dealing with Halyard's task engine.
@@ -289,6 +292,28 @@ hal admin publish version [parameters]
  * `--alias`: (*Required*) The alias this version of Spinnaker goes by.
  * `--changelog`: (*Required*) A link to this Spinnaker release's changelog.
  * `--version`: (*Required*) The version (x.y.z) of Spinnaker to be recorded. This must exist as a BOM.
+
+---
+## hal backup
+
+This is used to periodically checkpoint your configured Spinnaker installation as well as allow you to remotely store all aspects of your configured Spinnaker installation.
+
+#### Usage
+```
+hal backup [subcommands]
+```
+#### Subcommands
+ * `create`: Create a backup.
+
+---
+## hal backup create
+
+Create a backup.
+
+#### Usage
+```
+hal backup create
+```
 
 ---
 ## hal config

--- a/halyard-backup/halyard-backup.gradle
+++ b/halyard-backup/halyard-backup.gradle
@@ -1,0 +1,11 @@
+dependencies {
+  compile spinnaker.dependency('bootActuator')
+  compile spinnaker.dependency('bootWeb')
+  compile spinnaker.dependency('lombok')
+  compile spinnaker.dependency('fabric8Api')
+  compile spinnaker.dependency('googleStorage')
+
+  compile project(':halyard-config')
+  compile project(':halyard-core')
+  compile project(':halyard-deploy')
+}

--- a/halyard-backup/src/main/java/com/netflix/spinnaker/halyard/backup/services/v1/BackupService.java
+++ b/halyard-backup/src/main/java/com/netflix/spinnaker/halyard/backup/services/v1/BackupService.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.backup.services.v1;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class BackupService {
+  @Autowired
+  HalconfigParser halconfigParser;
+
+  @Autowired
+  HalconfigDirectoryStructure directoryStructure;
+
+  public void create() {
+    Halconfig halconfig = halconfigParser.getHalconfig();
+    halconfig.backupLocalFiles(directoryStructure.getBackupConfigDependenciesPath().toString());
+    halconfigParser.backupConfig();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/BackupCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/BackupCommand.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.backup.CreateBackupCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class BackupCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "backup";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Backup and restore (remote or local) copies of your halconfig and all required files.";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String longDescription = String.join(" ", "This is used to periodically checkpoint your configured Spinnaker installation as well as",
+      "allow you to remotely store all aspects of your configured Spinnaker installation.");
+
+
+  public BackupCommand() {
+    registerSubcommand(new CreateBackupCommand());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
@@ -63,6 +63,7 @@ public class HalCommand extends NestableCommand {
 
   public HalCommand() {
     registerSubcommand(new AdminCommand());
+    registerSubcommand(new BackupCommand());
     registerSubcommand(new ConfigCommand());
     registerSubcommand(new DeployCommand());
     registerSubcommand(new TaskCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/backup/CreateBackupCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/backup/CreateBackupCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.backup;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class CreateBackupCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "create";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "Create a backup.";
+
+  @Override
+  protected void executeThis() {
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to create a backup.")
+        .setSuccessMessage("Successfully created a backup.")
+        .setOperation(Daemon.createBackup())
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.halyard.cli.services.v1;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
-import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import com.netflix.spinnaker.halyard.core.DaemonOptions;
@@ -47,6 +46,13 @@ public class Daemon {
 
   public static ShallowTaskList getTasks() {
     return getService().getTasks();
+  }
+
+  public static Supplier<Void> createBackup() {
+    return () -> {
+      ResponseUnwrapper.get(getService().createBackup(""));
+      return null;
+    };
   }
 
   public static Supplier<String> getCurrentDeployment() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.halyard.cli.services.v1;
 
-import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import com.netflix.spinnaker.halyard.core.DaemonOptions;
@@ -44,6 +43,9 @@ public interface DaemonService {
 
   @GET("/v1/tasks/{uuid}/")
   <C, T> DaemonTask<C, T> getTask(@Path("uuid") String uuid);
+
+  @PUT("/v1/backup/create")
+  DaemonTask<Halconfig, Void> createBackup(@Body String _ignore);
 
   @GET("/v1/config/")
   DaemonTask<Halconfig, Halconfig> getHalconfig();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
@@ -64,9 +64,13 @@ public class HalconfigDirectoryStructure {
     return ensureRelativeHalDirectory(deploymentName, "history");
   }
 
-  public Path getBackupConfigPath(String deploymentName) {
-    File history = ensureRelativeHalDirectory(deploymentName, "history").toFile();
-    return new File(history, "halconfig").toPath();
+  public Path getBackupConfigPath() {
+    Path backup = ensureDirectory(Paths.get(halconfigDirectory, ".backup"));
+    return new File(backup.toFile(), "config").toPath();
+  }
+
+  public Path getBackupConfigDependenciesPath() {
+    return ensureDirectory(Paths.get(halconfigDirectory, ".backup", "required-files"));
   }
 
   public Path getGenerateResultPath(String deploymentName) {
@@ -80,7 +84,7 @@ public class HalconfigDirectoryStructure {
     return path;
   }
 
-  private void ensureDirectory(Path path) {
+  private Path ensureDirectory(Path path) {
     File file = path.toFile();
     if (file.exists()) {
       if (!file.isDirectory()) {
@@ -105,5 +109,7 @@ public class HalconfigDirectoryStructure {
         );
       }
     }
+
+    return path;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
@@ -141,18 +141,18 @@ public class HalconfigParser {
     saveConfigTo(Paths.get(halconfigPath));
   }
 
-  public void backupConfig(String deploymentName) {
+  public void backupConfig() {
     // It's possible we are asked to backup the halconfig without having loaded it first.
     boolean backup = useBackup;
     useBackup = false;
     getHalconfig();
     useBackup = backup;
-    saveConfigTo(halconfigDirectoryStructure.getBackupConfigPath(deploymentName));
+    saveConfigTo(halconfigDirectoryStructure.getBackupConfigPath());
   }
 
-  public void switchToBackupConfig(String deploymentName) {
+  public void switchToBackupConfig() {
     DaemonTaskHandler.setContext(null);
-    backupHalconfigPath = halconfigDirectoryStructure.getBackupConfigPath(deploymentName).toString();
+    backupHalconfigPath = halconfigDirectoryStructure.getBackupConfigPath().toString();
     useBackup = true;
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
@@ -83,7 +83,7 @@ public class DeployService {
   public NodeDiff configDiff(String deploymentName) {
     try {
       DeploymentConfiguration deploymentConfiguration = deploymentService.getDeploymentConfiguration(deploymentName);
-      halconfigParser.switchToBackupConfig(deploymentName);
+      halconfigParser.switchToBackupConfig();
       DeploymentConfiguration oldDeploymentConfiguration = deploymentService.getDeploymentConfiguration(deploymentName);
 
       return deploymentConfiguration.diff(oldDeploymentConfiguration);
@@ -122,7 +122,7 @@ public class DeployService {
   }
 
   public RemoteAction deploy(String deploymentName, List<DeployOption> deployOptions, List<String> serviceNames) {
-    halconfigParser.backupConfig(deploymentName);
+    halconfigParser.backupConfig();
 
     DeploymentConfiguration deploymentConfiguration = deploymentService.getDeploymentConfiguration(deploymentName);
     SpinnakerServiceProvider<DeploymentDetails> serviceProvider = serviceProviderFactory.create(deploymentConfiguration);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverBootstrapProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverBootstrapProfileFactory.java
@@ -20,7 +20,6 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.ConsulConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.SupportsConsul;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleAccount;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
@@ -66,7 +65,7 @@ public class ClouddriverBootstrapProfileFactory extends SpringProfileFactory {
     }
 
     Providers providers = deploymentConfiguration.getProviders();
-    List<String> files = processRequiredFiles(providers);
+    List<String> files = backupRequiredFiles(providers);
     profile.appendContents(yamlToString(providers))
         .appendContents(profile.getBaseContents())
         .setRequiredFiles(files);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverProfileFactory.java
@@ -35,7 +35,7 @@ public class ClouddriverProfileFactory extends SpringProfileFactory {
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
     Providers providers = deploymentConfiguration.getProviders();
-    List<String> files = processRequiredFiles(providers);
+    List<String> files = backupRequiredFiles(providers);
     profile.appendContents(yamlToString(providers))
         .appendContents(profile.getBaseContents())
         .setRequiredFiles(files);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/FiatProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/FiatProfileFactory.java
@@ -36,7 +36,7 @@ public class FiatProfileFactory extends SpringProfileFactory {
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
     Authz authz = deploymentConfiguration.getSecurity().getAuthz();
-    List<String> files = processRequiredFiles(authz);
+    List<String> files = backupRequiredFiles(authz);
     AuthConfig authConfig = new AuthConfig().setAuth(authz);
     profile.appendContents(yamlToString(authConfig))
         .appendContents(profile.getBaseContents())

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
@@ -54,7 +54,7 @@ public class Front50ProfileFactory extends SpringProfileFactory {
       throw new HalException(Problem.Severity.FATAL, "No persistent storage type was configured.");
     }
 
-    List<String> files = processRequiredFiles(persistentStorage);
+    List<String> files = backupRequiredFiles(persistentStorage);
     Map<String, Map<String, Object>> persistentStorageMap = new HashMap<>();
 
     NodeIterator children = persistentStorage.getChildren();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
@@ -36,13 +36,13 @@ public class GateProfileFactory extends SpringProfileFactory {
 
   @Override
   public void setProfile(Profile profile,
-                         DeploymentConfiguration deploymentConfiguration,
-                         SpinnakerRuntimeSettings endpoints) {
+      DeploymentConfiguration deploymentConfiguration,
+      SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
     Security security = deploymentConfiguration.getSecurity();
-    List<String> requiredFiles = processRequiredFiles(security.getApiSecurity());
-    requiredFiles.addAll(processRequiredFiles(security.getAuthn()));
-    requiredFiles.addAll(processRequiredFiles(security.getAuthz()));
+    List<String> requiredFiles = backupRequiredFiles(security.getApiSecurity());
+    requiredFiles.addAll(backupRequiredFiles(security.getAuthn()));
+    requiredFiles.addAll(backupRequiredFiles(security.getAuthz()));
     GateConfig gateConfig = new GateConfig(endpoints.getServices().getGate(), security);
     gateConfig.getCors().setAllowedOrigins(endpoints.getServices().getDeck());
     profile.appendContents(yamlToString(gateConfig))

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/IgorProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/IgorProfileFactory.java
@@ -41,7 +41,7 @@ public class IgorProfileFactory extends SpringProfileFactory {
     }
 
     Cis cis = deploymentConfiguration.getCi();
-    List<String> files = processRequiredFiles(cis);
+    List<String> files = backupRequiredFiles(cis);
     profile.appendContents(yamlToString(cis))
         .appendContents(profile.getBaseContents())
         .setRequiredFiles(files);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RoscoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RoscoProfileFactory.java
@@ -35,7 +35,7 @@ public class RoscoProfileFactory extends SpringProfileFactory {
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
     Providers providers = deploymentConfiguration.getProviders();
-    List<String> files = processRequiredFiles(providers);
+    List<String> files = backupRequiredFiles(providers);
     profile.appendContents(yamlToString(providers))
         .appendContents(profile.getBaseContents())
         .setRequiredFiles(files);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApacheSpinnakerProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApacheSpinnakerProfileFactory.java
@@ -57,7 +57,7 @@ public class ApacheSpinnakerProfileFactory extends TemplateBackedProfileFactory 
 
   @Override
   protected List<String> requiredFiles(DeploymentConfiguration deploymentConfiguration) {
-   return processRequiredFiles(deploymentConfiguration.getSecurity().getUiSecurity());
+   return backupRequiredFiles(deploymentConfiguration.getSecurity().getUiSecurity());
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -107,6 +107,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     }
 
     profile.appendContents(configTemplate.setBindings(bindings).toString())
-        .setRequiredFiles(processRequiredFiles(uiSecurity));
+        .setRequiredFiles(backupRequiredFiles(uiSecurity));
   }
 }

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -20,6 +20,7 @@ dependencies {
   compile spinnaker.dependency('bootWeb')
   compile spinnaker.dependency('lombok')
 
+  compile project(':halyard-backup')
   compile project(':halyard-cli')
   compile project(':halyard-config')
   compile project(':halyard-core')

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BackupController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BackupController.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1;
+
+import com.netflix.spinnaker.halyard.backup.services.v1.BackupService;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Reports the entire contents of ~/.hal/config
+ */
+@RestController
+@RequestMapping("/v1/backup")
+public class BackupController {
+  @Autowired
+  BackupService backupService;
+
+  @RequestMapping(value = "/create", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> create() {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
+    builder.setBuildResponse(() -> {
+      backupService.create();
+      return null;
+    });
+    return DaemonTaskHandler.submitTask(builder::build, "Generate backup");
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@
 
 rootProject.name="halyard"
 
+include 'halyard-backup'
 include 'halyard-cli'
 include 'halyard-config'
 include 'halyard-core'


### PR DESCRIPTION
This feeds into a KMS story for remote backups.

Right now it takes your entire halconfig, determines all files it needs, and copies it and the files into `~/.hal/.backups/`, rewriting properties as needed.