### PR TITLE
feat(deploy): Allow users to specify service settings

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
@@ -36,6 +36,10 @@ public class HalconfigDirectoryStructure {
     return ensureRelativeHalDirectory(deploymentName, "profiles");
   }
 
+  public Path getUserServiceSettingsPath(String deploymentName) {
+    return ensureRelativeHalDirectory(deploymentName, "service-settings");
+  }
+
   public Path getVaultTokenPath(String deploymentName) {
     Path halconfigPath = Paths.get(halconfigDirectory, deploymentName);
     ensureDirectory(halconfigPath);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/BakeDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/BakeDeployer.java
@@ -43,7 +43,7 @@ public class BakeDeployer implements Deployer<BakeServiceProvider, DeploymentDet
       List<String> serviceNames) {
     List<BakeService> enabledServices = serviceProvider.getPrioritizedBakeableServices(serviceNames)
         .stream()
-        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).isEnabled())
+        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).getEnabled())
         .collect(Collectors.toList());
 
     Map<String, String> installCommands = enabledServices.stream().reduce(new HashMap<>(), (commands, installable) -> {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalDeployer.java
@@ -40,7 +40,7 @@ public class LocalDeployer implements Deployer<LocalServiceProvider, DeploymentD
       List<String> serviceNames) {
     List<LocalService> enabledServices = serviceProvider.getLocalServices(serviceNames)
         .stream()
-        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).isEnabled())
+        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).getEnabled())
         .collect(Collectors.toList());
 
     Map<String, String> installCommands = enabledServices.stream().reduce(new HashMap<>(), (commands, installable) -> {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
@@ -115,7 +115,7 @@ public class GenerateService {
       }
 
       ServiceSettings settings = runtimeSettings.getServiceSettings(service);
-      if (settings == null || !settings.isEnabled()) {
+      if (settings == null || !settings.getEnabled()) {
         continue;
       }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/MetricRegistryProfileFactoryBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/MetricRegistryProfileFactoryBuilder.java
@@ -59,7 +59,7 @@ public class MetricRegistryProfileFactoryBuilder {
         URI uri;
         try {
           String baseUrl;
-          if (settings.isBasicAuthEnabled()) {
+          if (settings.getBasicAuthEnabled()) {
             baseUrl = settings.getAuthBaseUrl();
           } else {
             baseUrl = settings.getBaseUrl();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SecurityConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SecurityConfig.java
@@ -26,7 +26,7 @@ public class SecurityConfig {
   User user = new User();
 
   SecurityConfig(ServiceSettings settings) {
-    if (settings.isBasicAuthEnabled()) {
+    if (settings.getBasicAuthEnabled() == null || settings.getBasicAuthEnabled()) {
       String username = settings.getUsername();
       String password = settings.getPassword();
       assert(username != null && password != null);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
@@ -34,6 +34,7 @@ import retrofit.http.POST;
 import retrofit.http.Path;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -85,22 +86,24 @@ abstract public class ClouddriverService extends SpringService<ClouddriverServic
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 7002;
+    Integer port = 7002;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulClientService.java
@@ -33,10 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -77,7 +74,7 @@ abstract public class ConsulClientService extends SpinnakerService<ConsulApi> im
     for (Map.Entry<Type, ServiceSettings> entry : endpoints.getAllServiceSettings().entrySet()) {
       ServiceSettings settings = entry.getValue();
       Type type = entry.getKey();
-      if (!settings.isSidecar() && settings.isEnabled()) {
+      if (!settings.getSidecar() && settings.getEnabled()) {
         String serviceName = type.getCanonicalName();
         String profileName = consulClientService(serviceName);
         String profilePath = Paths.get(CLIENT_OUTPUT_PATH, serviceName + ".json").toString();
@@ -107,17 +104,19 @@ abstract public class ConsulClientService extends SpinnakerService<ConsulApi> im
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends ServiceSettings {
-    int port = 8500;
+    Integer port = 8500;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = false;
-    boolean sidecar = true;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = false;
+    Boolean sidecar = true;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() { }
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulServerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulServerService.java
@@ -26,9 +26,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -60,18 +58,19 @@ abstract public class ConsulServerService extends SpinnakerService<ConsulApi> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends ServiceSettings {
-    int port = 8500;
+    Integer port = 8500;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    boolean enabled = true;
-    boolean safeToUpdate = false;
-    boolean monitored = false;
-    boolean sidecar = false;
-    int targetSize = 3;
+    Boolean enabled = true;
+    Boolean safeToUpdate = false;
+    Boolean monitored = false;
+    Boolean sidecar = false;
+    Integer targetSize = 3;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() { }
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/DeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/DeckService.java
@@ -33,9 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -102,15 +100,17 @@ abstract public class DeckService extends SpinnakerService<DeckService.Deck> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends ServiceSettings {
-    int port = 9000;
+    Integer port = 9000;
     String address = "localhost";
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = false;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = false;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/EchoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/EchoService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import retrofit.http.GET;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,17 +79,19 @@ abstract public class EchoService extends SpringService<EchoService.Echo> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 8089;
+    Integer port = 8089;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/FiatService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/FiatService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import retrofit.http.GET;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,17 +79,19 @@ abstract public class FiatService extends SpringService<FiatService.Fiat> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 7003;
+    Integer port = 7003;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import retrofit.http.GET;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,17 +79,19 @@ abstract public class Front50Service extends SpringService<Front50Service.Front5
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 8080;
+    Integer port = 8080;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
@@ -30,7 +30,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -75,15 +77,17 @@ abstract public class GateService extends SpringService<GateService.Gate> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 8084;
+    Integer port = 8084;
     String address = "localhost";
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/HasServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/HasServiceSettings.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 
 public interface HasServiceSettings<T> {
   ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration);
+  ServiceSettings getDefaultServiceSettings(DeploymentConfiguration deploymentConfiguration);
   SpinnakerService<T> getService();
   SpinnakerArtifact getArtifact();
   String getServiceName();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/IgorService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/IgorService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import retrofit.http.GET;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,17 +79,19 @@ abstract public class IgorService extends SpringService<IgorService.Igor> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 8088;
+    Integer port = 8088;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import retrofit.http.*;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -97,22 +98,24 @@ abstract public class OrcaService extends SpringService<OrcaService.Orca> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 8083;
+    Integer port = 8083;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RedisService.java
@@ -27,9 +27,7 @@ import lombok.EqualsAndHashCode;
 import org.springframework.stereotype.Component;
 import redis.clients.jedis.Jedis;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -58,17 +56,19 @@ abstract public class RedisService extends SpinnakerService<Jedis> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends ServiceSettings {
-    int port = 6379;
+    Integer port = 6379;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "redis";
     String healthEndpoint = null;
-    boolean enabled = true;
-    boolean safeToUpdate = false;
-    boolean monitored = false;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = false;
+    Boolean monitored = false;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {
       env.put("MASTER", "true");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RoscoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RoscoService.java
@@ -30,6 +30,7 @@ import org.springframework.stereotype.Component;
 import retrofit.http.GET;
 
 import java.nio.file.Paths;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -78,17 +79,19 @@ abstract public class RoscoService extends SpringService<RoscoService.Rosco> {
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends SpringServiceSettings {
-    int port = 8087;
+    Integer port = 8087;
     // Address is how the service is looked up.
     String address = "localhost";
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = true;
-    boolean sidecar = false;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = true;
+    Boolean sidecar = false;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() {}
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerMonitoringDaemonService.java
@@ -33,10 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -82,7 +79,7 @@ abstract public class SpinnakerMonitoringDaemonService extends SpinnakerService<
     List<Profile> results = new ArrayList<>();
     for (Map.Entry<Type, ServiceSettings> entry : endpoints.getAllServiceSettings().entrySet()) {
       ServiceSettings settings = entry.getValue();
-      if (settings.isMonitored() && settings.isEnabled()) {
+      if (settings.getMonitored() && settings.getEnabled()) {
         String serviceName = entry.getKey().getCanonicalName();
         String profileName = serviceRegistryProfileName(serviceName);
         String profilePath = Paths.get(REGISTRY_OUTPUT_PATH, serviceName + ".yml").toString();
@@ -117,15 +114,17 @@ abstract public class SpinnakerMonitoringDaemonService extends SpinnakerService<
   @EqualsAndHashCode(callSuper = true)
   @Data
   public class Settings extends ServiceSettings {
-    int port = 8008;
+    Integer port = 8008;
     String address = "localhost";
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = false;
-    boolean sidecar = true;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = false;
+    Boolean sidecar = true;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerServiceProvider.java
@@ -39,7 +39,9 @@ abstract public class SpinnakerServiceProvider<D extends DeploymentDetails> {
       SpinnakerService service = getSpinnakerService(type);
       if (service != null) {
         log.info("Building service settings entry for " + service.getServiceName());
-        ServiceSettings settings = service.buildServiceSettings(deploymentConfiguration);
+        ServiceSettings settings = service.getDefaultServiceSettings(deploymentConfiguration);
+        settings.mergePreferThis(service.buildServiceSettings(deploymentConfiguration));
+
         endpoints.setServiceSettings(type, settings);
       }
     }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpringServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpringServiceSettings.java
@@ -21,6 +21,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang.RandomStringUtils;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -34,14 +35,10 @@ abstract public class SpringServiceSettings extends ServiceSettings {
 
     String key = "SPRING_PROFILES_ACTIVE";
     String val = profiles.stream().collect(Collectors.joining(","));
-    env.put(key, val);
+    getEnv().put(key, val);
   }
 
   SpringServiceSettings() {}
-
-  SpringServiceSettings(List<String> profiles) {
-    setProfiles(profiles);
-  }
 
   public void enableAuth() {
     setBasicAuthEnabled(true);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/VaultClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/VaultClientService.java
@@ -28,10 +28,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -62,10 +59,11 @@ abstract public class VaultClientService extends SpinnakerService<VaultClientSer
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends ServiceSettings {
-    boolean enabled = true;
-    boolean safeToUpdate = true;
-    boolean monitored = false;
-    boolean sidecar = true;
+    Boolean enabled = true;
+    Boolean safeToUpdate = true;
+    Boolean monitored = false;
+    Boolean sidecar = true;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() { }
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/VaultServerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/VaultServerService.java
@@ -41,9 +41,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -225,12 +223,14 @@ abstract public class VaultServerService extends SpinnakerService<VaultServerSer
   @EqualsAndHashCode(callSuper = true)
   @Data
   public static class Settings extends ServiceSettings {
-    int port = 8200;
+    Integer port = 8200;
 
-    boolean enabled = true;
-    boolean safeToUpdate = false;
-    boolean monitored = false;
-    boolean sidecar = true;
+    Boolean enabled = true;
+    Boolean safeToUpdate = false;
+    Boolean monitored = false;
+    Boolean sidecar = true;
+    Integer targetSize = 1;
+    Map<String, String> env = new HashMap<>();
 
     public Settings() { }
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianServiceProvider.java
@@ -94,7 +94,7 @@ public class BakeDebianServiceProvider extends BakeServiceProvider {
     List<String> serviceNames = new ArrayList<>(installCommands.keySet());
     List<String> upstartNames = getPrioritizedBakeableServices(serviceNames)
         .stream()
-        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).isEnabled())
+        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).getEnabled())
         .map(i -> ((BakeDebianService) i).getUpstartServiceName())
         .filter(Objects::nonNull)
         .collect(Collectors.toList());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedService.java
@@ -98,8 +98,9 @@ public interface KubernetesDistributedService<T> extends DistributedService<T, K
   }
 
   @Override
-  default Map<String, Object> buildRollbackPipeline(AccountDeploymentDetails<KubernetesAccount> details, ServiceSettings settings) {
-    Map<String, Object> pipeline = DistributedService.super.buildRollbackPipeline(details, settings);
+  default Map<String, Object> buildRollbackPipeline(AccountDeploymentDetails<KubernetesAccount> details, SpinnakerRuntimeSettings runtimeSettings) {
+    ServiceSettings settings = runtimeSettings.getServiceSettings(getService());
+    Map<String, Object> pipeline = DistributedService.super.buildRollbackPipeline(details, runtimeSettings);
 
     List<Map<String, Object>> stages = (List<Map<String, Object>>) pipeline.get("stages");
     assert(stages != null && !stages.isEmpty());
@@ -282,7 +283,7 @@ public interface KubernetesDistributedService<T> extends DistributedService<T, K
     containers.add(container);
 
     ServiceSettings monitoringSettings = runtimeSettings.getServiceSettings(monitoringService);
-    if (monitoringSettings.isEnabled() && serviceSettings.isMonitored()) {
+    if (monitoringSettings.getEnabled() && serviceSettings.getMonitored()) {
       serviceSettings = runtimeSettings.getServiceSettings(monitoringService);
       container = buildContainer(monitoringService.getServiceName(), serviceSettings, configSources, size);
       containers.add(container);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianServiceProvider.java
@@ -76,7 +76,7 @@ public class LocalDebianServiceProvider extends LocalServiceProvider {
     List<String> serviceNames = new ArrayList<>(installCommands.keySet());
     List<String> upstartNames = getLocalServices(serviceNames)
         .stream()
-        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).isEnabled())
+        .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()).getEnabled())
         .map(i -> ((LocalDebianService) i).getUpstartServiceName())
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
@@ -104,7 +104,7 @@ public class LocalDebianServiceProvider extends LocalServiceProvider {
   public RemoteAction clean(DeploymentDetails details, SpinnakerRuntimeSettings runtimeSettings) {
     String uninstallArtifacts = String.join("\n", getServices()
         .stream()
-        .filter(s -> s != null && runtimeSettings.getServiceSettings(s).isEnabled())
+        .filter(s -> s != null && runtimeSettings.getServiceSettings(s).getEnabled())
         .map(s -> ((LocalDebianService) s).uninstallArtifactCommand())
         .collect(Collectors.toList()));
 


### PR DESCRIPTION
Documentation in the github.io repo incoming.

This applies to runtime settings like which port a service is deployed on, or what address they should bind to.