### PR TITLE
fix(deploy) Switch to `ssh` from `gcloud ssh`

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
@@ -101,10 +101,11 @@ public class DaemonTask<C, T> {
   }
 
   void cleanupResources() {
+    log.info(this + " killing all jobs");
     jobExecutor.cancelAllJobs();
     for (DaemonTask child : children) {
       if (child != null) {
-        log.info("Interrupting child " + child);
+        log.info(this + "Interrupting child " + child);
 
         if (timedOut) {
           child.timeout();
@@ -172,7 +173,7 @@ public class DaemonTask<C, T> {
 
     TaskRepository.getTask(childTask.getUuid());
 
-    log.info("Collected child task " + childTask + " with state " + childTask.getState());
+    log.info(this + "Collected child task " + childTask + " with state " + childTask.getState());
     if (childTask.getResponse() == null) {
       throw new RuntimeException("Child response may not be null.");
     }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDeckService.java
@@ -53,7 +53,6 @@ public class GoogleDeckService extends DeckService implements GoogleDistributedS
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
     Settings settings = new Settings(deploymentConfiguration.getSecurity().getUiSecurity());
     settings.setArtifactId(getArtifactId(deploymentConfiguration.getName()))
-        .setAddress(buildAddress())
         .setLocation("us-central1-f")
         .setEnabled(true);
     return settings;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleGateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleGateService.java
@@ -55,7 +55,6 @@ public class GoogleGateService extends GateService implements GoogleDistributedS
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
     Settings settings = new Settings(deploymentConfiguration.getSecurity().getApiSecurity());
     settings.setArtifactId(getArtifactId(deploymentConfiguration.getName()))
-        .setAddress(buildAddress())
         .setLocation("us-central1-f")
         .setEnabled(true);
     return settings;


### PR DESCRIPTION
gcloud was spawning a subprocess that java couldn't kill, leading to a large number of leaked processes