### PR TITLE
Install kubectl inside the container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM java:8
 
 MAINTAINER delivery-engineering@netflix.com
 
+ENV KUBECTL_RELEASE=v1.7.3
+
 COPY . workdir/
 
 WORKDIR workdir
@@ -15,5 +17,9 @@ RUN echo '#!/usr/bin/env bash' | tee /usr/local/bin/hal > /dev/null && \
   echo '/opt/halyard/bin/hal "$@"' | tee /usr/local/bin/hal > /dev/null
 
 RUN chmod +x /usr/local/bin/hal
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
 
 CMD "/opt/halyard/bin/halyard"

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,6 +2,8 @@ FROM java:8
 
 MAINTAINER delivery-engineering@netflix.com
 
+ENV KUBECTL_RELEASE=v1.7.3
+
 COPY . workdir/
 
 WORKDIR workdir
@@ -14,5 +16,9 @@ RUN echo '#!/usr/bin/env bash' | tee /usr/local/bin/hal > /dev/null && \
   echo '/opt/halyard/bin/hal "$@"' | tee /usr/local/bin/hal > /dev/null
 
 RUN chmod +x /usr/local/bin/hal
+
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
 
 CMD "/opt/halyard/bin/halyard"


### PR DESCRIPTION
The halyard container image needs the kubectl command for setting up distributed environments.

It was missing from the default setup and needs to be installed afterwards, which can be PITA when repeatedly running it.

I installed it inside to have it available without additional work.