### PR TITLE
feat(deploy): GCE red/black pipelines

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSAccountCommand.java
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 @Parameters(separators = "=")
 public class OracleBMCSAccountCommand extends AbstractAccountCommand {
   protected String getProviderName() {
-    return Provider.ProviderType.ORACLEBMCS.getId();
+    return Provider.ProviderType.ORACLEBMCS.getName();
   }
 
   public OracleBMCSAccountCommand() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSAddAccountCommand.java
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.oraclebmcs.Oracle
 @Parameters(separators = "=")
 public class OracleBMCSAddAccountCommand extends AbstractAddAccountCommand {
   protected String getProviderName() {
-    return Provider.ProviderType.ORACLEBMCS.getId();
+    return Provider.ProviderType.ORACLEBMCS.getName();
   }
 
   @Parameter(

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSCommand.java
@@ -19,7 +19,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 @Parameters(separators = "=")
 public class OracleBMCSCommand extends AbstractNamedProviderCommand {
   protected String getProviderName() {
-    return Provider.ProviderType.ORACLEBMCS.getId();
+    return Provider.ProviderType.ORACLEBMCS.getName();
   }
 
   public OracleBMCSCommand() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSEditAccountCommand.java
@@ -20,7 +20,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.oraclebmcs.Oracle
 @Parameters(separators = "=")
 public class OracleBMCSEditAccountCommand extends AbstractEditAccountCommand<OracleBMCSAccount> {
   protected String getProviderName() {
-    return Provider.ProviderType.ORACLEBMCS.getId();
+    return Provider.ProviderType.ORACLEBMCS.getName();
   }
 
   @Parameter(

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ArtifactSources.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ArtifactSources.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.config.v1;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Data
+@ConfigurationProperties("spinnaker.artifacts")
+@Configuration
+public class ArtifactSources {
+  String googleImageProject = "marketplace-spinnaker-release";
+  String dockerRegistry = "gcr.io/spinnaker-marketplace";
+  String debianRepository = "https://dl.bintray.com/spinnaker-releases/debians";
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -38,6 +39,9 @@ public abstract class Account extends Node implements Cloneable {
   public String getNodeName() {
     return name;
   }
+
+  // Override this method if your cloud provider account needs special settings enabled for it act as a bootstrapping account.
+  public void makeBootstrappingAccount(ArtifactSources artifactSources) {}
 
   @Override
   public NodeIterator getChildren() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Provider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Provider.java
@@ -52,7 +52,7 @@ public abstract class Provider<A extends Account> extends Node implements Clonea
 
   @Override
   public String getNodeName() {
-    return providerType().getId();
+    return providerType().getName();
   }
 
   abstract public ProviderType providerType();
@@ -62,15 +62,24 @@ public abstract class Provider<A extends Account> extends Node implements Clonea
     AWS("aws"),
     AZURE("azure"),
     DOCKERREGISTRY("dockerRegistry"),
-    GOOGLE("google"),
+    GOOGLE("google", "gce"),
     KUBERNETES("kubernetes"),
     OPENSTACK("openstack"),
     ORACLEBMCS("oraclebmcs");
 
     @Getter
+    String name;
+
+    @Getter
     String id;
 
-    ProviderType(String id) {
+    ProviderType(String name) {
+      this.name = name;
+      this.id = name;
+    }
+
+    ProviderType(String name, String id) {
+      this.name = name;
       this.id = id;
     }
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
@@ -16,9 +16,11 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.google;
 
+import com.amazonaws.services.codepipeline.model.Artifact;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.clouddriver.google.ComputeVersion;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
+import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.ConsulConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.SupportsConsul;
@@ -77,5 +79,10 @@ public class GoogleAccount extends CommonGoogleAccount implements Cloneable, Sup
           .setRemediation("Do the provided credentials have access to project " + getProject() + "?");
       return null;
     }
+  }
+
+  @Override
+  public void makeBootstrappingAccount(ArtifactSources artifactSources) {
+    imageProjects.add(artifactSources.getGoogleImageProject());
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/DeployConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/DeployConfig.java
@@ -30,21 +30,6 @@ public class DeployConfig {
   }
 
   @Bean
-  String dockerRegistry(@Value("${spinnaker.artifacts.dockerRegistry:gcr.io/spinnaker-marketplace}") String dockerRegistry) {
-    return dockerRegistry;
-  }
-
-  @Bean
-  String debianRepository(@Value("${spinnaker.artifacts.debianRepository:https://dl.bintray.com/spinnaker-releases/debians}") String debianRepository) {
-    return debianRepository;
-  }
-
-  @Bean
-  String googleImageProject(@Value("${spinnaker.artifacts.googleImageProject:marketplace-spinnaker-release}") String googleImageProject) {
-    return googleImageProject;
-  }
-
-  @Bean
   String vaultSecretPrefix(@Value("${spinnaker.vault.secretPrefix:secrets/spinnaker/}") String vaultSecretPrefix) {
     return vaultSecretPrefix;
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
@@ -112,10 +112,10 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
             DaemonTaskHandler.newStage("Deploying " + distributedService.getServiceName() + " via provider API");
             deployServiceManually(deploymentDetails, resolvedConfiguration, distributedService, safeToUpdate);
           } else {
+            DaemonTaskHandler.newStage("Deploying " + distributedService.getServiceName() + " via red/black");
             Orca orca = serviceProvider
                 .getDeployableService(SpinnakerService.Type.ORCA_BOOTSTRAP, Orca.class)
                 .connectToPrimaryService(deploymentDetails, runtimeSettings);
-            DaemonTaskHandler.newStage("Deploying " + distributedService.getServiceName() + " via red/black");
             deployServiceWithOrca(deploymentDetails, resolvedConfiguration, orca, distributedService);
           }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/ServiceProviderFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/ServiceProviderFactory.java
@@ -83,7 +83,7 @@ public class ServiceProviderFactory {
       case GOOGLE:
         return googleDistributedServiceProvider;
       default:
-        throw new IllegalArgumentException("No Clustered Simple Deployment for " + providerType.getId());
+        throw new IllegalArgumentException("No Clustered Simple Deployment for " + providerType.getName());
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverBootstrapProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverBootstrapProfileFactory.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
+import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.ConsulConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.SupportsConsul;
@@ -35,6 +36,9 @@ public class ClouddriverBootstrapProfileFactory extends SpringProfileFactory {
   @Autowired
   AccountService accountService;
 
+  @Autowired
+  ArtifactSources artifactSources;
+
   @Override
   public SpinnakerArtifact getArtifact() {
     return SpinnakerArtifact.CLOUDDRIVER;
@@ -50,6 +54,8 @@ public class ClouddriverBootstrapProfileFactory extends SpringProfileFactory {
     }
 
     Account account = accountService.getAnyProviderAccount(deploymentConfiguration.getName(), deploymentEnvironment.getAccountName());
+
+    account.makeBootstrappingAccount(artifactSources);
 
     if (account instanceof SupportsConsul) {
       SupportsConsul consulAccount = (SupportsConsul) account;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianServiceProvider.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.debian;
 
+import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.core.RemoteAction;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
@@ -37,7 +38,7 @@ import java.util.stream.Collectors;
 @Component
 public class BakeDebianServiceProvider extends BakeServiceProvider {
   @Autowired
-  private String debianRepository;
+  private ArtifactSources artifactSources;
 
   @Autowired
   BakeDebianClouddriverService clouddriverService;
@@ -107,7 +108,7 @@ public class BakeDebianServiceProvider extends BakeServiceProvider {
 
     resource = new JarResource("/debian/pre-bake.sh");
     bindings = new HashMap<>();
-    bindings.put("debian-repository", debianRepository);
+    bindings.put("debian-repository", artifactSources.getDebianRepository());
     bindings.put("install-commands", String.join("\n", serviceInstalls));
     bindings.put("upstart-init", upstartInit);
     bindings.put("startup-file", Paths.get(startupScriptPath, "startup.sh").toString());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleConsulServerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleConsulServerService.java
@@ -20,14 +20,12 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.go
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleAccount;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConsulServerService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -38,31 +36,9 @@ import java.util.List;
 @Component
 @Data
 public class GoogleConsulServerService extends ConsulServerService implements GoogleDistributedService<ConsulServerService.Consul> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  GoogleMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
-
-  @Autowired
-  String googleImageProject;
-
-  @Autowired
-  String startupScriptPath;
-
-  @Autowired
-  GoogleVaultServerService vaultServerService;
-
-  @Override
-  public GoogleConsulServerService getConsulServerService() {
-    return this;
-  }
+  GoogleDistributedServiceDelegate googleDistributedServiceDelegate;
 
   @Autowired
   public List<String> getScopes() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleMonitoringDaemonService.java
@@ -30,9 +30,6 @@ import org.springframework.stereotype.Component;
 @Data
 public class GoogleMonitoringDaemonService extends SpinnakerMonitoringDaemonService {
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
   ArtifactService artifactService;
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleProviderUtils.java
@@ -53,6 +53,9 @@ import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.FAT
 class GoogleProviderUtils {
   // Map from service -> the port & job managing the connection.
   private static ConcurrentHashMap<String, Proxy> proxyMap = new ConcurrentHashMap<>();
+  public static String getNetworkName() {
+    return "spinnaker-hal";
+  }
 
   static String defaultServiceAccount(AccountDeploymentDetails<GoogleAccount> details) {
     GoogleAccount account = details.getAccount();
@@ -156,7 +159,7 @@ class GoogleProviderUtils {
   }
 
   static String ensureSpinnakerNetworkExists(AccountDeploymentDetails<GoogleAccount> details) {
-    String networkName = "spinnaker-hal";
+    String networkName = getNetworkName();
     String project = details.getAccount().getProject();
 
     Compute compute = getCompute(details);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleVaultServerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleVaultServerService.java
@@ -20,13 +20,12 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.go
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleAccount;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.VaultServerService;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -37,26 +36,9 @@ import java.util.List;
 @Component
 @Data
 public class GoogleVaultServerService extends VaultServerService implements GoogleDistributedService<VaultServerService.Vault> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  GoogleMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
-
-  @Autowired
-  String googleImageProject;
-
-  @Autowired
-  String startupScriptPath;
-
-  @Autowired
-  GoogleConsulServerService consulServerService;
+  GoogleDistributedServiceDelegate googleDistributedServiceDelegate;
 
   @Override
   public void ensureRunning(AccountDeploymentDetails<GoogleAccount> details,
@@ -82,11 +64,6 @@ public class GoogleVaultServerService extends VaultServerService implements Goog
       GenerateService.ResolvedConfiguration resolvedConfiguration) {
     /* vault server may not stage profiles, since it acts as our config server */
     return new ArrayList<>();
-  }
-
-  @Override
-  public GoogleVaultServerService getVaultServerService() {
-    return this;
   }
 
   public String getArtifactId(String deploymentName) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverBootstrapService.java
@@ -18,13 +18,11 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverBootstrapService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -35,17 +33,9 @@ import java.util.List;
 @Component
 @Data
 public class KubernetesClouddriverBootstrapService extends ClouddriverBootstrapService implements KubernetesDistributedService<ClouddriverService.Clouddriver> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverService.java
@@ -18,12 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,17 +29,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesClouddriverService extends ClouddriverService implements KubernetesDistributedService<ClouddriverService.Clouddriver> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDeckService.java
@@ -18,14 +18,13 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.deck.DeckDockerProfileFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.deck.DeckDockerProfileFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DeckService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -37,20 +36,12 @@ import java.util.List;
 @Component
 @Data
 public class KubernetesDeckService extends DeckService implements KubernetesDistributedService<DeckService.Deck> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Autowired
   DeckDockerProfileFactory deckDockerProfileFactory;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceDelegate.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceDelegate.java
@@ -16,7 +16,7 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.google;
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
@@ -26,10 +26,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-public class GoogleDistributedServiceDelegate {
+public class KubernetesDistributedServiceDelegate {
   @Autowired
-  @Getter
-  GoogleMonitoringDaemonService monitoringDaemonService;
+  ArtifactSources artifactSources;
+
+  public String getDockerRegistry() {
+    return artifactSources.getDockerRegistry();
+  }
 
   @Autowired
   @Getter
@@ -40,29 +43,6 @@ public class GoogleDistributedServiceDelegate {
   ServiceInterfaceFactory serviceInterfaceFactory;
 
   @Autowired
-  ArtifactSources artifactSources;
-
-  @Autowired
   @Getter
-  String startupScriptPath;
-
-  @Autowired
-  @Getter
-  GoogleVaultClientService vaultClientService;
-
-  @Autowired
-  @Getter
-  GoogleVaultServerService vaultServerService;
-
-  @Autowired
-  @Getter
-  GoogleConsulClientService consulClientService;
-
-  @Autowired
-  @Getter
-  GoogleConsulServerService consulServerService;
-
-  public String getGoogleImageProject() {
-    return artifactSources.getGoogleImageProject();
-  }
+  KubernetesMonitoringDaemonService monitoringDaemonService;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesEchoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesEchoService.java
@@ -18,12 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.EchoService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,17 +29,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesEchoService extends EchoService implements KubernetesDistributedService<EchoService.Echo> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFiatService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFiatService.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.FiatService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,17 +32,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesFiatService extends FiatService implements KubernetesDistributedService<FiatService.Fiat> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFront50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFront50Service.java
@@ -18,11 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.Front50Service;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -30,17 +29,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesFront50Service extends Front50Service implements KubernetesDistributedService<Front50Service.Front50> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesGateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesGateService.java
@@ -18,13 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.config.model.v1.security.ApiSecurity;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.GateService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,17 +29,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesGateService extends GateService implements KubernetesDistributedService<GateService.Gate> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesIgorService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesIgorService.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.IgorService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,17 +32,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesIgorService extends IgorService implements KubernetesDistributedService<IgorService.Igor> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesMonitoringDaemonService.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerMonitoringDaemonService;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,11 +32,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesMonitoringDaemonService extends SpinnakerMonitoringDaemonService {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  ArtifactService artifactService;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
@@ -48,9 +47,9 @@ public class KubernetesMonitoringDaemonService extends SpinnakerMonitoringDaemon
 
   private String getArtifactId(String deploymentName) {
     String artifactName = getArtifact().getName();
-    String version = artifactService.getArtifactVersion(deploymentName, getArtifact());
+    String version = getArtifactService().getArtifactVersion(deploymentName, getArtifact());
 
-    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, dockerRegistry);
+    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry());
     return KubernetesUtil.getImageId(image);
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaBootstrapService.java
@@ -18,13 +18,11 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaBootstrapService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -35,17 +33,9 @@ import java.util.List;
 @Component
 @Data
 public class KubernetesOrcaBootstrapService extends OrcaBootstrapService implements KubernetesDistributedService<OrcaService.Orca> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaService.java
@@ -18,12 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,17 +29,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesOrcaService extends OrcaService implements KubernetesDistributedService<OrcaService.Orca> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisBootstrapService.java
@@ -18,12 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RedisBootstrapService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import redis.clients.jedis.Jedis;
@@ -32,20 +30,9 @@ import redis.clients.jedis.Jedis;
 @Component
 @Data
 public class KubernetesRedisBootstrapService extends RedisBootstrapService implements KubernetesDistributedService<Jedis> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
-
-  @Autowired
-  JobExecutor jobExecutor;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisService.java
@@ -25,13 +25,12 @@ import com.netflix.spinnaker.halyard.core.job.v1.JobStatus;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RedisService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import redis.clients.jedis.Jedis;
@@ -45,17 +44,9 @@ import java.util.stream.Collectors;
 @Component
 @Data
 public class KubernetesRedisService extends RedisService implements KubernetesDistributedService<Jedis> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Jedis connectToPrimaryService(AccountDeploymentDetails<KubernetesAccount> details, SpinnakerRuntimeSettings runtimeSettings) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRoscoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRoscoService.java
@@ -18,12 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RoscoService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -31,17 +29,9 @@ import org.springframework.stereotype.Component;
 @Component
 @Data
 public class KubernetesRoscoService extends RoscoService implements KubernetesDistributedService<RoscoService.Rosco> {
+  @Delegate
   @Autowired
-  private String dockerRegistry;
-
-  @Autowired
-  KubernetesMonitoringDaemonService monitoringDaemonService;
-
-  @Autowired
-  ArtifactService artifactService;
-
-  @Autowired
-  ServiceInterfaceFactory serviceInterfaceFactory;
+  KubernetesDistributedServiceDelegate distributedServiceDelegate;
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianServiceProvider.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
+import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.core.RemoteAction;
 import com.netflix.spinnaker.halyard.core.resource.v1.JarResource;
 import com.netflix.spinnaker.halyard.core.resource.v1.TemplatedResource;
@@ -34,7 +35,7 @@ import java.util.stream.Collectors;
 @Component
 public class LocalDebianServiceProvider extends LocalServiceProvider {
   @Autowired
-  private String debianRepository;
+  private ArtifactSources artifactSources;
 
   @Autowired
   LocalDebianClouddriverService clouddriverService;
@@ -91,7 +92,7 @@ public class LocalDebianServiceProvider extends LocalServiceProvider {
     bindings = new HashMap<>();
     bindings.put("prepare-environment", "true");
     bindings.put("install-redis", "true");
-    bindings.put("debian-repository", debianRepository);
+    bindings.put("debian-repository", artifactSources.getDebianRepository());
     bindings.put("install-commands", String.join("\n", serviceInstalls));
     bindings.put("service-action", "restart");
     bindings.put("upstart-init", upstartInit);


### PR DESCRIPTION
Not much going on here, there were two widespread changes
1. Switching ProviderType.id to return the id expected by clouddriver (since the google provider is referenced internal to spinnaker as "GCE").
2. Moving some of DeployConfig into a separate spring config class to allow provider accounts to generically modify themselves to include whatever config is needed if they used in the bootstrapping process. This was done to put "marketplace-spinnaker-release" into the list of external image projects in our google account.