### PR TITLE
feat(version): No default spinnaker version

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -45,7 +45,7 @@ public class DeploymentConfiguration extends Node {
    *
    * @see Halconfig#halyardVersion
    */
-  String version = "master-latest-unvalidated";
+  String version = "";
 
   /**
    * Providers, e.g. Kubernetes, GCE, AWS, etc...

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/VersionsService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/VersionsService.java
@@ -67,7 +67,7 @@ public class VersionsService {
     if (version == null || version.isEmpty()) {
       throw new HalException(
           new ConfigProblemBuilder(FATAL,
-              "No version specified to load.")
+              "You must pick a version of Spinnaker to deploy.")
               .build()
       );
     }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentConfigurationValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentConfigurationValidator.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.config.services.v1.VersionsService;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -40,6 +41,11 @@ public class DeploymentConfigurationValidator extends Validator<DeploymentConfig
   public void validate(ConfigProblemSetBuilder p, DeploymentConfiguration n) {
     String version = n.getVersion();
     Versions versions = versionsService.getVersions();
+
+    if (StringUtils.isEmpty(version)) {
+      p.addProblem(Problem.Severity.WARNING, "You have not yet selected a version of Spinnaker to deploy.", "version");
+      return;
+    }
 
     Optional<Versions.IllegalVersion> illegalVersion = versions.getIllegalVersions()
         .stream()

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/HalconfigSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/HalconfigSpec.groovy
@@ -45,7 +45,6 @@ class HalconfigSpec extends Specification {
     then:
     deployment.getNodeName()
     deployment.getName()
-    deployment.getVersion()
     deployment.getProviders()
     deployment.getCi()
   }


### PR DESCRIPTION
The behavior is now: A user can configure spinnaker w/o a versioned picked, but once they deploy it will fail.