### PR TITLE
feat(oraclebmcs): Add Oracle BMCS persistent storage configuration

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -169,6 +169,8 @@ _Version: 0.21.0-SNAPSHOT_
  * [**hal config storage edit**](#hal-config-storage-edit)
  * [**hal config storage gcs**](#hal-config-storage-gcs)
  * [**hal config storage gcs edit**](#hal-config-storage-gcs-edit)
+ * [**hal config storage oraclebmcs**](#hal-config-storage-oraclebmcs)
+ * [**hal config storage oraclebmcs edit**](#hal-config-storage-oraclebmcs-edit)
  * [**hal config storage s3**](#hal-config-storage-s3)
  * [**hal config storage s3 edit**](#hal-config-storage-s3-edit)
  * [**hal config version**](#hal-config-version)
@@ -2661,6 +2663,7 @@ hal config storage [parameters] [subcommands]
  * `azs`: Manage and view Spinnaker configuration for the "azs" persistent store.
  * `edit`: Edit Spinnaker's persistent storage.
  * `gcs`: Manage and view Spinnaker configuration for the "gcs" persistent store.
+ * `oraclebmcs`: Manage and view Spinnaker configuration for the "oraclebmcs" persistent store.
  * `s3`: Manage and view Spinnaker configuration for the "s3" persistent store.
 
 ---
@@ -2735,6 +2738,40 @@ hal config storage gcs edit [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: The Google Cloud Platform project you are using to host the GCS bucket as a backing store.
  * `--root-folder`: (*Default*: `spinnaker`) The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
+
+---
+## hal config storage oraclebmcs
+
+Manage and view Spinnaker configuration for the "oraclebmcs" persistent store.
+
+#### Usage
+```
+hal config storage oraclebmcs [parameters] [subcommands]
+```
+#### Parameters
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+#### Subcommands
+ * `edit`: Edit configuration for the "oraclebmcs" persistent store.
+
+---
+## hal config storage oraclebmcs edit
+
+Edit configuration for the "oraclebmcs" persistent store.
+
+#### Usage
+```
+hal config storage oraclebmcs edit [parameters]
+```
+#### Parameters
+ * `--bucketName`: The bucket name to store persistent state object in
+ * `--compartment-id`: Provide the OCID of the Oracle BMCS Compartment to use.
+ * `--fingerprint`: Fingerprint of the public key
+ * `--namespace`: The namespace the bucket and objects should be created in
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--region`: An Oracle BMCS region (e.g., us-phoenix-1)
+ * `--ssh-private-key-file-path`: Path to the private key in PEM format
+ * `--tenancy-id`: Provide the OCID of the Oracle BMCS Tenancy to use.
+ * `--user-id`: Provide the OCID of the Oracle BMCS User you're authenticating as
 
 ---
 ## hal config storage s3

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
@@ -20,6 +20,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.EditPersistentStorageCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.azs.AzsCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.gcs.GcsCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.oraclebmcs.OracleBMCSCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.s3.S3Command;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
@@ -40,6 +41,7 @@ public class PersistentStorageCommand extends AbstractConfigCommand {
     registerSubcommand(new GcsCommand());
     registerSubcommand(new S3Command());
     registerSubcommand(new AzsCommand());
+    registerSubcommand(new OracleBMCSCommand());
     registerSubcommand(new EditPersistentStorageCommand());
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/oraclebmcs/OracleBMCSCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/oraclebmcs/OracleBMCSCommand.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.oraclebmcs;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.AbstractNamedPersistentStoreCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
+
+@Parameters(separators = "=")
+public class OracleBMCSCommand extends AbstractNamedPersistentStoreCommand {
+  protected String getPersistentStoreType() {
+    return PersistentStore.PersistentStoreType.ORACLEBMCS.getId();
+  }
+
+  public OracleBMCSCommand() {
+    super();
+    registerSubcommand(new OracleBMCSEditCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/oraclebmcs/OracleBMCSEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/oraclebmcs/OracleBMCSEditCommand.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.oraclebmcs;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.AbstractPersistentStoreEditCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.oraclebmcs.OracleBMCSCommandProperties;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
+import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.OracleBMCSPersistentStore;
+
+@Parameters(separators = "=")
+public class OracleBMCSEditCommand extends AbstractPersistentStoreEditCommand<OracleBMCSPersistentStore> {
+  protected String getPersistentStoreType() {
+    return PersistentStore.PersistentStoreType.ORACLEBMCS.getId();
+  }
+
+  @Parameter(
+          names = "--compartment-id",
+          description = OracleBMCSCommandProperties.COMPARTMENT_ID_DESCRIPTION
+  )
+  private String compartmentId;
+
+  @Parameter(
+          names = "--user-id",
+          description = OracleBMCSCommandProperties.USER_ID_DESCRIPTION
+  )
+  private String userId;
+
+  @Parameter(
+          names = "--fingerprint",
+          description = OracleBMCSCommandProperties.FINGERPRINT_DESCRIPTION
+  )
+  private String fingerprint;
+
+  @Parameter(
+          names = "--ssh-private-key-file-path",
+          converter = PathExpandingConverter.class,
+          description = OracleBMCSCommandProperties.SSH_PRIVATE_KEY_FILE_PATH_DESCRIPTION
+  )
+  private String sshPrivateKeyFilePath;
+
+  @Parameter(
+          names = "--tenancy-id",
+          description = OracleBMCSCommandProperties.TENANCY_ID_DESCRIPTION
+  )
+  private String tenancyId;
+
+  @Parameter(
+          names = "--region",
+          description = OracleBMCSCommandProperties.REGION_DESCRIPTION
+  )
+  private String region;
+
+  @Parameter(
+          names = "--bucket-name",
+          description = "The bucket name to store persistent state object in"
+  )
+  private String bucketName;
+
+  @Parameter(
+          names = "--namespace",
+          description = "The namespace the bucket and objects should be created in"
+  )
+  private String namespace;
+
+  @Override
+  protected OracleBMCSPersistentStore editPersistentStore(OracleBMCSPersistentStore persistentStore) {
+    persistentStore.setCompartmentId(isSet(compartmentId) ? compartmentId : persistentStore.getCompartmentId());
+    persistentStore.setUserId(isSet(userId) ? userId : persistentStore.getUserId());
+    persistentStore.setFingerprint(isSet(fingerprint) ? fingerprint : persistentStore.getFingerprint());
+    persistentStore.setSshPrivateKeyFilePath(isSet(sshPrivateKeyFilePath) ? sshPrivateKeyFilePath : persistentStore.getSshPrivateKeyFilePath());
+    persistentStore.setTenancyId(isSet(tenancyId) ? tenancyId : persistentStore.getTenancyId());
+    persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());
+    persistentStore.setBucketName(isSet(bucketName) ? bucketName : persistentStore.getBucketName());
+    persistentStore.setNamespace(isSet(namespace) ? namespace : persistentStore.getNamespace());
+
+    return persistentStore;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oraclebmcs/OracleBMCSCommandProperties.java
@@ -10,7 +10,7 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.oraclebmcs;
 
 public class OracleBMCSCommandProperties {
-  static final String COMPARTMENT_ID_DESCRIPTION = "Provide the OCID of the Oracle BMCS Compartment to use.";
+  public static final String COMPARTMENT_ID_DESCRIPTION = "Provide the OCID of the Oracle BMCS Compartment to use.";
   public static final String USER_ID_DESCRIPTION = "Provide the OCID of the Oracle BMCS User you're authenticating as";
   public static final String FINGERPRINT_DESCRIPTION = "Fingerprint of the public key";
   public static final String SSH_PRIVATE_KEY_FILE_PATH_DESCRIPTION = "Path to the private key in PEM format";

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/PersistentStorage.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/PersistentStorage.java
@@ -1,9 +1,6 @@
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
-import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.AzsPersistentStore;
-import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.GcsPersistentStore;
-import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.RedisPersistentStore;
-import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3PersistentStore;
+import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.*;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -20,6 +17,7 @@ public class PersistentStorage extends Node {
   GcsPersistentStore gcs = new GcsPersistentStore();
   RedisPersistentStore redis = new RedisPersistentStore();
   S3PersistentStore s3 = new S3PersistentStore();
+  OracleBMCSPersistentStore oraclebmcs = new OracleBMCSPersistentStore();
 
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/PersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/PersistentStore.java
@@ -52,7 +52,8 @@ public abstract class PersistentStore extends Node {
     AZS("azs"),
     GCS("gcs"),
     REDIS("redis"),
-    S3("s3");
+    S3("s3"),
+    ORACLEBMCS("oraclebmcs");
 
     String id;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/OracleBMCSPersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/OracleBMCSPersistentStore.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.persistentStorage;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class OracleBMCSPersistentStore extends PersistentStore {
+
+  private String bucketName;
+
+  @NotNull
+  @Size(min = 1)
+  private String namespace;
+
+  @NotNull
+  @Size(min = 1)
+  private String compartmentId;
+
+  private String region;
+
+  @NotNull
+  @Size(min = 1)
+  private String userId;
+
+  @NotNull
+  @Size(min = 1)
+  private String fingerprint;
+
+  @NotNull
+  @LocalFile
+  @Size(min = 1)
+  private String sshPrivateKeyFilePath;
+
+  @NotNull
+  @Size(min = 1)
+  private String tenancyId;
+
+  @Override
+  public PersistentStoreType persistentStoreType() {
+    return PersistentStoreType.ORACLEBMCS;
+  }
+
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/PersistentStorageService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/PersistentStorageService.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStorage;
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.AzsPersistentStore;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.GcsPersistentStore;
+import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.OracleBMCSPersistentStore;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3PersistentStore;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
@@ -96,6 +97,9 @@ public class PersistentStorageService {
         break;
       case AZS:
         persistentStorage.setAzs((AzsPersistentStore) newPersistentStore);
+        break;
+      case ORACLEBMCS:
+        persistentStorage.setOraclebmcs((OracleBMCSPersistentStore) newPersistentStore);
         break;
       default:
         throw new RuntimeException("Unknown persistent store " + newPersistentStore.persistentStoreType());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/OracleBMCSValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/OracleBMCSValidator.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017 Oracle America, Inc.
+ *
+ * The contents of this file are subject to the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * If a copy of the Apache License Version 2.0 was not distributed with this file,
+ * You can obtain one at https://www.apache.org/licenses/LICENSE-2.0.html
+ */
+
+package com.netflix.spinnaker.halyard.config.validate.v1.persistentStorage;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.OracleBMCSPersistentStore;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Pattern;
+
+@Component
+public class OracleBMCSValidator extends Validator<OracleBMCSPersistentStore> {
+
+  // https://docs.us-phoenix-1.oraclecloud.com/Content/Object/Tasks/managingbuckets.htm
+  private static final String BUCKET_REGEX = "[a-zA-Z0-9\\-_\\.]{1,63}+";
+  private static final List<String> REGIONS = Arrays.asList("us-phoenix-1");
+
+  @Override
+  public void validate(ConfigProblemSetBuilder psBuilder, OracleBMCSPersistentStore oracleBMCSPersistentStore) {
+    notNullOrEmpty(oracleBMCSPersistentStore.getCompartmentId(), "compartment id", psBuilder);
+    notNullOrEmpty(oracleBMCSPersistentStore.getUserId(), "user id", psBuilder);
+    notNullOrEmpty(oracleBMCSPersistentStore.getFingerprint(), "fingerprint", psBuilder);
+    notNullOrEmpty(oracleBMCSPersistentStore.getSshPrivateKeyFilePath(), "ssh private key file path", psBuilder);
+    notNullOrEmpty(oracleBMCSPersistentStore.getTenancyId(), "tenancy id", psBuilder);
+    notNullOrEmpty(oracleBMCSPersistentStore.getNamespace(), "namespace", psBuilder);
+
+    // region and bucketName *can* be null/empty - they then get defaulted in front50 code
+
+    if (oracleBMCSPersistentStore.getRegion() != null && !oracleBMCSPersistentStore.getRegion().isEmpty() && !REGIONS.contains(oracleBMCSPersistentStore.getRegion())) {
+      psBuilder.addProblem(Severity.ERROR, "the region is invalid");
+    }
+
+    if (oracleBMCSPersistentStore.getBucketName() != null && !oracleBMCSPersistentStore.getBucketName().isEmpty()) {
+      boolean bucketNameValid = Pattern.matches(BUCKET_REGEX, oracleBMCSPersistentStore.getBucketName());
+      if (!bucketNameValid) {
+        psBuilder.addProblem(Severity.ERROR, "bucket name is invalid");
+      }
+    }
+
+    // TODO (simonlord): Once BMCS SDK is in maven we can access via spinnaker.dependency("clouddriverOracleBmcs") and test ensureBucket (a la GCS)
+  }
+
+  private void notNullOrEmpty(String param, String paramName, ConfigProblemSetBuilder psBuilder) {
+    if (param == null || param.isEmpty()) {
+      psBuilder.addProblem(Severity.FATAL, "You must provide a " + paramName);
+    }
+  }
+}


### PR DESCRIPTION
This adds support to Halyard for configuring front50 to use Oracle's Object Storage Service.