### PR TITLE
chore(logs): Reduce job poll log level from info to debug

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/job/v1/JobExecutorLocal.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/job/v1/JobExecutorLocal.java
@@ -139,7 +139,7 @@ public class JobExecutorLocal extends JobExecutor {
   @Override
   public JobStatus updateJob(String jobId) {
     try {
-      log.info("Polling state for " + jobId + "...");
+      log.debug("Polling state for " + jobId + "...");
       ExecutionHandler handler = jobIdToHandlerMap.get(jobId);
 
       if (handler == null) {


### PR DESCRIPTION
You will probably want to supply narrower capture level than `--log all` to the CLI