### PR TITLE
feat(validation): Support AWS assumeRole and setting credentials at the command line

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,4 +1,4 @@
-_Version: 0.26.0-SNAPSHOT_
+_Version: 0.27.0-SNAPSHOT_
 
 # Table of Contents
 
@@ -1030,7 +1030,11 @@ hal config provider aws account add ACCOUNT [parameters]
 ```
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
- * `--account-id`: Your AWS account ID to manage. See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.
+ * `--access-key-id, --access-key`: Your AWS Access Key ID. If not provided, Halyard will try to find AWS as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * `--account-id`: (*Required*) Your AWS account ID to manage. See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.
+ * `--assume-role, --role`: If set, Halyard will configure a credentials provider that use AWS Security Token Service to assume the specified role.
+
+Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--default-key-pair`: Provide the name of the AWS key-pair to use. See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.
  * `--discovery`: The endpoint your Eureka discovery system is reachable at. See https://github.com/Netflix/eureka for more information.
 
@@ -1041,6 +1045,7 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--regions`: (*Default*: `[]`) The AWS regions this Spinnaker account will manage.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
+ * `--secret-key`: Your AWS Secret Key.
 
 ---
 ## hal config provider aws account delete
@@ -1066,9 +1071,13 @@ hal config provider aws account edit ACCOUNT [parameters]
 ```
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
+ * `--access-key-id, --access-key`: Your AWS Access Key ID. If not provided, Halyard will try to find AWS as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
  * `--account-id`: Your AWS account ID to manage. See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.
  * `--add-region`: Add this region to the list of managed regions.
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
+ * `--assume-role, --role`: If set, Halyard will configure a credentials provider that use AWS Security Token Service to assume the specified role.
+
+Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--default-key-pair`: Provide the name of the AWS key-pair to use. See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.
  * `--discovery`: The endpoint your Eureka discovery system is reachable at. See https://github.com/Netflix/eureka for more information.
 
@@ -1081,6 +1090,7 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
  * `--remove-region`: Remove this region from the list of managed regions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
+ * `--secret-key`: Your AWS Secret Key.
 
 ---
 ## hal config provider aws account get
@@ -3083,10 +3093,15 @@ Edit configuration for the "s3" persistent store.
 hal config storage s3 edit [parameters]
 ```
 #### Parameters
+ * `--access-key-id, --access-key`: Your AWS Access Key ID. If not provided, Halyard will try to find AWS as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * `--assume-role, --role`: If set, Halyard will configure a credentials provider that use AWS Security Token Service to assume the specified role.
+
+Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--bucket`: The name of a storage bucket that your specified account has access to. If not specified, a random name will be chosen. If you specify a globally unique bucket name that doesn't exist yet, Halyard will create that bucket for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: This is only required if the bucket you specify doesn't exist yet. In that case, the bucket will be created in that region. See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
  * `--root-folder`: The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
+ * `--secret-key`: Your AWS Secret Key.
 
 ---
 ## hal config version

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.s3
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.persistentStorage.AbstractPersistentStoreEditCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws.AwsCommandProperties;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3PersistentStore;
@@ -52,11 +53,33 @@ public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3Persiste
   )
   private String region;
 
+  @Parameter(
+    names = {"--assume-role", "--role"},
+    description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION
+  )
+  private String assumeRole;
+
+  @Parameter(
+    names = {"--access-key-id", "--access-key"},
+    description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
+  )
+  private String accessKeyId;
+
+  @Parameter(
+    names = "--secret-key",
+    description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
+    password = true
+  )
+  private String secretKey;
+
   @Override
   protected S3PersistentStore editPersistentStore(S3PersistentStore persistentStore) {
     persistentStore.setBucket(isSet(bucket) ? bucket : persistentStore.getBucket());
     persistentStore.setRootFolder(isSet(rootFolder) ? rootFolder : persistentStore.getRootFolder());
     persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());
+    persistentStore.setAssumeRole(isSet(assumeRole) ? assumeRole : persistentStore.getAssumeRole());
+    persistentStore.setAccessKeyId(isSet(accessKeyId) ? accessKeyId : persistentStore.getAccessKeyId());
+    persistentStore.setSecretKey(isSet(secretKey) ? secretKey : persistentStore.getSecretKey());
 
     if (persistentStore.getBucket() == null) {
       String bucketName = "spin-" + UUID.randomUUID().toString();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws;
 
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
@@ -34,48 +35,71 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
   }
 
   @Parameter(
-      names = "--default-key-pair",
-      description = AwsCommandProperties.DEFAULT_KEY_PAIR_DESCRIPTION
+    names = "--default-key-pair",
+    description = AwsCommandProperties.DEFAULT_KEY_PAIR_DESCRIPTION
   )
   private String defaultKeyPair;
 
   @Parameter(
-      names = "--edda",
-      description = AwsCommandProperties.EDDA_DESCRIPTION
+    names = "--edda",
+    description = AwsCommandProperties.EDDA_DESCRIPTION
   )
   private String edda;
 
   @Parameter(
-      names = "--discovery",
-      description = AwsCommandProperties.DISCOVERY_DESCRIPTION
+    names = "--discovery",
+    description = AwsCommandProperties.DISCOVERY_DESCRIPTION
   )
   private String discovery;
 
   @Parameter(
-      names = "--account-id",
-      description = AwsCommandProperties.ACCOUNT_ID_DESCRIPTION
+    names = "--account-id",
+    description = AwsCommandProperties.ACCOUNT_ID_DESCRIPTION,
+    required = true
   )
   private String accountId;
 
   @Parameter(
-      names = "--regions",
-      variableArity = true,
-      description = AwsCommandProperties.REGIONS_DESCRIPTION
+    names = "--regions",
+    variableArity = true,
+    description = AwsCommandProperties.REGIONS_DESCRIPTION
   )
   private List<String> regions = new ArrayList<>();
+
+  @Parameter(
+    names = {"--assume-role", "--role"},
+    description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION
+  )
+  private String assumeRole;
+
+  @Parameter(
+    names = {"--access-key-id", "--access-key"},
+    description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
+  )
+  private String accessKeyId;
+
+  @Parameter(
+    names = "--secret-key",
+    description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
+    password = true
+  )
+  private String secretKey;
 
   @Override
   protected Account buildAccount(String accountName) {
     AwsAccount account = (AwsAccount) new AwsAccount().setName(accountName);
     account.setDefaultKeyPair(defaultKeyPair)
-        .setEdda(edda)
-        .setDiscovery(discovery)
-        .setAccountId(accountId)
-        .setRegions(regions
-            .stream()
-            .map(r -> new AwsAccount.AwsRegion().setName(r))
-            .collect(Collectors.toList())
-        );
+      .setEdda(edda)
+      .setDiscovery(discovery)
+      .setAccountId(accountId)
+      .setRegions(regions
+        .stream()
+        .map(r -> new AwsAccount.AwsRegion().setName(r))
+        .collect(Collectors.toList())
+      )
+      .setAssumeRole(assumeRole)
+      .setAccessKeyId(accessKeyId)
+      .setSecretKey(secretKey);
 
     return account;
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
@@ -18,20 +18,29 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws;
 
 public class AwsCommandProperties {
-  static final String DEFAULT_KEY_PAIR_DESCRIPTION = "Provide the name of the AWS key-pair to use."
-      + " See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.";
+  public static final String DEFAULT_KEY_PAIR_DESCRIPTION = "Provide the name of the AWS key-pair to use."
+    + " See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.";
 
-  static final String EDDA_DESCRIPTION = "The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker,"
-      + " but is helpful for reducing the request volume against AWS."
-      + " See https://github.com/Netflix/edda for more information.";
+  public static final String EDDA_DESCRIPTION = "The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker,"
+    + " but is helpful for reducing the request volume against AWS."
+    + " See https://github.com/Netflix/edda for more information.";
 
-  static final String DISCOVERY_DESCRIPTION = "The endpoint your Eureka discovery system is reachable at."
-      + " See https://github.com/Netflix/eureka for more information.\n\n"
-      + "Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2 \n\nUsing {{region}} will make Spinnaker"
-      + " use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.";
+  public static final String DISCOVERY_DESCRIPTION = "The endpoint your Eureka discovery system is reachable at."
+    + " See https://github.com/Netflix/eureka for more information.\n\n"
+    + "Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2 \n\nUsing {{region}} will make Spinnaker"
+    + " use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.";
 
-  static final String ACCOUNT_ID_DESCRIPTION = "Your AWS account ID to manage."
-      + " See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.";
+  public static final String ACCOUNT_ID_DESCRIPTION = "Your AWS account ID to manage."
+    + " See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.";
 
-  static final String REGIONS_DESCRIPTION = "The AWS regions this Spinnaker account will manage.";
+  public static final String REGIONS_DESCRIPTION = "The AWS regions this Spinnaker account will manage.";
+
+  public static final String ASSUME_ROLE_DESCRIPTION = "If set, Halyard will configure a credentials provider that use AWS"
+    + " Security Token Service to assume the specified role.\n\n"
+    + "Example: \"user/spinnaker\" or \"role/spinnakerManaged\"";
+
+  public static final String ACCESS_KEY_ID_DESCRIPTION = "Your AWS Access Key ID. If not provided, Halyard will try to find AWS"
+    + " as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default";
+
+  public static final String SECRET_KEY_DESCRIPTION = "Your AWS Secret Key.";
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
@@ -21,13 +21,18 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
+@ToString(exclude = {"accessKeyId", "secretKey"})
 public class S3PersistentStore extends PersistentStore {
   private String bucket;
   private String rootFolder = "front50";
   private String region;
+  private String assumeRole;
+  private String accessKeyId;
+  private String secretKey;
 
   @Override
   public PersistentStoreType persistentStoreType() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
@@ -17,17 +17,21 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.aws;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.ToString;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@ToString(exclude = {"accessKeyId", "secretKey"})
 public class AwsAccount extends Account {
 
   private String defaultKeyPair;
@@ -35,6 +39,9 @@ public class AwsAccount extends Account {
   private String discovery;
   private String accountId;
   private List<AwsRegion> regions = new ArrayList<>();
+  private String assumeRole;
+  private String accessKeyId;
+  private String secretKey;
 
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/S3Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/S3Validator.java
@@ -22,17 +22,23 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.netflix.spinnaker.front50.config.S3Config;
 import com.netflix.spinnaker.front50.config.S3Properties;
 import com.netflix.spinnaker.front50.model.StorageService;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3PersistentStore;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.config.validate.v1.providers.aws.AwsAccountValidator;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import org.springframework.stereotype.Component;
+
+import java.util.Optional;
 
 @Component
 public class S3Validator extends Validator<S3PersistentStore> {
   @Override
   public void validate(ConfigProblemSetBuilder ps, S3PersistentStore n) {
-    AWSCredentialsProvider credentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
+    AWSCredentialsProvider credentialsProvider = AwsAccountValidator.getAwsCredentialsProvider(n.getAccessKeyId(), n.getSecretKey());
     S3Config s3Config = new S3Config();
     S3Properties s3Properties = new S3Properties();
     s3Properties.setBucket(n.getBucket());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/aws/AwsAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/aws/AwsAccountValidator.java
@@ -18,35 +18,80 @@
 package com.netflix.spinnaker.halyard.config.validate.v1.providers.aws;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Regions;
 import com.amazonaws.services.ec2.AmazonEC2;
-import com.amazonaws.services.ec2.AmazonEC2ClientBuilder;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.AssumeRoleAmazonCredentials;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class AwsAccountValidator extends Validator<AwsAccount> {
   @Override
   public void validate(ConfigProblemSetBuilder p, AwsAccount n) {
-    DaemonTaskHandler.message(String.format("Validating %s with %s", n.getNodeName(), getClass().getSimpleName()));
+    DaemonTaskHandler.message(String.format("Validating AWS account named %s with %s", n.getNodeName(), getClass().getSimpleName()));
 
-    AWSCredentialsProvider credentialsProvider = DefaultAWSCredentialsProviderChain.getInstance();
+    AWSCredentialsProvider credentialsProvider = getAwsCredentialsProvider(n.getAccessKeyId(), n.getSecretKey());
+    AmazonClientProvider amazonClientProvider = new AmazonClientProvider();
+    AmazonCredentials amazonCredentials;
 
-    n.getRegions().forEach(awsRegion -> {
-      AmazonEC2 ec2Client = AmazonEC2ClientBuilder.standard()
-        .withCredentials(credentialsProvider)
-        .withRegion(awsRegion.getName())
-        .build();
+    // TODO The required (third) constructor in *AmazonCredentials is package protected.
+    // We're abusing the second constructor here until the required constructor is changed to public.
+    if (StringUtils.isNotBlank(n.getAssumeRole())) {
+      amazonCredentials = new AssumeRoleAmazonCredentials(new AssumeRoleAmazonCredentials(n.getName(), "", "", n.getAccountId(), null,
+        convert(n.getRegions()), null, n.getRequiredGroupMembership(), null, n.getAssumeRole(), null), credentialsProvider);
+    } else {
+      amazonCredentials = new AmazonCredentials(new AmazonCredentials(n.getName(), "", "", n.getAccountId(), null,
+        convert(n.getRegions()), null, n.getRequiredGroupMembership(), null), credentialsProvider);
+    }
+
+    getRegionsOrDefault(n.getRegions()).forEach(awsRegion -> {
+      AmazonEC2 ec2Client = amazonClientProvider.getAmazonEC2(amazonCredentials.getCredentialsProvider(), awsRegion.getName());
       try {
         ec2Client.describeRegions();
       } catch (Exception e) {
-        p.addProblem(Severity.ERROR, "Failed to validate AWS account in region \"" + awsRegion.getName() +
-          "\". Error message: " + e.getMessage());
+        if (StringUtils.isNotBlank(n.getAssumeRole())) {
+          p.addProblem(Severity.WARNING, "Failed to validate AWS account in region \"" + awsRegion.getName() +
+            "\", assuming role \"" + n.getAssumeRole() + "\". This might indicate an error. Error message: " + e.getMessage());
+        } else {
+          p.addProblem(Severity.ERROR, "Failed to validate AWS account in region \"" + awsRegion.getName() +
+            "\". Error message: " + e.getMessage());
+        }
       }
     });
+  }
+
+  public static AWSCredentialsProvider getAwsCredentialsProvider(String accessKeyId, String secretKey) {
+    if (accessKeyId != null && secretKey != null) {
+      return new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKeyId, secretKey));
+    } else {
+      return DefaultAWSCredentialsProviderChain.getInstance();
+    }
+  }
+
+  private List<AmazonCredentials.AWSRegion> convert(List<AwsAccount.AwsRegion> regions) {
+    if (regions == null) {
+      return null;
+    }
+    return regions.stream()
+      .map(region -> new AmazonCredentials.AWSRegion(region.getName(), null))
+      .collect(Collectors.toList());
+  }
+
+  private List<AwsAccount.AwsRegion> getRegionsOrDefault(List<AwsAccount.AwsRegion> regions) {
+    return regions.isEmpty() ? Collections.singletonList(new AwsAccount.AwsRegion().setName(Regions.DEFAULT_REGION.getName())) : regions;
   }
 }


### PR DESCRIPTION
Second take at implementing validation of AWS accounts and S3 buckets. Please take a look @lwander  @ewiseblatt.

It kind of supports the assumeRole, and you can set credentials in the cli. It's not properly tested, so expect the unexpected. I just wanted to get it out there and collect some feedback.