### PR TITLE
Enable authentication in deck when authn is enabled

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckDockerProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckDockerProfileFactory.java
@@ -57,6 +57,7 @@ public class DeckDockerProfileFactory extends DeckProfileFactory {
       env.put("DECK_HOST", deckSettings.getHost());
       env.put("DECK_PORT", deckSettings.getPort() + "");
       env.put("API_HOST", gateSettings.getBaseUrl());
+      env.put("AUTH_ENABLED", Boolean.toString(deploymentConfiguration.getSecurity().getAuthn().isEnabled()));
       env.put("DECK_CERT", apacheSsl.getSslCertificateFile());
       env.put("DECK_KEY", apacheSsl.getSslCertificateKeyFile());
       env.put("PASSPHRASE", apacheSsl.getSslCertificatePassphrase());


### PR DESCRIPTION
This fixes an issue where the `authEnabled` property is not set when authentication is enabled in Halyard. 

If `authEnabled` is not set properly when `authn` is enabled, the Deck UI doesn't work properly (failure to redirect to login page, missing user banner, etc,.).