### PR TITLE
feat(deploy): Disable nu-orca instances during deploy

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -27,6 +27,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+import retrofit.client.Response;
 import retrofit.http.*;
 
 import java.nio.file.Paths;
@@ -81,6 +82,9 @@ abstract public class OrcaService extends SpringService<OrcaService.Orca> {
 
     @GET("/executions/activeByInstance")
     Map<String, ActiveExecutions> getActiveExecutions();
+
+    @POST("/admin/instance/enabled")
+    Response setInstanceStatusEnabled(@Body Map<String, String> request);
 
     @GET("/resolvedEnv")
     Map<String, String> resolvedEnv();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedService.java
@@ -57,6 +57,7 @@ public interface DistributedService<T, A extends Account> extends HasServiceSett
   String getServiceName();
   SpinnakerMonitoringDaemonService getMonitoringDaemonService();
   <S> S connectToService(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings, SpinnakerService<S> sidecar);
+  <S> S connectToInstance(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings, SpinnakerService<S> sidecar, String instanceId);
   String connectCommand(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings);
   void deleteVersion(AccountDeploymentDetails<A> details, ServiceSettings settings, Integer version);
   void resizeVersion(AccountDeploymentDetails<A> details, ServiceSettings settings, int version, int targetSize);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesProviderUtils.java
@@ -205,7 +205,7 @@ class KubernetesProviderUtils {
     return halSecret(name, version, "dependencies");
   }
 
-  static List<String> kubectlPortForwardCommand(AccountDeploymentDetails<KubernetesAccount> details, String namespace, String instance, int port) {
+  static List<String> kubectlPortForwardCommand(AccountDeploymentDetails<KubernetesAccount> details, String namespace, String instance, int targetPort, int localPort) {
     List<String> command =  kubectlAccountCommand(details);
     command.add("--namespace");
     command.add(namespace);
@@ -213,7 +213,7 @@ class KubernetesProviderUtils {
     command.add("port-forward");
     command.add(instance);
 
-    command.add(port + "");
+    command.add(localPort + ":" + targetPort);
     return command;
   }
 


### PR DESCRIPTION
This gracefully handles a mix of nu & old orcas by only disabling (and then flagging for either deletion or scaling down depending on the age) orca instances that implement the new `/admin/instance/enabled` endpoint. All other orcas are untouched & reported as "unkillable". See sample behavior here: 
![hal-nu-orca](https://user-images.githubusercontent.com/4874941/28842317-284daba4-76cb-11e7-86f5-c89c102384f7.png)
