### PR TITLE
feat(deploy): Multi VM monitoring

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianMonitoringDaemonService.java
@@ -18,6 +18,7 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
@@ -36,6 +37,7 @@ import java.util.List;
 @Component
 public class BakeDebianMonitoringDaemonService extends SpinnakerMonitoringDaemonService implements BakeDebianService<SpinnakerMonitoringDaemonService.SpinnakerMonitoringDaemon> {
   final String upstartServiceName = "spinnaker-monitoring";
+  final String pipRequirementsFile = "/opt/spinnaker-monitoring/requirements.txt";
 
   @Autowired
   ArtifactService artifactService;
@@ -51,6 +53,15 @@ public class BakeDebianMonitoringDaemonService extends SpinnakerMonitoringDaemon
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
     return new Settings().setArtifactId(getArtifactId(deploymentConfiguration.getName()))
         .setEnabled(true);
+  }
+
+  @Override
+  public String installArtifactCommand(DeploymentDetails deploymentDetails) {
+    String installCommand = BakeDebianService.super.installArtifactCommand(deploymentDetails);
+    return String.join("\n", installCommand,
+        "sed -i -e 's/#@ //g' " + pipRequirementsFile,
+        "pip install " + pipRequirementsFile
+        );
   }
 
   public String getArtifactId(String deploymentName) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
@@ -416,7 +416,7 @@ public interface GoogleDistributedService<T> extends DistributedService<T, Googl
     deployDescription.put("stack", stack);
     deployDescription.put("freeFormDetails", detail);
     deployDescription.put("network", network);
-    deployDescription.put("metadata", metadata);
+    deployDescription.put("instanceMetadata", metadata);
     deployDescription.put("serviceAccountEmail", serviceAccountEmail);
     deployDescription.put("authScopes", scopes);
     deployDescription.put("accountName", accountName);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesMonitoringDaemonService.java
@@ -20,7 +20,6 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.KubernetesUtil;
 import com.netflix.spinnaker.clouddriver.kubernetes.deploy.description.servergroup.KubernetesImageDescription;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerMonitoringDaemonService;
 import lombok.Data;
 import lombok.EqualsAndHashCode;


### PR DESCRIPTION
This isn't complete, since the monitoring config folder isn't pointing at the expected /opt/spinnaker-monitoring/config/, but instead /opt/spinnaker-monitoring making it difficult for k8s to mount spinnaker-monitoring.yml. This will either take change to spinnaker/spinnaker-monitoring or the config mounting in halyard. I'm talking to @ewiseblatt about it.