### PR TITLE
fix(install): Use halyard-user to assign ownership to log dir

### DIFF
--- a/halyard-web/pkg_scripts/postInstall.sh
+++ b/halyard-web/pkg_scripts/postInstall.sh
@@ -5,6 +5,15 @@ echo '/opt/halyard/bin/hal "$@"' | sudo tee /usr/local/bin/hal > /dev/null
 
 chmod +x /usr/local/bin/hal
 
-install --mode=755 --owner=spinnaker --group=spinnaker --directory  /var/log/spinnaker/halyard 
+HAL_USER=""
+if [ -f "/opt/spinnaker/config/halyard-user" ]; then
+  HAL_USER=$(cat /opt/spinnaker/config/halyard-user)
+fi
+
+if [ -z "$HAL_USER" ];
+  HAL_USER="ubuntu"
+fi
+
+install --mode=755 --owner=$HAL_USER --group=$HAL_USER --directory /var/log/spinnaker/halyard
 
 service halyard restart

--- a/install/InstallHalyard.sh.gen
+++ b/install/InstallHalyard.sh.gen
@@ -369,6 +369,8 @@ if [ "$?" != "0" ]; then
 fi
 set -e
 
+configure_halyard_defaults
+
 echo "$(tput bold)Configuring external apt repos...$(tput sgr0)"
 add_apt_repositories
 
@@ -384,7 +386,6 @@ fi
 echo "$(tput bold)Installing Halyard...$(tput sgr0)"
 install_halyard
 
-configure_halyard_defaults
 configure_bash_completion
 
 start halyard

--- a/install/nightly/InstallHalyard.sh
+++ b/install/nightly/InstallHalyard.sh
@@ -369,6 +369,8 @@ if [ "$?" != "0" ]; then
 fi
 set -e
 
+configure_halyard_defaults
+
 echo "$(tput bold)Configuring external apt repos...$(tput sgr0)"
 add_apt_repositories
 
@@ -384,7 +386,6 @@ fi
 echo "$(tput bold)Installing Halyard...$(tput sgr0)"
 install_halyard
 
-configure_halyard_defaults
 configure_bash_completion
 
 start halyard

--- a/install/stable/InstallHalyard.sh
+++ b/install/stable/InstallHalyard.sh
@@ -369,6 +369,8 @@ if [ "$?" != "0" ]; then
 fi
 set -e
 
+configure_halyard_defaults
+
 echo "$(tput bold)Configuring external apt repos...$(tput sgr0)"
 add_apt_repositories
 
@@ -384,7 +386,6 @@ fi
 echo "$(tput bold)Installing Halyard...$(tput sgr0)"
 install_halyard
 
-configure_halyard_defaults
 configure_bash_completion
 
 start halyard


### PR DESCRIPTION
There are duplicate changes to the install script, because the InstallHalyard.sh.gen generates (with some small templating) the other two InstallHalyard.sh files.

By first setting halyard-user (before Halyard is installed) we can be sure that the log dir can be correctly assigned on both installs & updates of Halyard.