### PR TITLE
feat(validate): Version mismatch warning

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigDirectoryStructure.java
@@ -68,6 +68,10 @@ public class HalconfigDirectoryStructure {
     return ensureRelativeHalDirectory(deploymentName, "history");
   }
 
+  public Path getCachePath() {
+    return ensureDirectory(Paths.get(halconfigDirectory, ".cache"));
+  }
+
   public Path getBackupConfigPath() {
     Path backup = ensureDirectory(Paths.get(halconfigDirectory, ".backup"));
     return new File(backup.toFile(), "config").toPath();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentConfigurationValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentConfigurationValidator.java
@@ -24,10 +24,12 @@ import com.netflix.spinnaker.halyard.config.services.v1.VersionsService;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @Component
 public class DeploymentConfigurationValidator extends Validator<DeploymentConfiguration> {
@@ -53,7 +55,36 @@ public class DeploymentConfigurationValidator extends Validator<DeploymentConfig
     boolean isReleased = versions.getVersions().stream().anyMatch(v -> Objects.equals(v.getVersion(), version));
 
     if (!isReleased) {
-      p.addProblem(Problem.Severity.WARNING, "Version \"" + version + "\" is not a released (validated) version of Spinnaker.", "version");
+      // Checks if version is of the form X.Y.Z
+      if (version.matches("\\d+\\.\\d+\\.\\d+")) {
+        String majorMinor = toMajorMinor(version);
+        Optional<Versions.Version> patchVersion = versions.getVersions()
+            .stream()
+            .map(v -> new ImmutablePair<>(v, toMajorMinor(v.getVersion())))
+            .filter(v -> v.getRight() != null)
+            .filter(v -> v.getRight().equals(majorMinor))
+            .map(ImmutablePair::getLeft)
+            .findFirst();
+
+        if (patchVersion.isPresent()) {
+          p.addProblem(Problem.Severity.WARNING, "Version \"" + version + "\" was patched by \"" + patchVersion.get().getVersion() + "\". Please upgrade when possible.")
+              .setRemediation("https://spinnaker.github.io/setup/install/upgrades/");
+        } else {
+          p.addProblem(Problem.Severity.WARNING, "Version \"" + version + "\" is no longer supported by the Spinnaker team. Please upgrade when possible.")
+              .setRemediation("https://spinnaker.github.io/setup/install/upgrades/");
+        }
+      } else {
+        p.addProblem(Problem.Severity.WARNING, "Version \"" + version + "\" is not a released (validated) version of Spinnaker.", "version");
+      }
     }
+  }
+
+  public static String toMajorMinor(String fullVersion) {
+    int lastDot = fullVersion.lastIndexOf(".");
+    if (lastDot < 0) {
+      return null;
+    }
+
+    return fullVersion.substring(0, lastDot);
   }
 }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/AtomicFileWriter.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/AtomicFileWriter.java
@@ -17,11 +17,7 @@
 
 package com.netflix.spinnaker.halyard.core;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
-import static java.nio.file.StandardOpenOption.APPEND;
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.WRITE;
+import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -30,7 +26,10 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
-import lombok.extern.slf4j.Slf4j;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+import static java.nio.file.StandardOpenOption.*;
 
 @Slf4j
 public class AtomicFileWriter {


### PR DESCRIPTION
I was going to add generic support for notifications, but realized that different kinds of notifications merit different treatment, and didn't want to hard-code all of those, or come up with something robust enough to handle all of our future notification worries. So instead I'm going to be splitting up the notification work into three categories:

1. Spinnaker update available: Addressed here, see below screenshots.
2. Halyard update available: Will be addressed similar to how it was done here.
3. Critical spinnaker announcement: I can only think of security-style patches that need to be applied by the Halyard operator, and therefore think that special cases of 1 & 2 are more appropriate. 
![update-warning-2](https://cloud.githubusercontent.com/assets/4874941/26131541/8973fffe-3a68-11e7-8da0-ef4665bed28c.png)
![update-warning](https://cloud.githubusercontent.com/assets/4874941/26131542/8975813a-3a68-11e7-95c3-7fc3fc5d1833.png)

