### PR TITLE
feat(validation): Add validation for AWS accounts and S3

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@
 Netflix, Inc <*@netflix.com>
 Google, Inc <*@google.com>
 Microsoft, Inc <*@microsoft.com>
+Schibsted ASA <*@schibsted.com>

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,4 +1,4 @@
-_Version: 0.21.0-SNAPSHOT_
+_Version: 0.24.0-SNAPSHOT_
 
 # Table of Contents
 
@@ -2823,8 +2823,9 @@ Edit configuration for the "s3" persistent store.
 hal config storage s3 edit [parameters]
 ```
 #### Parameters
- * `--bucket`: The name of a storage bucket that your specified account has access to.
+ * `--bucket`: The name of a storage bucket that your specified account has access to. If not specified, a random name will be chosen. If you specify a globally unique bucket name that doesn't exist yet, Halyard will create that bucket for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--region`: This is only required if the bucket you specify doesn't exist yet. In that case, the bucket will be created in that region. See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
  * `--root-folder`: (*Default*: `spinnaker`) The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
@@ -19,8 +19,11 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.s3
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.AbstractPersistentStoreEditCommand;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3PersistentStore;
+
+import java.util.UUID;
 
 @Parameters(separators = "=")
 public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3PersistentStore> {
@@ -29,21 +32,37 @@ public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3Persiste
   }
 
   @Parameter(
-      names = "--bucket",
-      description = "The name of a storage bucket that your specified account has access to."
+    names = "--bucket",
+    description = "The name of a storage bucket that your specified account has access to. If not "
+      + "specified, a random name will be chosen. If you specify a globally unique bucket name "
+      + "that doesn't exist yet, Halyard will create that bucket for you."
   )
   private String bucket;
 
   @Parameter(
-      names = "--root-folder",
-      description = "The root folder in the chosen bucket to place all of Spinnaker's persistent data in."
+    names = "--root-folder",
+    description = "The root folder in the chosen bucket to place all of Spinnaker's persistent data in."
   )
   private String rootFolder = "spinnaker";
+
+  @Parameter(
+    names = "--region",
+    description = "This is only required if the bucket you specify doesn't exist yet. In that case, the "
+      + "bucket will be created in that region. See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region."
+  )
+  private String region;
 
   @Override
   protected S3PersistentStore editPersistentStore(S3PersistentStore persistentStore) {
     persistentStore.setBucket(isSet(bucket) ? bucket : persistentStore.getBucket());
     persistentStore.setRootFolder(isSet(rootFolder) ? rootFolder : persistentStore.getRootFolder());
+    persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());
+
+    if (persistentStore.getBucket() == null) {
+      String bucketName = "spin-" + UUID.randomUUID().toString();
+      AnsiUi.raw("Generated bucket name: " + bucketName);
+      persistentStore.setBucket(bucketName);
+    }
 
     return persistentStore;
   }

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -6,8 +6,8 @@ dependencies {
   compile spinnaker.dependency('clouddriverAzure')
   compile spinnaker.dependency('clouddriverOpenstack')
   compile spinnaker.dependency('front50Gcs')
-  compile spinnaker.dependency('front50S3')
-
+  compile 'com.netflix.spinnaker.front50:front50-s3:1.95.0'
+//  compile spinnaker.dependency('front50S3')
 
   compile project(':halyard-core')
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
@@ -27,6 +27,7 @@ import lombok.EqualsAndHashCode;
 public class S3PersistentStore extends PersistentStore {
   private String bucket;
   private String rootFolder;
+  private String region;
 
   @Override
   public PersistentStoreType persistentStoreType() {


### PR DESCRIPTION
#116: Add validation for AWS accounts and S3 persistent storage. The S3 bucket validation will create the bucket if it does not exist (this makes the S3 validation behave in the same way as the GCS validation).