### PR TITLE
fix(halyard/KubernetesDistributedService): Clean Command

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceProvider.java
@@ -75,7 +75,8 @@ public class KubernetesDistributedServiceProvider extends DistributedServiceProv
 
   @Override
   public RemoteAction clean(AccountDeploymentDetails<KubernetesAccount> details, SpinnakerRuntimeSettings runtimeSettings) {
-    KubernetesProviderUtils.kubectlDeleteNamespaceCommand(DaemonTaskHandler.getJobExecutor(), details, "spinnaker");
+    KubernetesSharedServiceSettings kubernetesSharedServiceSettings = new KubernetesSharedServiceSettings(details.getDeploymentConfiguration());
+    KubernetesProviderUtils.kubectlDeleteNamespaceCommand(DaemonTaskHandler.getJobExecutor(), details, kubernetesSharedServiceSettings.getDeployLocation());
     return new RemoteAction();
   }
 }


### PR DESCRIPTION
https://github.com/spinnaker/halyard/pull/654 introduced a bug where the clean command would not accept a user defined deploy location. 