### PR TITLE
Make buildResponse a required field of StaticRequestBuilder

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
@@ -100,6 +100,10 @@ public class DaemonResponse<T> {
     private Supplier<ProblemSet> validateResponse;
     private Severity severity = Severity.WARNING;
 
+    public StaticRequestBuilder(Supplier<K> buildResponse) {
+      this.buildResponse = buildResponse;
+    }
+
     public DaemonResponse<K> build() {
       if (buildResponse == null) {
         throw new IllegalArgumentException("No response provided to build");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
@@ -95,8 +95,7 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
         // Do nothing, the bootstrapping services should already be running, and the services that can't be updated
         // having nothing to rollback to
       } else {
-        DaemonResponse.StaticRequestBuilder<Void> builder = new DaemonResponse.StaticRequestBuilder<>();
-        builder.setBuildResponse(() -> {
+        DaemonResponse.StaticRequestBuilder<Void> builder = new DaemonResponse.StaticRequestBuilder<>(() -> {
           Orca orca = serviceProvider
               .getDeployableService(SpinnakerService.Type.ORCA_BOOTSTRAP, Orca.class)
               .connectToPrimaryService(deploymentDetails, runtimeSettings);
@@ -175,8 +174,7 @@ public class DistributedDeployer<T extends Account> implements Deployer<Distribu
       if (distributedService.isRequiredToBootstrap() || !safeToUpdate) {
         deployServiceManually(deploymentDetails, resolvedConfiguration, distributedService, safeToUpdate);
       } else {
-        DaemonResponse.StaticRequestBuilder<Void> builder = new DaemonResponse.StaticRequestBuilder<>();
-        builder.setBuildResponse(() -> {
+        DaemonResponse.StaticRequestBuilder<Void> builder = new DaemonResponse.StaticRequestBuilder<>(() -> {
           if (runningServiceDetails.getLatestEnabledVersion() == null) {
             DaemonTaskHandler.newStage("Deploying " + distributedService.getServiceName() + " via provider API");
             deployServiceManually(deploymentDetails, resolvedConfiguration, distributedService, safeToUpdate);

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
@@ -54,8 +54,8 @@ public class AccountController {
       @PathVariable String providerName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<List<Account>> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> accountService.getAllAccounts(deploymentName, providerName));
+    StaticRequestBuilder<List<Account>> builder = new StaticRequestBuilder<>(
+            () -> accountService.getAllAccounts(deploymentName, providerName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -72,8 +72,8 @@ public class AccountController {
       @PathVariable String accountName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<Account> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> accountService.getProviderAccount(deploymentName, providerName, accountName));
+    StaticRequestBuilder<Account> builder = new StaticRequestBuilder<>(
+            () -> accountService.getProviderAccount(deploymentName, providerName, accountName));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AdminController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AdminController.java
@@ -38,8 +38,7 @@ public class AdminController {
       @RequestParam(required = false) String latestSpinnaker,
       @RequestParam(required = false) String latestHalyard,
       @RequestBody String _ignored) {
-    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>(() -> {
       if (!StringUtils.isEmpty(latestSpinnaker)) {
         artifactService.publishLatestSpinnaker(latestSpinnaker);
       }
@@ -57,8 +56,7 @@ public class AdminController {
   DaemonTask<Halconfig, Void> deprecateVersion(
       @RequestParam(required = false) String illegalReason,
       @RequestBody Versions.Version version) {
-    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>( () -> {
       artifactService.deprecateVersion(version, illegalReason);
       return null;
     });
@@ -69,8 +67,7 @@ public class AdminController {
   @RequestMapping(value = "/publishVersion", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> publishVersion(
       @RequestBody Versions.Version version) {
-    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>(() -> {
       artifactService.publishVersion(version);
       return null;
     });
@@ -82,8 +79,7 @@ public class AdminController {
   DaemonTask<Halconfig, Void> publishBom(
       @RequestParam String bomPath,
       @RequestBody String _ignored) {
-    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>(() -> {
       artifactService.writeBom(bomPath);
       return null;
     });
@@ -97,8 +93,7 @@ public class AdminController {
       @PathVariable String artifactName,
       @RequestParam String profilePath,
       @RequestBody String _ignored) {
-    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>(() -> {
       artifactService.writeArtifactConfig(bomPath, artifactName, profilePath);
       return null;
     });

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BackupController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BackupController.java
@@ -42,15 +42,14 @@ public class BackupController {
 
   @RequestMapping(value = "/create", method = RequestMethod.PUT)
   DaemonTask<Halconfig, StringBodyRequest> create() {
-    StaticRequestBuilder<StringBodyRequest> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> new StringBodyRequest(backupService.create()));
+    StaticRequestBuilder<StringBodyRequest> builder = new StaticRequestBuilder<>(
+            () -> new StringBodyRequest(backupService.create()));
     return DaemonTaskHandler.submitTask(builder::build, "Create backup");
   }
 
   @RequestMapping(value = "/restore", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> restore(@RequestParam String backupPath) {
-    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> {
+    StaticRequestBuilder<Void> builder = new StaticRequestBuilder<>( () -> {
       backupService.restore(backupPath);
       return null;
     });

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
@@ -53,9 +53,8 @@ public class BakeryController {
   DaemonTask<Halconfig, BakeryDefaults> getBakeryDefaults(@PathVariable String deploymentName, @PathVariable String providerName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<BakeryDefaults> builder = new DaemonResponse.StaticRequestBuilder<>();
-
-    builder.setBuildResponse(() -> bakeryService.getBakeryDefaults(deploymentName, providerName));
+    DaemonResponse.StaticRequestBuilder<BakeryDefaults> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> bakeryService.getBakeryDefaults(deploymentName, providerName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -97,8 +96,8 @@ public class BakeryController {
   DaemonTask<Halconfig, List<BaseImage>> images(@PathVariable String deploymentName, @PathVariable String providerName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<List<BaseImage>> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> bakeryService.getAllBaseImages(deploymentName, providerName));
+    StaticRequestBuilder<List<BaseImage>> builder = new StaticRequestBuilder<>(
+            () -> bakeryService.getAllBaseImages(deploymentName, providerName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -115,8 +114,8 @@ public class BakeryController {
       @PathVariable String baseImageId,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<BaseImage> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> bakeryService.getProviderBaseImage(deploymentName, providerName, baseImageId));
+    StaticRequestBuilder<BaseImage> builder = new StaticRequestBuilder<>(
+            () -> bakeryService.getProviderBaseImage(deploymentName, providerName, baseImageId));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CiController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CiController.java
@@ -48,9 +48,8 @@ public class CiController {
       @PathVariable String ciName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<Ci> builder = new StaticRequestBuilder<>();
-
-    builder.setBuildResponse(() -> ciService.getCi(deploymentName, ciName));
+    StaticRequestBuilder<Ci> builder = new StaticRequestBuilder<>(
+            () -> ciService.getCi(deploymentName, ciName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -88,9 +87,7 @@ public class CiController {
   DaemonTask<Halconfig, List<Ci>> cis(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<List<Ci>> builder = new StaticRequestBuilder<>();
-
-    builder.setBuildResponse(() -> ciService.getAllCis(deploymentName));
+    StaticRequestBuilder<List<Ci>> builder = new StaticRequestBuilder<>(() -> ciService.getAllCis(deploymentName));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ClusterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ClusterController.java
@@ -61,8 +61,8 @@ public class ClusterController {
   DaemonTask<Halconfig, List<Cluster>> clusters(@PathVariable String deploymentName, @PathVariable String providerName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
-    DaemonResponse.StaticRequestBuilder<List<Cluster>> builder = new DaemonResponse.StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> clusterService.getAllClusters(deploymentName, providerName));
+    DaemonResponse.StaticRequestBuilder<List<Cluster>> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> clusterService.getAllClusters(deploymentName, providerName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -79,8 +79,8 @@ public class ClusterController {
       @PathVariable String clusterName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Cluster> builder = new DaemonResponse.StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> clusterService.getProviderCluster(deploymentName, providerName, clusterName));
+    DaemonResponse.StaticRequestBuilder<Cluster> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> clusterService.getProviderCluster(deploymentName, providerName, clusterName));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ConfigController.java
@@ -45,15 +45,13 @@ public class ConfigController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Halconfig> config() {
-    StaticRequestBuilder<Halconfig> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> configService.getConfig());
+    StaticRequestBuilder<Halconfig> builder = new StaticRequestBuilder<>(() -> configService.getConfig());
     return DaemonTaskHandler.submitTask(builder::build, "Get halconfig");
   }
 
   @RequestMapping(value = "/currentDeployment", method = RequestMethod.GET)
   DaemonTask<Halconfig, String> currentDeployment() {
-    StaticRequestBuilder<String> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> configService.getCurrentDeployment());
+    StaticRequestBuilder<String> builder = new StaticRequestBuilder<>(() -> configService.getCurrentDeployment());
     return DaemonTaskHandler.submitTask(builder::build, "Get current deployment");
   }
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentEnvironmentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentEnvironmentController.java
@@ -49,9 +49,8 @@ public class DeploymentEnvironmentController {
   DaemonTask<Halconfig, DeploymentEnvironment> getDeploymentEnvironment(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<DeploymentEnvironment> builder = new DaemonResponse.StaticRequestBuilder<>();
-
-    builder.setBuildResponse(() -> deploymentEnvironmentService.getDeploymentEnvironment(deploymentName));
+    DaemonResponse.StaticRequestBuilder<DeploymentEnvironment> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> deploymentEnvironmentService.getDeploymentEnvironment(deploymentName));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
@@ -48,9 +48,8 @@ public class FeaturesController {
   DaemonTask<Halconfig, Features> getFeatures(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Features> builder = new DaemonResponse.StaticRequestBuilder<>();
-
-    builder.setBuildResponse(() -> featuresService.getFeatures(deploymentName));
+    DaemonResponse.StaticRequestBuilder<Features> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> featuresService.getFeatures(deploymentName));
 
     return DaemonTaskHandler.submitTask(builder::build, "Get features");
   }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
@@ -51,8 +51,8 @@ public class MasterController {
   DaemonTask<Halconfig, List<Master>> masters(@PathVariable String deploymentName, @PathVariable String ciName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<List<Master>> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> masterService.getAllMasters(deploymentName, ciName));
+    StaticRequestBuilder<List<Master>> builder = new StaticRequestBuilder<>(
+            () -> masterService.getAllMasters(deploymentName, ciName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -69,8 +69,8 @@ public class MasterController {
       @PathVariable String masterName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<Master> builder = new StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> masterService.getCiMaster(deploymentName, ciName, masterName));
+    StaticRequestBuilder<Master> builder = new StaticRequestBuilder<>(
+            () -> masterService.getCiMaster(deploymentName, ciName, masterName));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MetricStoresController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MetricStoresController.java
@@ -48,10 +48,10 @@ public class MetricStoresController {
   DaemonTask<Halconfig, MetricStores> getMetricStores(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<MetricStores> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<MetricStores> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> metricStoresService.getMetricStores(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> metricStoresService.getMetricStores(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> metricStoresService.validateMetricStores(deploymentName));
@@ -65,10 +65,10 @@ public class MetricStoresController {
       @PathVariable String metricStoreType,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<MetricStore> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<MetricStore> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> metricStoresService.getMetricStore(deploymentName, metricStoreType));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> metricStoresService.getMetricStore(deploymentName, metricStoreType));
 
     if (validate) {
       builder.setValidateResponse(() -> metricStoresService.validateMetricStore(deploymentName, metricStoreType));

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PersistentStorageController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PersistentStorageController.java
@@ -49,9 +49,9 @@ public class PersistentStorageController {
   DaemonTask<Halconfig, PersistentStorage> getPersistentStorage(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<PersistentStorage> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<PersistentStorage> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> persistentStorageService.getPersistentStorage(deploymentName));
 
-    builder.setBuildResponse(() -> persistentStorageService.getPersistentStorage(deploymentName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -91,9 +91,9 @@ public class PersistentStorageController {
       @PathVariable String persistentStoreType,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<PersistentStore> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<PersistentStore> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> persistentStorageService.getPersistentStore(deploymentName, persistentStoreType));
 
-    builder.setBuildResponse(() -> persistentStorageService.getPersistentStore(deploymentName, persistentStoreType));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
@@ -52,9 +52,9 @@ public class ProviderController {
       @PathVariable String providerName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<Provider> builder = new StaticRequestBuilder<>();
+    StaticRequestBuilder<Provider> builder = new StaticRequestBuilder<>(
+            () -> providerService.getProvider(deploymentName, providerName));
 
-    builder.setBuildResponse(() -> providerService.getProvider(deploymentName, providerName));
     builder.setSeverity(severity);
 
     if (validate) {
@@ -121,9 +121,9 @@ public class ProviderController {
   DaemonTask<Halconfig, List<Provider>> providers(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    StaticRequestBuilder<List<Provider>> builder = new StaticRequestBuilder<>();
+    StaticRequestBuilder<List<Provider>> builder = new StaticRequestBuilder<>(
+            () -> providerService.getAllProviders(deploymentName));
 
-    builder.setBuildResponse(() -> providerService.getAllProviders(deploymentName));
     builder.setSeverity(severity);
 
     if (validate) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
@@ -47,10 +47,9 @@ public class SecurityController {
   DaemonTask<Halconfig, Security> getSecurity(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Security> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<Security> builder = new DaemonResponse.StaticRequestBuilder<>(() -> securityService.getSecurity(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getSecurity(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateSecurity(deploymentName));
@@ -63,10 +62,9 @@ public class SecurityController {
   DaemonTask<Halconfig, UiSecurity> getUiSecurity(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<UiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<UiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>(() -> securityService.getUiSecurity(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getUiSecurity(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateUiSecurity(deploymentName));
@@ -102,10 +100,9 @@ public class SecurityController {
   DaemonTask<Halconfig, ApacheSsl> getApacheSsl(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<ApacheSsl> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<ApacheSsl> builder = new DaemonResponse.StaticRequestBuilder<>(() -> securityService.getApacheSsl(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getApacheSsl(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateUiSecurity(deploymentName));
@@ -162,10 +159,10 @@ public class SecurityController {
   DaemonTask<Halconfig, ApiSecurity> getApiSecurity(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<ApiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<ApiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> securityService.getApiSecurity(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getApiSecurity(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateApiSecurity(deploymentName));
@@ -201,10 +198,10 @@ public class SecurityController {
   DaemonTask<Halconfig, SpringSsl> getSpringSsl(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<SpringSsl> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<SpringSsl> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> securityService.getSpringSsl(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getSpringSsl(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateUiSecurity(deploymentName));
@@ -284,10 +281,10 @@ public class SecurityController {
   DaemonTask<Halconfig, GroupMembership> getGroupMembership(@PathVariable String deploymentName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<GroupMembership> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<GroupMembership> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> securityService.getGroupMembership(deploymentName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getGroupMembership(deploymentName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateAuthz(deploymentName));
@@ -301,10 +298,10 @@ public class SecurityController {
       @PathVariable String methodName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<AuthnMethod> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<AuthnMethod> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> securityService.getAuthnMethod(deploymentName, methodName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getAuthnMethod(deploymentName, methodName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateAuthnMethod(deploymentName, methodName));
@@ -318,10 +315,10 @@ public class SecurityController {
       @PathVariable String roleProviderName,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
       @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<RoleProvider> builder = new DaemonResponse.StaticRequestBuilder<>();
+    DaemonResponse.StaticRequestBuilder<RoleProvider> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> securityService.getRoleProvider(deploymentName, roleProviderName));
 
     builder.setSeverity(severity);
-    builder.setBuildResponse(() -> securityService.getRoleProvider(deploymentName, roleProviderName));
 
     if (validate) {
       builder.setValidateResponse(() -> securityService.validateRoleProvider(deploymentName, roleProviderName));

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -37,22 +37,22 @@ public class VersionsController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Versions> config() {
-    DaemonResponse.StaticRequestBuilder<Versions> builder = new DaemonResponse.StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> versionsService.getVersions());
+    DaemonResponse.StaticRequestBuilder<Versions> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> versionsService.getVersions());
     return DaemonTaskHandler.submitTask(builder::build, "Get released versions");
   }
 
   @RequestMapping(value = "/latest/", method = RequestMethod.GET)
   DaemonTask<Halconfig, String> latest() {
-    DaemonResponse.StaticRequestBuilder<String> builder = new DaemonResponse.StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> versionsService.getLatestSpinnakerVersion());
+    DaemonResponse.StaticRequestBuilder<String> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> versionsService.getLatestSpinnakerVersion());
     return DaemonTaskHandler.submitTask(builder::build, "Get latest released version");
   }
 
   @RequestMapping(value = "/bom/{version:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, BillOfMaterials> bom(@PathVariable String version) {
-    DaemonResponse.StaticRequestBuilder<BillOfMaterials> builder = new DaemonResponse.StaticRequestBuilder<>();
-    builder.setBuildResponse(() -> versionsService.getBillOfMaterials(version));
+    DaemonResponse.StaticRequestBuilder<BillOfMaterials> builder = new DaemonResponse.StaticRequestBuilder<>(
+            () -> versionsService.getBillOfMaterials(version));
     return DaemonTaskHandler.submitTask(builder::build, "Get BOM for " + version);
   }
 }


### PR DESCRIPTION
Per Joshua Bloch's description in "Effective Java", required fields of
a builder should be compile-time required.

Context - this ticket:

https://github.com/spinnaker/halyard/issues/617

Appears to have been allowed because a required field was missing
during a large refactor:

https://github.com/spinnaker/halyard/pull/283