### PR TITLE
fix(deploy): Fix deserialization bug showing strange errors

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
@@ -229,7 +229,7 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
     Supplier<String> idSupplier;
     if (!runningServiceDetails.getLoadBalancer().isExists()) {
       Map<String, Object> task = distributedService.buildUpsertLoadBalancerTask(details, runtimeSettings);
-      idSupplier = () -> orca.submitTask(task).get("ref");
+      idSupplier = () -> (String) orca.submitTask(task).get("ref");
       orcaRunner.monitorTask(idSupplier, orca);
     }
 
@@ -242,7 +242,7 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
     }
 
     Map<String, Object> pipeline = distributedService.buildDeployServerGroupPipeline(details, runtimeSettings, configs, maxRemaining, scaleDown);
-    idSupplier = () -> orca.orchestrate(pipeline).get("ref");
+    idSupplier = () -> (String) orca.orchestrate(pipeline).get("ref");
     orcaRunner.monitorPipeline(idSupplier, orca);
   }
 
@@ -252,7 +252,7 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
       SpinnakerRuntimeSettings runtimeSettings) {
     DaemonTaskHandler.newStage("Rolling back " + distributedService.getServiceName());
     Map<String, Object> pipeline = distributedService.buildRollbackPipeline(details, runtimeSettings);
-    Supplier<String> idSupplier = () -> orca.orchestrate(pipeline).get("ref");
+    Supplier<String> idSupplier = () -> (String) orca.orchestrate(pipeline).get("ref");
     orcaRunner.monitorPipeline(idSupplier, orca);
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -72,10 +72,10 @@ abstract public class OrcaService extends SpringService<OrcaService.Orca> {
   public interface Orca {
     @Headers("Content-type: application/context+json")
     @POST("/ops")
-    Map<String, String> submitTask(@Body Map task);
+    Map<String, Object> submitTask(@Body Map task);
 
     @POST("/orchestrate")
-    Map<String, String> orchestrate(@Body Map pipeline);
+    Map<String, Object> orchestrate(@Body Map pipeline);
 
     @GET("/{id}")
     Map<String, Object> getRef(@Path(encode = false, value = "id") String id);


### PR DESCRIPTION
When kubernetes returns a 503 for a non-existent service, retrofit tries to cast the error message into that of the original response body type. 