### PR TITLE
feat(logs): Collect service logs

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -178,6 +178,7 @@ _Version: 0.21.0-SNAPSHOT_
  * [**hal deploy**](#hal-deploy)
  * [**hal deploy apply**](#hal-deploy-apply)
  * [**hal deploy clean**](#hal-deploy-clean)
+ * [**hal deploy collect-logs**](#hal-deploy-collect-logs)
  * [**hal deploy connect**](#hal-deploy-connect)
  * [**hal deploy details**](#hal-deploy-details)
  * [**hal deploy diff**](#hal-deploy-diff)
@@ -2841,6 +2842,7 @@ hal deploy [subcommands]
 #### Subcommands
  * `apply`: Deploy or update the currently configured instance of Spinnaker to a selected environment.
  * `clean`: Remove all Spinnaker artifacts in your target deployment environment.
+ * `collect-logs`: Collect logs from the specified Spinnaker services.
  * `connect`: Connect to your Spinnaker deployment.
  * `details`: Get details about your currently deployed Spinnaker installation.
  * `diff`: This shows what changes you have made since Spinnaker was last deployed.
@@ -2876,6 +2878,19 @@ hal deploy clean [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 ---
+## hal deploy collect-logs
+
+This command collects logs from all Spinnaker services, and depending on how it was deployed, it will collect logs from sidecars and startup scripts as well.
+
+#### Usage
+```
+hal deploy collect-logs [parameters]
+```
+#### Parameters
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--service-names`: (*Default*: `[]`) When supplied, logs from only the specified services will be collected.
+
+---
 ## hal deploy connect
 
 This command connects to your Spinnaker deployment, assuming it was already deployed. In the case of the `Local*` deployment type, this is a NoOp.
@@ -2887,7 +2902,7 @@ hal deploy connect [parameters]
 #### Parameters
  * `--auto-run`: This command will generate a script to be run on your behalf. By default, the script will run without intervention - if you want to override this, provide "true" or "false" to this flag.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--service-names`: (*Default*: `[]`) When supplied, connect to the specified Spinnaker services. When supplied, connections to the UI & API servers are opened.
+ * `--service-names`: (*Default*: `[]`) When supplied, connections to the specified Spinnaker services are opened. When omitted, connections to the UI & API servers are opened to allow you to interact with Spinnaker in your browser.
 
 ---
 ## hal deploy details

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/DeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/DeployCommand.java
@@ -32,6 +32,7 @@ public class DeployCommand extends NestableCommand {
 
   public DeployCommand() {
     registerSubcommand(new ApplyDeployCommand());
+    registerSubcommand(new CollectLogsDeployCommand());
     registerSubcommand(new ConnectDeployCommand());
     registerSubcommand(new RollbackDeployCommand());
     registerSubcommand(new DiffDeployCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/CollectLogsDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/CollectLogsDeployCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.deploy;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Parameters(separators = "=")
+public class CollectLogsDeployCommand extends AbstractConfigCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "collect-logs";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Collect logs from the specified Spinnaker services.";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String longDescription = "This command collects logs from all Spinnaker services, and depending on how it was deployed, it will "
+      + "collect logs from sidecars and startup scripts as well.";
+
+  @Parameter(
+      names = "--service-names",
+      description = "When supplied, logs from only the specified services will be collected.",
+      variableArity = true
+  )
+  List<String> serviceNames = new ArrayList<>();
+
+  @Override
+  protected void executeThis() {
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to collect logs from Spinnaker.")
+        .setSuccessMessage("Succesfully collected service logs.")
+        .setOperation(Daemon.collectLogs(getCurrentDeployment(), !noValidate, serviceNames))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -288,6 +288,13 @@ public class Daemon {
     };
   }
 
+  public static Supplier<Void> collectLogs(String deploymentName, boolean validate, List<String> serviceNames) {
+    return () -> {
+      ResponseUnwrapper.get(getService().collectLogs(deploymentName, validate, serviceNames, ""));
+      return null;
+    };
+  }
+
   public static Supplier<Void> cleanDeployment(String deploymentName, boolean validate) {
     return () -> {
       ResponseUnwrapper.get(getService().cleanDeployment(deploymentName, validate, ""));

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -91,6 +91,13 @@ public interface DaemonService {
       @Query("serviceNames") List<String> serviceNames,
       @Body String _ignore);
 
+  @PUT("/v1/config/deployments/{deploymentName}/collectLogs/")
+  DaemonTask<Halconfig, Object> collectLogs(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Query("serviceNames") List<String> serviceNames,
+      @Body String _ignore);
+
   @POST("/v1/config/deployments/{deploymentName}/clean/")
   DaemonTask<Halconfig, Object> cleanDeployment(
       @Path("deploymentName") String deploymentName,

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
@@ -32,8 +32,18 @@ public class HalconfigDirectoryStructure {
   @Autowired
   String halconfigDirectory;
 
+  public Path getLogsPath(String deploymentName) {
+    return ensureRelativeHalDirectory(deploymentName, "service-logs");
+  }
+
   public Path getUserProfilePath(String deploymentName) {
     return ensureRelativeHalDirectory(deploymentName, "profiles");
+  }
+
+  public Path getServiceLogsPath(String deploymentName, String hostname, String serviceName) {
+    Path halconfigPath = Paths.get(getLogsPath(deploymentName).toString(), hostname, serviceName);
+    ensureDirectory(halconfigPath);
+    return halconfigPath;
   }
 
   public Path getUserServiceSettingsPath(String deploymentName) {
@@ -93,7 +103,7 @@ public class HalconfigDirectoryStructure {
     return path;
   }
 
-  private Path ensureDirectory(Path path) {
+  public Path ensureDirectory(Path path) {
     File file = path.toFile();
     if (file.exists()) {
       if (!file.isDirectory()) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/BakeDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/BakeDeployer.java
@@ -79,6 +79,11 @@ public class BakeDeployer implements Deployer<BakeServiceProvider, DeploymentDet
   }
 
   @Override
+  public void collectLogs(BakeServiceProvider serviceProvider, DeploymentDetails deploymentDetails, SpinnakerRuntimeSettings runtimeSettings, List<SpinnakerService.Type> serviceTypes) {
+    throw new HalException(Problem.Severity.FATAL, "This type of deployment does not generate logs that can be collected.");
+  }
+
+  @Override
   public RemoteAction connectCommand(BakeServiceProvider serviceProvider, DeploymentDetails deploymentDetails, SpinnakerRuntimeSettings runtimeSettings, List<SpinnakerService.Type> serviceTypes) {
     throw new HalException(Problem.Severity.FATAL, "This type of deployment cannot be run or connected to.");
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployer.java
@@ -38,6 +38,12 @@ public interface Deployer<S extends SpinnakerServiceProvider<D>, D extends Deplo
       SpinnakerRuntimeSettings runtimeSettings,
       List<SpinnakerService.Type> serviceTypes);
 
+  void collectLogs(
+      S serviceProvider,
+      D deploymentDetails,
+      SpinnakerRuntimeSettings runtimeSettings,
+      List<SpinnakerService.Type> serviceTypes);
+
   RemoteAction connectCommand(
       S serviceProvider,
       D deploymentDetails,

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalDeployer.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSetting
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalServiceProvider;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -32,6 +33,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Component
+@Slf4j
 public class LocalDeployer implements Deployer<LocalServiceProvider, DeploymentDetails> {
   @Override
   public RemoteAction deploy(
@@ -69,6 +71,13 @@ public class LocalDeployer implements Deployer<LocalServiceProvider, DeploymentD
       SpinnakerRuntimeSettings runtimeSettings,
       List<SpinnakerService.Type> serviceTypes) {
     throw new HalException(Problem.Severity.FATAL, "No support for rolling back debian deployments yet.");
+  }
+
+  @Override
+  public void collectLogs(LocalServiceProvider serviceProvider, DeploymentDetails deploymentDetails, SpinnakerRuntimeSettings runtimeSettings, List<SpinnakerService.Type> serviceTypes) {
+    for (LocalService localService : serviceProvider.getLocalServices(serviceTypes)) {
+      localService.collectLogs(deploymentDetails, runtimeSettings);
+    }
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/DefaultLogCollector.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/DefaultLogCollector.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
+
+abstract public class DefaultLogCollector<T, D extends DeploymentDetails> implements LogCollector<T, D> {
+  final HasServiceSettings<T> service;
+
+  public DefaultLogCollector(HasServiceSettings<T> service) {
+    this.service = service;
+  }
+
+  @Override
+  public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
+    return service.buildServiceSettings(deploymentConfiguration);
+  }
+
+  @Override
+  public ServiceSettings getDefaultServiceSettings(DeploymentConfiguration deploymentConfiguration) {
+    return service.getDefaultServiceSettings(deploymentConfiguration);
+  }
+
+  @Override
+  public SpinnakerService<T> getService() {
+    return service.getService();
+  }
+
+  @Override
+  public SpinnakerArtifact getArtifact() {
+    return service.getArtifact();
+  }
+
+  @Override
+  public String getServiceName() {
+    return service.getServiceName();
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/LogCollector.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/LogCollector.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
+
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+
+public interface LogCollector<T, D extends DeploymentDetails> extends HasServiceSettings<T> {
+  void collectLogs(D details, SpinnakerRuntimeSettings runtimeSettings);
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianMonitoringDaemonService.java
@@ -61,7 +61,7 @@ public class BakeDebianMonitoringDaemonService extends SpinnakerMonitoringDaemon
     return String.join("\n", installCommand,
         "sed -i -e 's/#@ //g' " + pipRequirementsFile,
         "pip install -r " + pipRequirementsFile
-        );
+    );
   }
 
   public String getArtifactId(String deploymentName) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedLogCollector.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedLogCollector.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DefaultLogCollector;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+
+import java.io.File;
+
+abstract public class DistributedLogCollector<T, A extends Account> extends DefaultLogCollector<T, AccountDeploymentDetails<A>> {
+  public DistributedLogCollector(HasServiceSettings<T> service) {
+    super(service);
+  }
+
+  abstract protected HalconfigDirectoryStructure getDirectoryStructure();
+
+  @Override
+  public void collectLogs(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings) {
+    DistributedService<T, A> distributedService = (DistributedService<T, A>) getService();
+    RunningServiceDetails runningServiceDetails = distributedService.getRunningServiceDetails(details, runtimeSettings);
+    runningServiceDetails.getInstances().values().forEach(is -> is.stream()
+        .filter(RunningServiceDetails.Instance::isRunning)
+        .forEach(i -> {
+          File outputDir = getDirectoryStructure().getServiceLogsPath(
+              details.getDeploymentName(),
+              i.getId(),
+              getService().getCanonicalName()).toFile();
+          collectInstanceLogs(details, runtimeSettings, outputDir, i.getId());
+        })
+    );
+  }
+
+  abstract protected void collectInstanceLogs(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings, File instanceOutputDir, String instanceId);
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedService.java
@@ -50,7 +50,6 @@ public interface DistributedService<T, A extends Account> extends HasServiceSett
       List<ConfigSource> configSources,
       boolean recreate);
 
-
   List<String> getHealthProviders();
   Map<String, List<String>> getAvailabilityZones(ServiceSettings settings);
   Provider.ProviderType getProviderType();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedLogCollectorFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedLogCollectorFactory.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.google;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleAccount;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@Component
+public class GoogleDistributedLogCollectorFactory {
+  public <T> LogCollector build(HasServiceSettings<T> service) {
+    return new GoogleDistributedLogCollector<>(service);
+  }
+
+  @Autowired
+  HalconfigDirectoryStructure directoryStructure;
+
+  private class GoogleDistributedLogCollector<T> extends DistributedLogCollector<T, GoogleAccount> {
+    GoogleDistributedLogCollector(HasServiceSettings<T> service) {
+      super(service);
+    }
+
+    @Override
+    protected HalconfigDirectoryStructure getDirectoryStructure() {
+      return directoryStructure;
+    }
+
+    @Override
+    protected void collectInstanceLogs(
+        AccountDeploymentDetails<GoogleAccount> details,
+        SpinnakerRuntimeSettings runtimeSettings,
+        File instanceOutputDir,
+        String instanceId) {
+      throw new HalException(Problem.Severity.FATAL, "Not yet implemented.");
+    }
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverBootstrapService.java
@@ -20,6 +20,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverBootstrapService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -36,6 +38,11 @@ public class KubernetesClouddriverBootstrapService extends ClouddriverBootstrapS
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverService.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -32,6 +34,11 @@ public class KubernetesClouddriverService extends ClouddriverService implements 
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDeckService.java
@@ -22,6 +22,8 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSetting
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.deck.DeckDockerProfileFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DeckService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -42,6 +44,11 @@ public class KubernetesDeckService extends DeckService implements KubernetesDist
 
   @Autowired
   DeckDockerProfileFactory deckDockerProfileFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedLogCollectorFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedLogCollectorFactory.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.SidecarService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+
+@Component
+public class KubernetesDistributedLogCollectorFactory {
+  public <T> DistributedLogCollector build(HasServiceSettings<T> service) {
+    return new KubernetesDistributedLogCollector<>(service);
+  }
+
+  @Autowired
+  HalconfigDirectoryStructure directoryStructure;
+
+  private class KubernetesDistributedLogCollector<T> extends DistributedLogCollector<T, KubernetesAccount> {
+    KubernetesDistributedLogCollector(HasServiceSettings<T> service) {
+      super(service);
+    }
+
+    @Override
+    protected HalconfigDirectoryStructure getDirectoryStructure() {
+      return directoryStructure;
+    }
+
+    @Override
+    protected void collectInstanceLogs(
+        AccountDeploymentDetails<KubernetesAccount> details,
+        SpinnakerRuntimeSettings runtimeSettings,
+        File instanceOutputDir,
+        String instanceId) {
+      DaemonTaskHandler.newStage("Reading " + getService().getCanonicalName() + " logs");
+      DaemonTaskHandler.message("Reading container " + getServiceName() + "'s logs");
+      KubernetesProviderUtils.storeInstanceLogs(
+          DaemonTaskHandler.getJobExecutor(),
+          details,
+          instanceId,
+          getServiceName(),
+          instanceOutputDir
+      );
+
+      DistributedService service = (DistributedService<T, KubernetesAccount>) getService();
+
+      for (Object rawSidecarService : service.getSidecars(runtimeSettings)) {
+        SidecarService sidecarService = (SidecarService) rawSidecarService;
+        String sidecarName = sidecarService.getService().getServiceName();
+        DaemonTaskHandler.message("Reading container " + sidecarName + "'s logs");
+        KubernetesProviderUtils.storeInstanceLogs(
+            DaemonTaskHandler.getJobExecutor(),
+            details,
+            instanceId,
+            sidecarName,
+            instanceOutputDir
+        );
+      }
+    }
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedService.java
@@ -39,19 +39,21 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails.I
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.*;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.SidecarService;
 import io.fabric8.kubernetes.api.model.*;
 import io.fabric8.kubernetes.api.model.extensions.ReplicaSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.utils.Strings;
+import lombok.experimental.Delegate;
 
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-public interface KubernetesDistributedService<T> extends DistributedService<T, KubernetesAccount> {
+public interface KubernetesDistributedService<T> extends DistributedService<T, KubernetesAccount>, LogCollector<T, AccountDeploymentDetails<KubernetesAccount>> {
   String getDockerRegistry();
   ArtifactService getArtifactService();
   ServiceInterfaceFactory getServiceInterfaceFactory();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceDelegate.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceDelegate.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSources;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,6 +30,10 @@ import org.springframework.stereotype.Component;
 public class KubernetesDistributedServiceDelegate {
   @Autowired
   ArtifactSources artifactSources;
+
+  @Autowired
+  @Getter
+  KubernetesDistributedLogCollectorFactory logCollectorFactory;
 
   public String getDockerRegistry() {
     return artifactSources.getDockerRegistry();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesEchoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesEchoService.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.EchoService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -32,6 +34,11 @@ public class KubernetesEchoService extends EchoService implements KubernetesDist
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFiatService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFiatService.java
@@ -18,10 +18,9 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
-import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.FiatService;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -35,6 +34,12 @@ public class KubernetesFiatService extends FiatService implements KubernetesDist
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
+
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFront50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFront50Service.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.Front50Service;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -32,6 +34,11 @@ public class KubernetesFront50Service extends Front50Service implements Kubernet
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesGateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesGateService.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.GateService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -32,6 +34,11 @@ public class KubernetesGateService extends GateService implements KubernetesDist
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesIgorService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesIgorService.java
@@ -20,8 +20,11 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.IgorService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -35,6 +38,11 @@ public class KubernetesIgorService extends IgorService implements KubernetesDist
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaBootstrapService.java
@@ -18,8 +18,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaBootstrapService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -36,6 +38,11 @@ public class KubernetesOrcaBootstrapService extends OrcaBootstrapService impleme
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesOrcaService.java
@@ -18,7 +18,9 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -32,6 +34,11 @@ public class KubernetesOrcaService extends OrcaService implements KubernetesDist
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisBootstrapService.java
@@ -18,7 +18,9 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RedisBootstrapService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -33,6 +35,11 @@ public class KubernetesRedisBootstrapService extends RedisBootstrapService imple
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRedisService.java
@@ -26,8 +26,10 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RedisService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -47,6 +49,11 @@ public class KubernetesRedisService extends RedisService implements KubernetesDi
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Jedis connectToPrimaryService(AccountDeploymentDetails<KubernetesAccount> details, SpinnakerRuntimeSettings runtimeSettings) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRoscoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesRoscoService.java
@@ -18,7 +18,9 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RoscoService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -32,6 +34,11 @@ public class KubernetesRoscoService extends RoscoService implements KubernetesDi
   @Delegate
   @Autowired
   KubernetesDistributedServiceDelegate distributedServiceDelegate;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  public DistributedLogCollector getLogCollector() {
+    return getLogCollectorFactory().build(this);
+  }
 
   @Override
   public Settings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/LocalLogCollectorFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/LocalLogCollectorFactory.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DefaultLogCollector;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.FileUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@Slf4j
+public class LocalLogCollectorFactory {
+  @Autowired
+  HalconfigDirectoryStructure directoryStructure;
+
+  public <T> LogCollector<T, DeploymentDetails> build(HasServiceSettings<T> service) {
+    return new LocalLogCollector<>(service);
+  }
+
+  public <T> LogCollector<T, DeploymentDetails> build(HasServiceSettings<T> service, String[] logPaths) {
+    return new LocalLogCollector<>(service, logPaths);
+  }
+
+  private class LocalLogCollector<T> extends DefaultLogCollector<T, DeploymentDetails> {
+    final List<Path> logPaths;
+
+    LocalLogCollector(HasServiceSettings<T> service) {
+      super(service);
+      this.logPaths = new ArrayList<>();
+      this.logPaths.add(Paths.get("/var/log/spinnaker/", getService().getCanonicalName()));
+      this.logPaths.add(Paths.get("/var/log/upstart/", getService().getCanonicalName() + ".log"));
+    }
+
+    LocalLogCollector(HasServiceSettings<T> service, String[] logPaths) {
+      super(service);
+      this.logPaths = Arrays.stream(logPaths).map(c -> Paths.get(c)).collect(Collectors.toList());
+    }
+
+    @Override
+    public void collectLogs(DeploymentDetails details, SpinnakerRuntimeSettings runtimeSettings) {
+      File outputDir = directoryStructure.getServiceLogsPath(
+          details.getDeploymentName(),
+          "localhost",
+          getService().getCanonicalName()).toFile();
+
+      for (Path path : logPaths) {
+        File logFile = path.toFile();
+        try {
+          if (logFile.exists()) {
+            log.warn("No logs file \"" + logFile + "\" found.");
+          } else if (logFile.isDirectory()) {
+            FileUtils.copyDirectoryToDirectory(logFile, outputDir);
+          } else if (logFile.isFile()) {
+            FileUtils.copyFileToDirectory(logFile, outputDir);
+          } else {
+            log.warn("Unknown file type " + logFile);
+          }
+        } catch (IOException e) {
+          throw new HalException(Problem.Severity.FATAL, "Unable to copy logs: " + e.getMessage(), e);
+        }
+      }
+    }
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/LocalService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/LocalService.java
@@ -21,13 +21,14 @@ import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import io.fabric8.utils.Strings;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-public interface LocalService<T> extends HasServiceSettings<T> {
+public interface LocalService<T> extends HasServiceSettings<T>, LogCollector<T, DeploymentDetails> {
   String getSpinnakerStagingPath();
   String installArtifactCommand(DeploymentDetails deploymentDetails);
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianClouddriverService.java
@@ -20,9 +20,13 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianClouddriverService extends ClouddriverService implements
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
@@ -22,10 +22,14 @@ import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DeckService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import io.fabric8.utils.Strings;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -37,6 +41,18 @@ public class LocalDebianDeckService extends DeckService implements LocalDebianSe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this, new String[] {
+      "/var/log/upstart/apache.log",
+      "/var/log/apache/"
+    });
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianEchoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianEchoService.java
@@ -20,9 +20,13 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.EchoService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianEchoService extends EchoService implements LocalDebianSe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianFiatService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianFiatService.java
@@ -20,9 +20,13 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.FiatService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianFiatService extends FiatService implements LocalDebianSe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianFront50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianFront50Service.java
@@ -20,9 +20,13 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.Front50Service;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianFront50Service extends Front50Service implements LocalDe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianGateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianGateService.java
@@ -20,13 +20,15 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.GateService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -36,6 +38,14 @@ public class LocalDebianGateService extends GateService implements LocalDebianSe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianIgorService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianIgorService.java
@@ -19,10 +19,14 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.IgorService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianIgorService extends IgorService implements LocalDebianSe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianMonitoringDaemonService.java
@@ -19,10 +19,14 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerMonitoringDaemonService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,17 @@ public class LocalDebianMonitoringDaemonService extends SpinnakerMonitoringDaemo
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this, new String[]{
+        "/var/log/upstart/spinnaker-monitoring.log",
+        "/var/log/spinnaker-monitoring/"
+    });
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianOrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianOrcaService.java
@@ -19,10 +19,14 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.OrcaService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianOrcaService extends OrcaService implements LocalDebianSe
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRedisService.java
@@ -20,15 +20,17 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RedisService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import redis.clients.jedis.Jedis;
-
-import java.util.Optional;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -42,6 +44,17 @@ public class LocalDebianRedisService extends RedisService implements LocalDebian
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this, new String[] {
+        "/var/log/upstart/redis-server.log",
+        "/var/log/redis/redis-server.log"
+    });
+  }
 
   @Override
   public String installArtifactCommand(DeploymentDetails deploymentDetails) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRoscoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRoscoService.java
@@ -19,10 +19,14 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.RoscoService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -34,6 +38,14 @@ public class LocalDebianRoscoService extends RoscoService implements LocalDebian
 
   @Autowired
   ArtifactService artifactService;
+
+  @Autowired
+  LocalLogCollectorFactory localLogCollectorFactory;
+
+  @Delegate(excludes = HasServiceSettings.class)
+  LogCollector getLocalLogCollector() {
+    return localLogCollectorFactory.build(this);
+  }
 
   @Override
   public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {


### PR DESCRIPTION
This becomes critical as we need to help users troubleshoot their spinnaker installation.

`hal deploy collect-logs` collects all logs related to Spinnaker and puts them in `~/hal/$DEPLOYMENT/service-logs/$INSTANCE/$SERVICE`. Not yet implemented for google distributed deployments.