### PR TITLE
fix(aws): Configure aws provider

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -64,6 +64,7 @@ _Version: 0.21.0-SNAPSHOT_
  * [**hal config provider aws account get**](#hal-config-provider-aws-account-get)
  * [**hal config provider aws account list**](#hal-config-provider-aws-account-list)
  * [**hal config provider aws disable**](#hal-config-provider-aws-disable)
+ * [**hal config provider aws edit**](#hal-config-provider-aws-edit)
  * [**hal config provider aws enable**](#hal-config-provider-aws-enable)
  * [**hal config provider azure**](#hal-config-provider-azure)
  * [**hal config provider azure account**](#hal-config-provider-azure-account)
@@ -998,6 +999,7 @@ hal config provider aws [parameters] [subcommands]
 #### Subcommands
  * `account`: Manage and view Spinnaker configuration for the aws provider's account
  * `disable`: Set the aws provider as disabled
+ * `edit`: Set provider-wide properties for the AWS provider
  * `enable`: Set the aws provider as enabled
 
 ---
@@ -1030,9 +1032,8 @@ hal config provider aws account add ACCOUNT [parameters]
 ```
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
- * `--access-key-id, --access-key`: Your AWS Access Key ID. If not provided, Halyard will try to find AWS as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
  * `--account-id`: (*Required*) Your AWS account ID to manage. See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.
- * `--assume-role, --role`: If set, Halyard will configure a credentials provider that use AWS Security Token Service to assume the specified role.
+ * `--assume-role`: (*Required*) If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
 
 Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--default-key-pair`: Provide the name of the AWS key-pair to use. See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.
@@ -1045,7 +1046,6 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--regions`: (*Default*: `[]`) The AWS regions this Spinnaker account will manage.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
- * `--secret-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
 
 ---
 ## hal config provider aws account delete
@@ -1071,11 +1071,10 @@ hal config provider aws account edit ACCOUNT [parameters]
 ```
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
- * `--access-key-id, --access-key`: Your AWS Access Key ID. If not provided, Halyard will try to find AWS as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
  * `--account-id`: Your AWS account ID to manage. See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.
  * `--add-region`: Add this region to the list of managed regions.
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
- * `--assume-role, --role`: If set, Halyard will configure a credentials provider that use AWS Security Token Service to assume the specified role.
+ * `--assume-role`: If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
 
 Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--default-key-pair`: Provide the name of the AWS key-pair to use. See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.
@@ -1090,7 +1089,6 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
  * `--remove-region`: Remove this region from the list of managed regions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
- * `--secret-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
 
 ---
 ## hal config provider aws account get
@@ -1128,6 +1126,20 @@ hal config provider aws disable [parameters]
 ```
 #### Parameters
  * `--no-validate`: (*Default*: `false`) Skip validation.
+
+---
+## hal config provider aws edit
+
+The AWS provider requires a central "Managing Account" to authenticate on behalf of other AWS accounts, or act as your sole, credential-based account. Since this configuration, as well as some defaults, span all AWS accounts, it is generally required to edit the AWS provider using this command.
+
+#### Usage
+```
+hal config provider aws edit [parameters]
+```
+#### Parameters
+ * `--access-key-id`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
 
 ---
 ## hal config provider aws enable
@@ -3106,15 +3118,15 @@ Edit configuration for the "s3" persistent store.
 hal config storage s3 edit [parameters]
 ```
 #### Parameters
- * `--access-key-id, --access-key`: Your AWS Access Key ID. If not provided, Halyard will try to find AWS as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
- * `--assume-role, --role`: If set, Halyard will configure a credentials provider that use AWS Security Token Service to assume the specified role.
+ * `--access-key-id`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * `--assume-role`: If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
 
 Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--bucket`: The name of a storage bucket that your specified account has access to. If not specified, a random name will be chosen. If you specify a globally unique bucket name that doesn't exist yet, Halyard will create that bucket for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: This is only required if the bucket you specify doesn't exist yet. In that case, the bucket will be created in that region. See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
  * `--root-folder`: The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
- * `--secret-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
+ * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
 
 ---
 ## hal config version

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
@@ -54,32 +54,31 @@ public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3Persiste
   private String region;
 
   @Parameter(
-    names = {"--assume-role", "--role"},
+    names = "--assume-role",
     description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION
   )
   private String assumeRole;
 
   @Parameter(
-    names = {"--access-key-id", "--access-key"},
+    names = "--access-key-id",
     description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
   )
   private String accessKeyId;
 
   @Parameter(
-    names = "--secret-key",
+    names = "--secret-access-key",
     description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
     password = true
   )
-  private String secretKey;
+  private String secretAccessKey;
 
   @Override
   protected S3PersistentStore editPersistentStore(S3PersistentStore persistentStore) {
     persistentStore.setBucket(isSet(bucket) ? bucket : persistentStore.getBucket());
     persistentStore.setRootFolder(isSet(rootFolder) ? rootFolder : persistentStore.getRootFolder());
     persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());
-    persistentStore.setAssumeRole(isSet(assumeRole) ? assumeRole : persistentStore.getAssumeRole());
     persistentStore.setAccessKeyId(isSet(accessKeyId) ? accessKeyId : persistentStore.getAccessKeyId());
-    persistentStore.setSecretKey(isSet(secretKey) ? secretKey : persistentStore.getSecretKey());
+    persistentStore.setSecretAccessKey(isSet(secretAccessKey) ? secretAccessKey : persistentStore.getSecretAccessKey());
 
     if (persistentStore.getBucket() == null) {
       String bucketName = "spin-" + UUID.randomUUID().toString();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
@@ -17,12 +17,12 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws;
 
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,23 +67,11 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
   private List<String> regions = new ArrayList<>();
 
   @Parameter(
-    names = {"--assume-role", "--role"},
-    description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION
+    names = "--assume-role",
+    description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION,
+    required = true
   )
   private String assumeRole;
-
-  @Parameter(
-    names = {"--access-key-id", "--access-key"},
-    description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
-  )
-  private String accessKeyId;
-
-  @Parameter(
-    names = "--secret-key",
-    description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
-    password = true
-  )
-  private String secretKey;
 
   @Override
   protected Account buildAccount(String accountName) {
@@ -94,12 +82,10 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
       .setAccountId(accountId)
       .setRegions(regions
         .stream()
-        .map(r -> new AwsAccount.AwsRegion().setName(r))
+        .map(r -> new AwsProvider.AwsRegion().setName(r))
         .collect(Collectors.toList())
       )
-      .setAssumeRole(assumeRole)
-      .setAccessKeyId(accessKeyId)
-      .setSecretKey(secretKey);
+      .setAssumeRole(assumeRole);
 
     return account;
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommand.java
@@ -32,5 +32,6 @@ public class AwsCommand extends AbstractNamedProviderCommand {
   public AwsCommand() {
     super();
     registerSubcommand(new AwsAccountCommand());
+    registerSubcommand(new AwsEditProviderCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
@@ -18,29 +18,29 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws;
 
 public class AwsCommandProperties {
-  public static final String DEFAULT_KEY_PAIR_DESCRIPTION = "Provide the name of the AWS key-pair to use."
-    + " See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.";
+  public static final String DEFAULT_KEY_PAIR_DESCRIPTION = "Provide the name of the AWS key-pair to use. "
+    + "See http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html for more information.";
 
-  public static final String EDDA_DESCRIPTION = "The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker,"
-    + " but is helpful for reducing the request volume against AWS."
-    + " See https://github.com/Netflix/edda for more information.";
+  public static final String EDDA_DESCRIPTION = "The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, "
+    + "but is helpful for reducing the request volume against AWS. "
+    + "See https://github.com/Netflix/edda for more information.";
 
-  public static final String DISCOVERY_DESCRIPTION = "The endpoint your Eureka discovery system is reachable at."
-    + " See https://github.com/Netflix/eureka for more information.\n\n"
-    + "Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2 \n\nUsing {{region}} will make Spinnaker"
-    + " use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.";
+  public static final String DISCOVERY_DESCRIPTION = "The endpoint your Eureka discovery system is reachable at. "
+    + "See https://github.com/Netflix/eureka for more information.\n\n"
+    + "Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2 \n\nUsing {{region}} will make Spinnaker "
+    + "use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.";
 
-  public static final String ACCOUNT_ID_DESCRIPTION = "Your AWS account ID to manage."
-    + " See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.";
+  public static final String ACCOUNT_ID_DESCRIPTION = "Your AWS account ID to manage. "
+    + "See http://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html for more information.";
 
   public static final String REGIONS_DESCRIPTION = "The AWS regions this Spinnaker account will manage.";
 
-  public static final String ASSUME_ROLE_DESCRIPTION = "If set, Halyard will configure a credentials provider that use AWS"
-    + " Security Token Service to assume the specified role.\n\n"
+  public static final String ASSUME_ROLE_DESCRIPTION = "If set, Halyard will configure a credentials provider that uses AWS "
+    + "Security Token Service to assume the specified role.\n\n"
     + "Example: \"user/spinnaker\" or \"role/spinnakerManaged\"";
 
-  public static final String ACCESS_KEY_ID_DESCRIPTION = "Your AWS Access Key ID. If not provided, Halyard will try to find AWS"
-    + " as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default";
+  public static final String ACCESS_KEY_ID_DESCRIPTION = "Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials "
+    + "as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default";
 
   public static final String SECRET_KEY_DESCRIPTION = "Your AWS Secret Key.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditAccountCommand.java
@@ -23,6 +23,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -77,23 +78,10 @@ public class AwsEditAccountCommand extends AbstractEditAccountCommand<AwsAccount
   private String removeRegion;
 
   @Parameter(
-    names = {"--assume-role", "--role"},
+    names = "--assume-role",
     description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION
   )
   private String assumeRole;
-
-  @Parameter(
-    names = {"--access-key-id", "--access-key"},
-    description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
-  )
-  private String accessKeyId;
-
-  @Parameter(
-    names = "--secret-key",
-    description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
-    password = true
-  )
-  private String secretKey;
 
   @Override
   protected Account editAccount(AwsAccount account) {
@@ -102,18 +90,16 @@ public class AwsEditAccountCommand extends AbstractEditAccountCommand<AwsAccount
     account.setDiscovery(isSet(discovery) ? discovery : account.getDiscovery());
     account.setAccountId(isSet(accountId) ? accountId : account.getAccountId());
     account.setAssumeRole(isSet(assumeRole) ? assumeRole : account.getAssumeRole());
-    account.setAccessKeyId(isSet(accessKeyId) ? accessKeyId : account.getAccessKeyId());
-    account.setSecretKey(isSet(secretKey) ? secretKey : account.getSecretKey());
 
     try {
       List<String> existingRegions = account
         .getRegions()
         .stream()
-        .map(AwsAccount.AwsRegion::getName).collect(Collectors.toList());
+        .map(AwsProvider.AwsRegion::getName).collect(Collectors.toList());
       regions = updateStringList(existingRegions, regions, addRegion, removeRegion);
       account.setRegions(regions
         .stream()
-        .map(r -> new AwsAccount.AwsRegion().setName(r))
+        .map(r -> new AwsProvider.AwsRegion().setName(r))
         .collect(Collectors.toList())
       );
     } catch (IllegalArgumentException e) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditProviderCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractEditProviderCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Parameters(separators = "=")
+@Data
+public class AwsEditProviderCommand extends AbstractEditProviderCommand<AwsAccount, AwsProvider> {
+  String shortDescription = "Set provider-wide properties for the AWS provider";
+
+  String longDescription = "The AWS provider requires a central \"Managing Account\" to authenticate on behalf of other "
+      + "AWS accounts, or act as your sole, credential-based account. Since this configuration, as well as some defaults, span "
+      + "all AWS accounts, it is generally required to edit the AWS provider using this command.";
+
+  @Parameter(
+      names = "--access-key-id",
+      description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
+  )
+  private String accessKeyId;
+
+  @Parameter(
+      names = "--secret-access-key",
+      description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
+      password = true
+  )
+  private String secretAccessKey;
+
+
+  protected String getProviderName() {
+    return Provider.ProviderType.AWS.getName();
+  }
+
+  @Override
+  protected Provider editProvider(AwsProvider provider) {
+    provider.setAccessKeyId(isSet(accessKeyId) ? accessKeyId : provider.getAccessKeyId());
+    provider.setSecretAccessKey(isSet(secretAccessKey) ? secretAccessKey : provider.getSecretAccessKey());
+    return provider;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/ListVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/ListVersionCommand.java
@@ -18,14 +18,10 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.versions;
 
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.versions.BomVersionCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.versions.LatestVersionCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
@@ -25,14 +25,12 @@ import lombok.ToString;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@ToString(exclude = {"accessKeyId", "secretKey"})
 public class S3PersistentStore extends PersistentStore {
   private String bucket;
   private String rootFolder = "front50";
   private String region;
-  private String assumeRole;
   private String accessKeyId;
-  private String secretKey;
+  private String secretAccessKey;
 
   @Override
   public PersistentStoreType persistentStoreType() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
@@ -17,8 +17,6 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.aws;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
@@ -31,25 +29,17 @@ import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-@ToString(exclude = {"accessKeyId", "secretKey"})
 public class AwsAccount extends Account {
-
   private String defaultKeyPair;
   private String edda;
   private String discovery;
   private String accountId;
-  private List<AwsRegion> regions = new ArrayList<>();
+  private List<AwsProvider.AwsRegion> regions = new ArrayList<>();
   private String assumeRole;
-  private String accessKeyId;
-  private String secretKey;
+  private String sessionName;
 
   @Override
   public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
     v.validate(psBuilder, this);
-  }
-
-  @Data
-  public static class AwsRegion {
-    String name;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsProvider.java
@@ -20,8 +20,34 @@ package com.netflix.spinnaker.halyard.config.model.v1.providers.aws;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+import java.util.Collections;
+import java.util.List;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
 public class AwsProvider extends Provider<AwsAccount> {
+  private String accessKeyId;
+  private String secretAccessKey;
+
+  private String defaultAssumeRole;
+  private String defaultKeyPairTemplate = "{{name}}-keypair";
+
+  private List<AwsRegion> defaultRegions = Collections.singletonList(new AwsRegion().setName("us-west-2"));
+  private AwsDefaults defaults = new AwsDefaults();
+
+  @Data
+  public static class AwsRegion {
+    String name;
+  }
+
+  @Data
+  public static class AwsDefaults {
+    String iamRole = "BaseIAMRole";
+  }
+
   @Override
   public ProviderType providerType() {
     return ProviderType.AWS;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSProvider.java
@@ -8,11 +8,13 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIterator;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIteratorFactory;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@EqualsAndHashCode(callSuper = true)
 @Data
 public class DCOSProvider extends HasClustersProvider<DCOSAccount, DCOSCluster> {
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/S3Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/S3Validator.java
@@ -17,28 +17,22 @@
 package com.netflix.spinnaker.halyard.config.validate.v1.persistentStorage;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.s3.AmazonS3;
 import com.netflix.spinnaker.front50.config.S3Config;
 import com.netflix.spinnaker.front50.config.S3Properties;
 import com.netflix.spinnaker.front50.model.StorageService;
-import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3PersistentStore;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.config.validate.v1.providers.aws.AwsAccountValidator;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import org.springframework.stereotype.Component;
 
-import java.util.Optional;
-
 @Component
 public class S3Validator extends Validator<S3PersistentStore> {
   @Override
   public void validate(ConfigProblemSetBuilder ps, S3PersistentStore n) {
-    AWSCredentialsProvider credentialsProvider = AwsAccountValidator.getAwsCredentialsProvider(n.getAccessKeyId(), n.getSecretKey());
+    AWSCredentialsProvider credentialsProvider = AwsAccountValidator.getAwsCredentialsProvider(n.getAccessKeyId(), n.getSecretAccessKey());
     S3Config s3Config = new S3Config();
     S3Properties s3Properties = new S3Properties();
     s3Properties.setBucket(n.getBucket());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerArtifact.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerArtifact.java
@@ -18,13 +18,6 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1;
 
 import lombok.Getter;
 
-import java.io.File;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-
 /**
  * An artifact is something deployed as a part of Spinnaker. It can be run with a number
  * of Profiles, but ultimately refers to a compiled/distributable binary of some format.

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/AwsCredentialsProfileFactoryBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/AwsCredentialsProfileFactoryBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
+import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import lombok.Data;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class AwsCredentialsProfileFactoryBuilder {
+  @Autowired
+  protected ArtifactService artifactService;
+
+  public AwsCredentialsProfileFactory build(SpinnakerArtifact artifact) {
+    return new AwsCredentialsProfileFactory(artifact);
+  }
+
+  public String getOutputFile(String spinnakerHome) {
+    return Paths.get(spinnakerHome, ".aws/credentials").toString();
+  }
+
+  @Data
+  public class AwsCredentialsProfileFactory extends TemplateBackedProfileFactory {
+    public AwsCredentialsProfileFactory(SpinnakerArtifact artifact) {
+      super();
+      this.artifact = artifact;
+    }
+
+    @Override
+    protected ArtifactService getArtifactService() {
+      return artifactService;
+    }
+
+    private String template = String.join("\n",
+        "[default]",
+        "aws_access_key_id = {%accessKeyId%}",
+        "aws_secret_access_key = {%secretAccessKey%}"
+    );
+
+    @Override
+    protected Map<String, String> getBindings(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+      AwsProvider awsProvider = deploymentConfiguration.getProviders().getAws();
+      Map<String, String> result = new HashMap<>();
+      result.put("accessKeyId", awsProvider.getAccessKeyId());
+      result.put("secretAccessKey", awsProvider.getSecretAccessKey());
+      return result;
+    }
+
+    SpinnakerArtifact artifact;
+
+    @Override
+    protected String commentPrefix() {
+      return null;
+    }
+
+    @Override
+    protected boolean showEditWarning() {
+      return false;
+    }
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianService.java
@@ -32,6 +32,10 @@ public interface BakeDebianService<T> extends BakeService<T> {
   ArtifactService getArtifactService();
   String getUpstartServiceName();
 
+  default String getHomeDirectory() {
+    return "/home/spinnaker";
+  }
+
   @Override
   default String getStartupCommand() {
     if (getUpstartServiceName() != null) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleClouddriverService.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.go
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.SidecarService;
 import lombok.Data;
@@ -40,6 +41,13 @@ public class GoogleClouddriverService extends ClouddriverService implements Goog
   @Delegate
   @Autowired
   GoogleDistributedServiceDelegate googleDistributedServiceDelegate;
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    List<Profile> profiles = super.getProfiles(deploymentConfiguration, endpoints);
+    generateAwsProfile(deploymentConfiguration, endpoints, getHomeDirectory()).ifPresent(p -> profiles.add(p));
+    return profiles;
+  }
 
   @Override
   public List<SidecarService> getSidecars(SpinnakerRuntimeSettings runtimeSettings) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
@@ -61,6 +61,10 @@ public interface GoogleDistributedService<T> extends DistributedService<T, Googl
     return "n1-highmem-2" ;
   }
 
+  default String getHomeDirectory() {
+    return "/home/spinnaker";
+  }
+
   default String buildAddress() {
     return String.format("%s.service.spinnaker.consul", getService().getCanonicalName());
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleFront50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleFront50Service.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.go
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.Front50Service;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.SidecarService;
 import lombok.Data;
@@ -40,6 +41,13 @@ public class GoogleFront50Service extends Front50Service implements GoogleDistri
   @Delegate
   @Autowired
   GoogleDistributedServiceDelegate googleDistributedServiceDelegate;
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    List<Profile> profiles = super.getProfiles(deploymentConfiguration, endpoints);
+    generateAwsProfile(deploymentConfiguration, endpoints, getHomeDirectory()).ifPresent(p -> profiles.add(p));
+    return profiles;
+  }
 
   @Override
   public List<SidecarService> getSidecars(SpinnakerRuntimeSettings runtimeSettings) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesClouddriverService.java
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
@@ -26,6 +28,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Component
@@ -38,6 +42,13 @@ public class KubernetesClouddriverService extends ClouddriverService implements 
   @Delegate(excludes = HasServiceSettings.class)
   public DistributedLogCollector getLogCollector() {
     return getLogCollectorFactory().build(this);
+  }
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    List<Profile> profiles = super.getProfiles(deploymentConfiguration, endpoints);
+    generateAwsProfile(deploymentConfiguration, endpoints, getHomeDirectory()).ifPresent(p -> profiles.add(p));
+    return profiles;
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFront50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesFront50Service.java
@@ -18,6 +18,8 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.Front50Service;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
@@ -26,6 +28,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Component
@@ -38,6 +42,13 @@ public class KubernetesFront50Service extends Front50Service implements Kubernet
   @Delegate(excludes = HasServiceSettings.class)
   public DistributedLogCollector getLogCollector() {
     return getLogCollectorFactory().build(this);
+  }
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    List<Profile> profiles = super.getProfiles(deploymentConfiguration, endpoints);
+    generateAwsProfile(deploymentConfiguration, endpoints, getHomeDirectory()).ifPresent(p -> profiles.add(p));
+    return profiles;
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianClouddriverService.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
@@ -29,6 +31,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -45,6 +49,13 @@ public class LocalDebianClouddriverService extends ClouddriverService implements
   @Delegate(excludes = HasServiceSettings.class)
   LogCollector getLocalLogCollector() {
     return localLogCollectorFactory.build(this);
+  }
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    List<Profile> profiles = super.getProfiles(deploymentConfiguration, endpoints);
+    generateAwsProfile(deploymentConfiguration, endpoints, getHomeDirectory()).ifPresent(p -> profiles.add(p));
+    return profiles;
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianFront50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianFront50Service.java
@@ -19,6 +19,8 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.debian;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.Front50Service;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
@@ -29,6 +31,8 @@ import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @EqualsAndHashCode(callSuper = true)
 @Data
@@ -45,6 +49,13 @@ public class LocalDebianFront50Service extends Front50Service implements LocalDe
   @Delegate(excludes = HasServiceSettings.class)
   LogCollector getLocalLogCollector() {
     return localLogCollectorFactory.build(this);
+  }
+
+  @Override
+  public List<Profile> getProfiles(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+    List<Profile> profiles = super.getProfiles(deploymentConfiguration, endpoints);
+    generateAwsProfile(deploymentConfiguration, endpoints, getHomeDirectory()).ifPresent(p -> profiles.add(p));
+    return profiles;
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianService.java
@@ -38,6 +38,10 @@ public interface LocalDebianService<T> extends LocalService<T> {
     return String.format("spinnaker-%s=%s", artifact.getName(), version);
   }
 
+  default String getHomeDirectory() {
+    return "/home/spinnaker";
+  }
+
   default String installArtifactCommand(DeploymentDetails deploymentDetails) {
     Map<String, String> bindings = new HashMap<>();
     String artifactName = getArtifact().getName();

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -24,7 +24,10 @@ import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/v1/versions")


### PR DESCRIPTION
Corrects assumptions about how clouddriver/front50 handle credentials & also ensures .aws/credentials file is generated & put in the right place when necessary.