### PR TITLE
feat(core): Warn if halyard version out of date

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentConfigurationValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentConfigurationValidator.java
@@ -68,10 +68,10 @@ public class DeploymentConfigurationValidator extends Validator<DeploymentConfig
     if (!isReleased) {
       // Checks if version is of the form X.Y.Z
       if (version.matches("\\d+\\.\\d+\\.\\d+")) {
-        String majorMinor = toMajorMinor(version);
+        String majorMinor = Versions.toMajorMinor(version);
         Optional<Versions.Version> patchVersion = versions.getVersions()
             .stream()
-            .map(v -> new ImmutablePair<>(v, toMajorMinor(v.getVersion())))
+            .map(v -> new ImmutablePair<>(v, Versions.toMajorMinor(v.getVersion())))
             .filter(v -> v.getRight() != null)
             .filter(v -> v.getRight().equals(majorMinor))
             .map(ImmutablePair::getLeft)
@@ -88,14 +88,5 @@ public class DeploymentConfigurationValidator extends Validator<DeploymentConfig
         p.addProblem(Problem.Severity.WARNING, "Version \"" + version + "\" is not a released (validated) version of Spinnaker.", "version");
       }
     }
-  }
-
-  public static String toMajorMinor(String fullVersion) {
-    int lastDot = fullVersion.lastIndexOf(".");
-    if (lastDot < 0) {
-      return null;
-    }
-
-    return fullVersion.substring(0, lastDot);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.validate.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.config.services.v1.VersionsService;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class HalconfigValidator extends Validator<Halconfig> {
+  @Autowired
+  VersionsService versionsService;
+
+  @Override
+  public void validate(ConfigProblemSetBuilder p, Halconfig n) {
+    try {
+      String runningVersion = versionsService.getRunningHalyardVersion();
+      String latestVersion = versionsService.getLatestHalyardVersion();
+
+      if (StringUtils.isEmpty(latestVersion)) {
+        log.warn("No latest version of halyard published.");
+        return;
+      }
+
+      if (runningVersion.contains("SNAPSHOT")) {
+        return;
+      }
+
+
+      if (Versions.lessThan(runningVersion, latestVersion)) {
+        p.addProblem(Problem.Severity.WARNING, "There is a newer version of Halyard available (" + latestVersion + "), please update when possible")
+            .setRemediation("sudo apt-get update && sudo apt-get upgrade spinnaker-halyard");
+      }
+    } catch (Exception e) {
+      log.warn("Unexpected error comparing versions: " + e);
+    }
+  }
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidatorSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidatorSpec.groovy
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.validate.v1
+
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder
+import com.netflix.spinnaker.halyard.config.services.v1.VersionsService
+import spock.lang.Specification
+
+class HalconfigValidatorSpec extends Specification {
+  void "complains that you're out of date"() {
+    given:
+    VersionsService versionsServiceMock = Mock(VersionsService)
+    versionsServiceMock.getLatestHalyardVersion() >> latest
+    versionsServiceMock.getRunningHalyardVersion() >> current
+    HalconfigValidator validator = new HalconfigValidator()
+    validator.versionsService = versionsServiceMock
+
+    ConfigProblemSetBuilder problemBuilder = new ConfigProblemSetBuilder(null);
+
+    when:
+    validator.validate(problemBuilder, null)
+
+    then:
+    def problems = problemBuilder.build().problems
+    problems.size() == 1
+    problems.get(0).message.contains("please update")
+
+    where:
+    current    | latest
+    "0.0.0"    | "1.0.0"
+    "0.0.0"    | "0.1.0"
+    "0.0.0"    | "0.0.1"
+    "1.0.0"    | "1.0.1"
+    "1.1.0"    | "1.1.1"
+    "1.2.0"    | "2.0.0"
+    "1.1.0"    | "10.0.0"
+    "3.1.0"    | "10.0.0"
+    "30.1.0-1" | "100.0.0"
+    "0.0.0-1"  | "1.0.0-0"
+    "0.0.0-2"  | "0.1.0-2"
+    "0.0.0-3"  | "0.0.1-1"
+    "0.0.1-1"  | "1.0.0-0"
+    "0.0.1-2"  | "0.1.0-2"
+    "0.0.1-3"  | "0.1.1-1"
+  }
+}

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/memoize/v1/ExpiringConcurrentMap.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/memoize/v1/ExpiringConcurrentMap.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.core.memoize.v1;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+@Slf4j
+public class ExpiringConcurrentMap<K, V> implements Map<K, V> {
+  private final long timeout;
+
+  private final ConcurrentHashMap<K, ExpiringConcurrentMap.Entry> delegate;
+
+  public static ExpiringConcurrentMap fromMillis(long timeout) {
+    return new ExpiringConcurrentMap(timeout);
+  }
+
+  public static ExpiringConcurrentMap fromMinutes(long timeout) {
+    return new ExpiringConcurrentMap(TimeUnit.MINUTES.toMillis(timeout));
+  }
+
+  private ExpiringConcurrentMap(long timeout) {
+    this.timeout = timeout;
+    this.delegate = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  public int size() {
+    return delegate.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return get(key) != null;
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return delegate.values().stream().anyMatch(v -> v.value.equals(value) && !v.expired());
+  }
+
+  @Override
+  public V get(Object key) {
+    Entry e = delegate.get(key);
+    if (e == null) {
+      return null;
+    } else if (e.expired()) {
+      log.info("Removing expired key: " + key);
+      delegate.remove(key);
+      return null;
+    } else {
+      return e.value;
+    }
+  }
+
+  @Override
+  public V put(K key, V value) {
+    delegate.put(key, new Entry(value));
+    return value;
+  }
+
+  @Override
+  public V remove(Object key) {
+    return (V) delegate.remove(key);
+  }
+
+  @Override
+  public void putAll(Map<? extends K, ? extends V> m) {
+    m.entrySet().forEach(es -> put(es.getKey(), es.getValue()));
+  }
+
+  @Override
+  public void clear() {
+    delegate.clear();
+  }
+
+  @Override
+  public Set<K> keySet() {
+    return entrySet().stream()
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
+  }
+
+  @Override
+  public Collection<V> values() {
+    return entrySet().stream()
+        .map(Map.Entry::getValue)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public Set<Map.Entry<K, V>> entrySet() {
+    Set<Map.Entry> result = delegate.entrySet()
+        .stream()
+        .filter(e -> !e.getValue().expired())
+        .collect(Collectors.toSet());
+
+    return result.stream()
+        .map(e -> new AbstractMap.SimpleEntry<>((K) e.getKey(), ((Entry) e.getValue()).value))
+        .collect(Collectors.toSet());
+  }
+
+  private class Entry {
+    long lastUpdate;
+    V value;
+
+    public Entry() { }
+
+    public Entry(V value) {
+      this.value = value;
+      this.lastUpdate = System.currentTimeMillis();
+    }
+
+    @Override
+    public String toString() {
+      return "lastUpdate: " + lastUpdate + ", value: " + value;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null) {
+        return false;
+      } else if (!Entry.class.isAssignableFrom(obj.getClass())) {
+        return false;
+      }
+
+      Entry other = (Entry) obj;
+
+      if (other.value == null) {
+        return value == null;
+      } else {
+        return other.value.equals(value);
+      }
+    }
+
+    boolean expired() {
+      return System.currentTimeMillis() - lastUpdate > timeout;
+    }
+  }
+}

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
@@ -20,8 +20,10 @@ package com.netflix.spinnaker.halyard.core.registry.v1;
 import lombok.Data;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Data
 public class Versions {
@@ -64,5 +66,48 @@ public class Versions {
     }
 
     return result.toString();
+  }
+
+  public static String toMajorMinor(String fullVersion) {
+    int lastDot = fullVersion.lastIndexOf(".");
+    if (lastDot < 0) {
+      return null;
+    }
+
+    return fullVersion.substring(0, lastDot);
+  }
+
+  public static String toMajorMinorPatch(String fullVersion) {
+    int lastDash = fullVersion.indexOf("-");
+    if (lastDash < 0) {
+      return fullVersion;
+    }
+
+    return fullVersion.substring(0, lastDash);
+  }
+
+  public static boolean lessThan(String v1, String v2) {
+    v1 = toMajorMinorPatch(v1);
+    v2 = toMajorMinorPatch(v2);
+
+    List<Integer> split1 = Arrays.stream(v1.split("\\.")).map(Integer::valueOf).collect(Collectors.toList());
+    List<Integer> split2 = Arrays.stream(v2.split("\\.")).map(Integer::valueOf).collect(Collectors.toList());
+
+    if (split1.size() != split2.size() || split1.size() != 3) {
+      throw new IllegalArgumentException("Both versions must satisfy the X.Y.Z naming convention");
+    }
+
+    for (int i = 0; i < split1.size(); i++) {
+      if (split1.get(i) == split2.get(i)) {
+        continue;
+      } else if (split1.get(i) < split2.get(i)) {
+        return true;
+      } else if (split1.get(i) > split2.get(i)) {
+        return false;
+      }
+    }
+
+    // all 3 points are equal
+    return false;
   }
 }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
@@ -14,6 +14,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -31,6 +32,7 @@ public class DaemonTask<C, T> {
   final String uuid;
   boolean timedOut;
   final long timeout;
+  final String version;
   State state = State.NOT_STARTED;
   DaemonResponse<T> response;
   Exception fatalError;
@@ -45,6 +47,9 @@ public class DaemonTask<C, T> {
     this.name = name;
     this.uuid = UUID.randomUUID().toString();
     this.timeout = timeout;
+    this.version = Optional.ofNullable(DaemonTask.class
+        .getPackage()
+        .getImplementationVersion()).orElse("Unknown");
   }
 
   void newStage(String name) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -42,7 +42,7 @@ public class VersionsController {
   @RequestMapping(value = "/latest/", method = RequestMethod.GET)
   DaemonTask<Halconfig, String> latest() {
     DaemonResponse.StaticRequestBuilder<String> builder = new DaemonResponse.StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> versionsService.getLatest());
+    builder.setBuildResponse(() -> versionsService.getLatestSpinnakerVersion());
     return DaemonTaskHandler.submitTask(builder::build, "Get latest released version");
   }
 


### PR DESCRIPTION
This introduces an `ExpiringConcurrentMap` to allow us to memoize with a short timeout a lot of the duplicate requests for Halyard versions.