### PR TITLE
fix(encoding): Read local dependencies directly into a byte array. Fi…

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesProviderUtils.java
@@ -146,7 +146,8 @@ class KubernetesProviderUtils {
       try {
         File f = new File(s);
         String name = f.getName();
-        String data = new String(Base64.getEncoder().encode(IOUtils.toString(new FileInputStream(f)).getBytes()));
+        String data = new String(Base64.getEncoder().encode(IOUtils.toByteArray(new FileInputStream(f))));
+
         secretContents.putIfAbsent(name, data);
       } catch (IOException e) {
         throw new HalException(Severity.ERROR, "Unable to read contents of \"" + s + "\": " + e);


### PR DESCRIPTION
…xes issues sending JKS files to Kubernetes via secrets.