### PR TITLE
Validate all Providers in ProvidersSpec.

### DIFF
--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/ProvidersSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/ProvidersSpec.groovy
@@ -17,48 +17,79 @@
 package com.netflix.spinnaker.halyard.config.model.v1
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Providers
+import com.netflix.spinnaker.halyard.config.model.v1.providers.appengine.AppengineProvider
+import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider
+import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSProvider
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleProvider
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesProvider
+import com.netflix.spinnaker.halyard.config.model.v1.providers.openstack.OpenstackProvider
+import com.netflix.spinnaker.halyard.config.model.v1.providers.oraclebmcs.OracleBMCSProvider
 import spock.lang.Specification
+import spock.lang.Unroll
 
 class ProvidersSpec extends Specification {
-  void "providers correctly reports configurable providers"() {
+
+  // This version makes use of groovy list comparisons. It's shorter and will actually
+  // detect if the set of actual providers has any extra values which aren't expected.
+  void "reports configurable providers"() {
     setup:
     def providers = new Providers()
     def iterator = providers.getChildren()
-    def kubernetes = false
-    def dockerRegistry = false
-    def google = false
-    def azure = false
+    def expectedProviders = [
+        AppengineProvider,
+        AwsProvider,
+        AzureProvider,
+        DCOSProvider,
+        DockerRegistryProvider,
+        GoogleProvider,
+        KubernetesProvider,
+        OracleBMCSProvider,
+        OpenstackProvider
+    ]
 
     when:
+    List actualProviders = []
     def child = iterator.getNext()
     while (child != null) {
-      if (child instanceof KubernetesProvider) {
-        kubernetes = true
-      }
-
-      if (child instanceof DockerRegistryProvider) {
-        dockerRegistry = true
-      }
-
-      if (child instanceof GoogleProvider) {
-        google = true
-      }
-
-      if (child instanceof AzureProvider) {
-        azure = true
-      }
-
+      actualProviders << child.class
       child = iterator.getNext()
     }
 
     then:
-    kubernetes
-    dockerRegistry
-    google
-    azure
+    actualProviders.sort() == expectedProviders.sort()
+  }
+
+  // This version has the advantage that on failure, it's really clear which
+  // provider(s) is/are missing. Each one gets its own separate, labeled run.
+  @Unroll("children includes #provider")
+  void "reports all configurable providers"() {
+
+    setup:
+    def iterator = new Providers().getChildren()
+
+    when:
+    List actualProviders = []
+    def child
+    while (child = iterator.next) {
+      actualProviders << child.class
+    }
+
+    then:
+    actualProviders.contains(provider)
+
+    where:
+    provider << [
+        AppengineProvider,
+        AwsProvider,
+        AzureProvider,
+        DCOSProvider,
+        DockerRegistryProvider,
+        GoogleProvider,
+        KubernetesProvider,
+        OracleBMCSProvider,
+        OpenstackProvider
+    ]
   }
 }

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/ProvidersSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/ProvidersSpec.groovy
@@ -31,40 +31,8 @@ import spock.lang.Unroll
 
 class ProvidersSpec extends Specification {
 
-  // This version makes use of groovy list comparisons. It's shorter and will actually
-  // detect if the set of actual providers has any extra values which aren't expected.
-  void "reports configurable providers"() {
-    setup:
-    def providers = new Providers()
-    def iterator = providers.getChildren()
-    def expectedProviders = [
-        AppengineProvider,
-        AwsProvider,
-        AzureProvider,
-        DCOSProvider,
-        DockerRegistryProvider,
-        GoogleProvider,
-        KubernetesProvider,
-        OracleBMCSProvider,
-        OpenstackProvider
-    ]
-
-    when:
-    List actualProviders = []
-    def child = iterator.getNext()
-    while (child != null) {
-      actualProviders << child.class
-      child = iterator.getNext()
-    }
-
-    then:
-    actualProviders.sort() == expectedProviders.sort()
-  }
-
-  // This version has the advantage that on failure, it's really clear which
-  // provider(s) is/are missing. Each one gets its own separate, labeled run.
-  @Unroll("children includes #provider")
-  void "reports all configurable providers"() {
+  @Unroll()
+  void "children includes #provider.simpleName"() {
 
     setup:
     def iterator = new Providers().getChildren()


### PR DESCRIPTION
READ FIRST.

I beefed up the ProvidersSpec to validate that _all_ current providers show up as children in the iterator. 

In addition, I restructured the spec to be a little more groovy and a little less iffy. But I couldn't decide _which_ of two structures to go with. So I'm interested in @lwander's opinion and preference. See the comments above each method for high-level descriptions of why you might prefer one or the other.