### PR TITLE
chore(install): New install path

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -224,6 +224,7 @@ hal [parameters] [subcommands]
 ```
 #### Global Parameters
  * `--options`: Get options for the specified field name.
+ * `-a, --alpha`: Enable alpha halyard features.
  * `-c, --color`: Enable terminal color output.
  * `-d, --debug`: Show detailed network traffic with halyard daemon.
  * `-h, --help`: (*Default*: `false`) Display help text about this command.

--- a/halyard-cli/daemon-halyard
+++ b/halyard-cli/daemon-halyard
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+../gradlew

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/Main.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/Main.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
 import com.netflix.spinnaker.halyard.cli.command.v1.HalCommand;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 
-
 public class Main {
   public static void main(String[] args) {
     GlobalOptions globalOptions = GlobalOptions.getGlobalOptions();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/GlobalOptions.java
@@ -35,6 +35,8 @@ public class GlobalOptions {
 
   private boolean quiet = false;
 
+  private boolean alpha = false;
+
   private String options;
 
   private Level log;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -25,7 +25,12 @@ import com.netflix.spinnaker.halyard.cli.command.v1.converter.FormatConverter;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LogLevelConverter;
 import com.netflix.spinnaker.halyard.cli.services.v1.ExpectedDaemonFailureException;
 import com.netflix.spinnaker.halyard.cli.services.v1.TaskKilledException;
-import com.netflix.spinnaker.halyard.cli.ui.v1.*;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiParagraphBuilder;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiPrinter;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiStoryBuilder;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiStyle;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
 import com.netflix.spinnaker.halyard.core.job.v1.JobExecutorLocal;
 import com.netflix.spinnaker.halyard.core.resource.v1.JarResource;
@@ -37,7 +42,12 @@ import retrofit.RetrofitError;
 
 import java.io.Console;
 import java.net.ConnectException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.ThreadLocalRandom;
 
 @Parameters(separators = "=")
@@ -62,7 +72,12 @@ public abstract class NestableCommand {
     GlobalOptions.getGlobalOptions().setDebug(debug);
   }
 
-  @Parameter(names = {"-q", "--quiet"}, description = "Show no task information or messages. When set, ANSI formatting will be disabled, and all prompts will be accepted.")
+  @Parameter(names = {"-a", "--alpha"}, description = "Enable alpha halyard features.")
+  public void setAlpha(boolean alpha) {
+    GlobalOptions.getGlobalOptions().setAlpha(alpha);
+  }
+
+    @Parameter(names = {"-q", "--quiet"}, description = "Show no task information or messages. When set, ANSI formatting will be disabled, and all prompts will be accepted.")
   public void setQuiet(boolean quiet) {
     GlobalOptions.getGlobalOptions().setQuiet(quiet);
     GlobalOptions.getGlobalOptions().setColor(!quiet);

--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+
+set -e
+
+function process_args() {
+  while [ "$#" -gt "0" ]
+  do
+    local key="$1"
+    shift
+    case $key in
+      --user)
+        echo "user"
+        HAL_USER="$1"
+        shift
+        ;;
+      --version)
+        echo "version"
+        VERSION="$1"
+        shift
+        ;;
+      -y)
+        echo "non-interactive"
+        YES=true
+        ;;
+      --help|-help|-h)
+        print_usage
+        exit 13
+        ;;
+      *)
+        echo "ERROR: Unknown argument '$key'"
+        exit -1
+    esac
+  done
+}
+
+function get_user() {
+  local user 
+
+  user=$(who -m | awk '{print $1;}')
+  if [ -z "$YES" ]; then
+    if [ "$user" = "root" ] || [ -z "$user" ]; then
+      read -p "Please supply a non-root user to run Halyard as: " user
+    fi
+  fi
+
+  echo $user
+}
+
+function configure_defaults() {
+  if [ -z "$HAL_USER" ]; then
+    HAL_USER=$(get_user)
+  fi
+
+  if [ -z "$HAL_USER" ]; then
+    >&2 echo "You have not supplied a user to run Halyard as."
+    exit 1
+  fi
+
+  if [ "$HAL_USER" = "root" ]; then
+    >&2 echo "Halyard may not be run as root. Supply a user to run Halyard as: "
+    >&2 echo "  sudo bash $0 --user <user>"
+    exit 1
+  fi
+
+  set +e
+  getent passwd $HAL_USER &> /dev/null
+
+  if [ "$?" != "0" ]; then
+    >&2 echo "Supplied user $HAL_USER does not exist"
+    exit 1
+  fi
+  set -e
+
+  if [ -z "$VERSION" ]; then
+    VERSION="latest"
+  fi
+
+  echo "$(tput bold)Halyard version will be $VERSION $(tput sgr0)"
+
+  home=$(getent passwd $HAL_USER | cut -d: -f6)
+  local halconfig_dir="$home/.hal"
+
+  echo "$(tput bold)Halconfig will be stored at $halconfig_dir/config$(tput sgr0)"
+
+  mkdir -p $halconfig_dir
+  chown $HAL_USER $halconfig_dir
+
+  mkdir -p /opt/spinnaker/config
+  chmod +rx /opt/spinnaker/config
+
+  cat > /opt/spinnaker/config/halyard.yml <<EOL
+halyard:
+  halconfig:
+    directory: $halconfig_dir
+
+spinnaker:
+  artifacts:
+    debianRepository: $SPINNAKER_REPOSITORY_URL
+    dockerRegistry: $SPINNAKER_DOCKER_REGISTRY
+    googleImageProject: $SPINNAKER_GCE_PROJECT
+EOL
+
+  echo $HAL_USER > /opt/spinnaker/config/halyard-user
+
+  cat > $halconfig_dir/uninstall.sh <<EOL
+#!/usr/bin/env bash
+
+if [[ `/usr/bin/id -u` -ne 0 ]]; then
+  echo "$0 must be executed with root permissions; exiting"
+  exit 1
+fi
+
+read -p "This script uninstalls Halyard and deletes all of its artifacts, are you sure you want to continue? (Y/n): " yes
+
+if [ "\$yes" != "y" ] && [ "\$yes" != "Y" ]; then
+  echo "Aborted"
+  exit 0
+fi
+
+rm /opt/halyard -rf
+rm /var/log/spinnaker/halyard -rf
+
+echo "Deleting halconfig and artifacts"
+rm $staging -rf
+rm /opt/spinnaker/config/halyard* -rf
+rm $halconfig_dir -rf
+EOL
+
+  chmod +x $halconfig_dir/uninstall.sh
+  echo "$(tput bold)Uninstall script is located at $halconfig_dir/uninstall.sh$(tput sgr0)"
+}
+
+
+function print_usage() {
+  cat <<EOF
+usage: $0 [-y] [--version=<version>] [--user=<user>]
+    -y                              Accept all default options during install
+                                    (non-interactive mode).
+
+    --version <version>             Specify the exact verison of Halyard to
+                                    install.
+
+    --user <user>                   Specify the user to run Halyard as. This
+                                    user must exist.
+EOF
+}
+
+function install_java() {
+  set +e
+  local java_version=$(java -version 2>&1 head -1)
+  set -e
+
+  if [[ "$java_version" == "*1.8*" ]]; then
+    echo "Java is already installed & at the right version"
+    return 0;
+  fi
+
+  if [ ! -f /etc/os-release ]; then
+    >&2 "Unable to determine OS platform (no /etc/os-release file)"
+    exit 1
+  fi
+
+  source /etc/os-release
+
+  if [ "$ID" = "ubuntu" ]; then
+    echo "Running ubuntu $VERSION_ID"
+    # Java 8
+    # https://launchpad.net/~openjdk-r/+archive/ubuntu/ppa
+    add-apt-repository -y ppa:openjdk-r/ppa
+    apt-get update ||:
+
+    apt-get install -y --force-yes openjdk-8-jre
+
+    # https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/983302
+    # It seems a circular dependency was introduced on 2016-04-22 with an openjdk-8 release, where
+    # the JRE relies on the ca-certificates-java package, which itself relies on the JRE. D'oh!
+    # This causes the /etc/ssl/certs/java/cacerts file to never be generated, causing a startup
+    # failure in Clouddriver.
+    dpkg --purge --force-depends ca-certificates-java
+    apt-get install ca-certificates-java
+  elif [ "$ID" = "debian" ] && [ "$VERSION_ID" = "8" ]; then
+    echo "Running debian 8 (jessie)"
+    apt install -t jessie-backports openjdk-8-jre-headless ca-certificates-java
+  elif [ "$ID" = "debian" ] && [ "$VERSION_ID" = "9" ]; then
+    echo "Running debian 9 (stretch)"
+    apt install -t stretch-backports openjdk-8-jre-headless ca-certificates-java
+  else
+    >&2 echo "Distribution $PRETTY_NAME is not supported yet - please file an issue"
+    >&2 echo "  https://github.com/spinnaker/halyard/issues"
+    exit 1
+  fi
+}
+
+function install_halyard() {
+  TEMPDIR=$(mktemp -d installhalyard.XXXX)
+  pushd $TEMPDIR
+
+  curl -O https://storage.googleapis.com/spinnaker-artifacts/halyard/$VERSION/debian/halyard.tar.gz
+  tar -xvf halyard.tar.gz -C /opt
+
+  mv /opt/hal /usr/local/bin
+  chmod +x /usr/local/bin/hal
+
+  mkdir -p /var/log/spinnaker/halyard
+  chown $HAL_USER /var/log/spinnaker/halyard
+  chmod 755 /var/log/spinnaker/halyard
+
+  popd
+  rm -rf $TEMPDIR
+}
+
+process_args $@
+configure_defaults
+
+install_java
+install_halyard
+
+su -c "hal -v" -s /bin/bash $HAL_USER

--- a/release/all.sh
+++ b/release/all.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+
+./gradlew clean && ./gradlew installDist
+
+PLATFORMS=(debian)
+VERSION=$1
+
+USAGE="You must supply <version>, e.g.\n $0 <version>"
+
+if [ -z "$VERSION" ]; then
+  >&2 echo $USAGE
+  exit 1
+fi
+
+for PLATFORM in "${PLATFORMS[@]}"; do
+  echo "Building & releasing $PLATFORM..."
+  ./release/$PLATFORM.sh
+  ./release/publish.sh $VERSION $PLATFORM
+done

--- a/release/debian.sh
+++ b/release/debian.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+tar -cvf halyard.tar.gz -C halyard-web/build/install halyard/ -C ../../../startup/debian hal

--- a/release/publish.sh
+++ b/release/publish.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+VERSION=$1
+PLATFORM=$2
+
+USAGE="You must supply <version> and <platform>, e.g.\n $0 <version> <platform>"
+
+if [ -z "$VERSION" ]; then
+  >&2 echo $USAGE
+  exit 1
+fi
+
+if [ -z "$PLATFORM" ]; then
+  >&2 echo $USAGE
+  exit 1
+fi
+
+./release/$PLATFORM.sh
+
+BUCKET_PATH=gs://spinnaker-artifacts/halyard/$VERSION/$PLATFORM/halyard.tar.gz
+
+gsutil cp halyard.tar.gz $BUCKET_PATH
+gsutil acl ch -u AllUsers:R $BUCKET_PATH

--- a/startup/debian/hal
+++ b/startup/debian/hal
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+
+HALYARD_DAEMON_PID_FILE=/opt/halyard/pid
+HALYARD_DAEMON_PID=""
+HALYARD_STARTUP_TIMEOUT_SECONDS=120
+
+HAL=/opt/halyard/bin/hal 
+
+function start_daemon() {
+    printf "The halyard daemon isn't running yet... starting it manually"
+
+    /opt/halyard/bin/halyard \
+      2> /var/log/spinnaker/halyard/halyard.err \
+      > /var/log/spinnaker/halyard/halyard.log &
+
+    echo $! > $HALYARD_DAEMON_PID_FILE 
+
+    local wait_start=$(date +%s)
+
+    set +e
+    $HAL --ready &> /dev/null
+    while [ "$?" != "0" ]; do
+        local wait_now=$(date +%s)
+        local wait_time=$(( $wait_now - $wait_start ))
+
+        if [ "$wait_time" -gt "$HALYARD_STARTUP_TIMEOUT_SECONDS" ]; then
+            >&2 echo ""
+            >&2 echo "Waiting for halyard to start timed out after $wait_time seconds"
+            exit 1
+        fi
+
+        printf '.'
+        sleep 2
+        $HAL --ready &> /dev/null
+    done
+    set -e
+
+    echo ""
+}
+
+if [ -f "$HALYARD_DAEMON_PID_FILE" ]; then
+    HALYARD_DAEMON_PID=$(cat $HALYARD_DAEMON_PID_FILE)
+fi
+
+if [ -z "$HALYARD_DAEMON_PID" ]; then
+    start_daemon
+else
+    ps $HALYARD_DAEMON_PID &> /dev/null
+
+    if [ $? -ne "0" ]; then
+        start_daemon
+    fi
+fi
+
+$HAL $@


### PR DESCRIPTION
The idea is:

1. We package up the JARs & generated wrapper scripts built by gradle
2. Users download that package as well as a script that starts the daemon when it's not running yet

Each system will need to supply a script to download java8, as well as provide a script to start the daemon when it's not running. 
