### PR TITLE
fix(deploy): Local debian shows default site when bound to port 80

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
@@ -73,7 +73,7 @@ public class LocalDebianDeckService extends DeckService implements LocalDebianSe
   @Override
   public String stageProfilesCommand(DeploymentDetails details, GenerateService.ResolvedConfiguration resolvedConfiguration) {
     String stage = LocalDebianService.super.stageProfilesCommand(details, resolvedConfiguration);
-    return Strings.join("\n", stage, "a2ensite spinnaker");
+    return Strings.join("\n", stage, "a2ensite spinnaker", "a2dissite 000-default");
 
   }
 


### PR DESCRIPTION
When I use the `$HOME/.hal/default/service-settings/deck.yml` file to bind to port 80, I'm unable to connect to Spinnaker site.

The default enabled `000-default.conf` file in the apache2 binds to port 80 and this has precedence over `spinnaker.conf` file.