### PR TITLE
refactor(deploy): Dynamically associate sidecars

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulClientService.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
 
+import com.netflix.spinnaker.clouddriver.consul.api.v1.services.AgentApi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
@@ -40,7 +41,7 @@ import java.util.Optional;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Component
-abstract public class ConsulClientService extends SpinnakerService<ConsulClientService.Consul> implements SidecarService {
+abstract public class ConsulClientService extends SpinnakerService<AgentApi> implements SidecarService {
   protected final String CLIENT_OUTPUT_PATH = "/etc/consul.d";
 
   @Autowired
@@ -60,8 +61,8 @@ abstract public class ConsulClientService extends SpinnakerService<ConsulClientS
   }
 
   @Override
-  public Class<Consul> getEndpointClass() {
-    return Consul.class;
+  public Class<AgentApi> getEndpointClass() {
+    return AgentApi.class;
   }
 
   public static String consulClientService(String serviceName) {
@@ -102,8 +103,6 @@ abstract public class ConsulClientService extends SpinnakerService<ConsulClientS
     result.add(profile);
     return result;
   }
-
-  public interface Consul { }
 
   @EqualsAndHashCode(callSuper = true)
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerMonitoringDaemonService.java
@@ -69,11 +69,11 @@ abstract public class SpinnakerMonitoringDaemonService extends SpinnakerService<
     return SpinnakerMonitoringDaemon.class;
   }
 
-  public static String serviceRegistryProfileName(String serviceName) {
+  private static String serviceRegistryProfileName(String serviceName) {
     return "registry/" + serviceName + ".yml";
   }
 
-  public static String monitoringProfileName() {
+  private static String monitoringProfileName() {
     return "spinnaker-monitoring.yml";
   }
 
@@ -102,8 +102,11 @@ abstract public class SpinnakerMonitoringDaemonService extends SpinnakerService<
   public List<Profile> getSidecarProfiles(GenerateService.ResolvedConfiguration resolvedConfiguration, SpinnakerService service) {
     List<Profile> result = new ArrayList<>();
     Map<String, Profile> monitoringProfiles = resolvedConfiguration.getProfilesForService(getType());
-    Profile profile = monitoringProfiles.get(serviceRegistryProfileName(service.getServiceName()));
+
+    String profileName = serviceRegistryProfileName(service.getCanonicalName());
+    Profile profile = monitoringProfiles.get(profileName);
     result.add(profile);
+
     profile = monitoringProfiles.get(monitoringProfileName());
     result.add(profile);
     return result;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianConsulClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianConsulClientService.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.debian;
 
+import com.netflix.spinnaker.clouddriver.consul.api.v1.services.AgentApi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.core.resource.v1.JarResource;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
@@ -41,7 +42,7 @@ import java.util.Map;
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Component
-public class BakeDebianConsulClientService extends ConsulClientService implements BakeDebianService<ConsulClientService.Consul> {
+public class BakeDebianConsulClientService extends ConsulClientService implements BakeDebianService<AgentApi> {
   @Autowired
   ArtifactService artifactService;
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/SidecarService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/SidecarService.java
@@ -24,5 +24,6 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerServic
 import java.util.List;
 
 public interface SidecarService {
+  SpinnakerService getService();
   List<Profile> getSidecarProfiles(GenerateService.ResolvedConfiguration resolvedConfiguration, SpinnakerService service);
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
@@ -57,19 +57,6 @@ public interface GoogleDistributedService<T> extends DistributedService<T, Googl
     return "/etc/default/spinnaker";
   }
 
-  default List<SidecarService> getSidecars(SpinnakerRuntimeSettings runtimeSettings) {
-    SpinnakerMonitoringDaemonService monitoringService = getMonitoringDaemonService();
-    ServiceSettings monitoringSettings = runtimeSettings.getServiceSettings(monitoringService);
-    ServiceSettings thisSettings = runtimeSettings.getServiceSettings(getService());
-
-    List<SidecarService> result = new ArrayList<>();
-    if (monitoringSettings.isEnabled() && thisSettings.isMonitored()) {
-      result.add(monitoringService);
-    }
-
-    return result;
-  }
-
   default List<String> getScopes() {
     List<String> result = new ArrayList<>();
     result.add("https://www.googleapis.com/auth/devstorage.read_only");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleProviderUtils.java
@@ -250,7 +250,7 @@ class GoogleProviderUtils {
     Integer port;
 
     static String buildKey(String deployment, String instance) {
-      return String.format("%s:%s", deployment, instance);
+      return String.format("%d:%s:%s", Thread.currentThread().getId(), deployment, instance);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesProviderUtils.java
@@ -56,6 +56,10 @@ class KubernetesProviderUtils {
   static class Proxy {
     String jobId;
     Integer port;
+
+    static String buildKey(String deployment) {
+      return String.format("%d:%s", Thread.currentThread().getId(), deployment);
+    }
   }
 
   static URI proxyServiceEndpoint(Proxy proxy, String namespace, String serviceName, int servicePort) {
@@ -72,7 +76,7 @@ class KubernetesProviderUtils {
 
   static Proxy openProxy(JobExecutor jobExecutor, AccountDeploymentDetails<KubernetesAccount> details) {
     KubernetesAccount account = details.getAccount();
-    Proxy proxy = proxyMap.getOrDefault(details.getDeploymentName(), new Proxy());
+    Proxy proxy = proxyMap.getOrDefault(Proxy.buildKey(details.getDeploymentName()), new Proxy());
     String jobId = proxy.jobId;
     if (StringUtils.isEmpty(jobId) || !jobExecutor.jobExists(jobId)) {
       DaemonTaskHandler.newStage("Connecting to the Kubernetes cluster in account \"" + account.getName() + "\"");
@@ -102,7 +106,7 @@ class KubernetesProviderUtils {
       Matcher matcher = portPattern.matcher(connectionMessage);
       if (matcher.find()) {
         proxy.setPort(Integer.valueOf(matcher.group(1)));
-        proxyMap.put(details.getDeploymentName(), proxy);
+        proxyMap.put(Proxy.buildKey(details.getDeploymentName()), proxy);
         DaemonTaskHandler.message("Connected to kubernetes cluster for account "
             + account.getName() + " on port " + proxy.getPort());
         DaemonTaskHandler.message("View the kube ui on http://localhost:" + proxy.getPort() + "/ui/");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/ResourceBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/ResourceBuilder.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
+
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import io.fabric8.kubernetes.api.model.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+class ResourceBuilder {
+  static Container buildContainer(String name, ServiceSettings settings, List<ConfigSource> configSources) {
+    int port = settings.getPort();
+    List<EnvVar> envVars = settings.getEnv().entrySet().stream().map(e -> {
+      EnvVarBuilder envVarBuilder = new EnvVarBuilder();
+      return envVarBuilder.withName(e.getKey()).withValue(e.getValue()).build();
+    }).collect(Collectors.toList());
+
+    configSources.forEach(c -> {
+      c.getEnv().entrySet().forEach(envEntry -> {
+        EnvVarBuilder envVarBuilder = new EnvVarBuilder();
+        envVars.add(envVarBuilder.withName(envEntry.getKey())
+            .withValue(envEntry.getValue())
+            .build());
+      });
+    });
+
+    ProbeBuilder probeBuilder = new ProbeBuilder();
+
+    if (settings.getHealthEndpoint() != null) {
+      probeBuilder = probeBuilder
+          .withNewHttpGet()
+          .withNewPort(port)
+          .withPath(settings.getHealthEndpoint())
+          .endHttpGet();
+    } else {
+      probeBuilder = probeBuilder
+          .withNewTcpSocket()
+          .withNewPort()
+          .withIntVal(port)
+          .endPort()
+          .endTcpSocket();
+    }
+
+    List<VolumeMount> volumeMounts = configSources.stream().map(c -> {
+      return new VolumeMountBuilder().withMountPath(c.getMountPath()).withName(c.getId()).build();
+    }).collect(Collectors.toList());
+    ContainerBuilder containerBuilder = new ContainerBuilder();
+
+    containerBuilder = containerBuilder
+        .withName(name)
+        .withImage(settings.getArtifactId())
+        .withPorts(new ContainerPortBuilder().withContainerPort(port).build())
+        .withVolumeMounts(volumeMounts)
+        .withEnv(envVars)
+        .withReadinessProbe(probeBuilder.build());
+
+    return containerBuilder.build();
+  }
+}


### PR DESCRIPTION
In the process I found that an update to kubectl caused contention when running multiple parallel proxies, this is fixed here as well by associating thread IDs with open connections to ensure no proxy is shared across Halyard Tasks.