### PR TITLE
fix(config/orca): append singular form and plural form of pipelineTemplates

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -40,8 +40,10 @@ public class OrcaProfileFactory extends SpringProfileFactory {
       profile.appendContents("default.securityGroups: ");
       profile.appendContents("default.vpc.securityGroups: ");
     }
-    
-    profile.appendContents("pipelineTemplates.enabled: "
-      + Boolean.toString(deploymentConfiguration.getFeatures().getPipelineTemplates() != null ? deploymentConfiguration.getFeatures().getPipelineTemplates() : false));
+
+    String pipelineTemplates = Boolean.toString(deploymentConfiguration.getFeatures().getPipelineTemplates() != null ? deploymentConfiguration.getFeatures().getPipelineTemplates() : false);
+    profile.appendContents("pipelineTemplates.enabled: " + pipelineTemplates);
+    // For backward compatibility
+    profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
   }
 }


### PR DESCRIPTION
To support old versions of orca, it is needed to append also the singular form and not just the plural.

#664