### PR TITLE
docs: link to spinnaker.io docs for halyard

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 A tool for configuring, installing, and updating Spinnaker.
 
+[Halyard Docs](https://www.spinnaker.io/setup/install/halyard/) are available on [spinnaker.io](https://spinnaker.io)
+
 ![](./demo.gif)
 
 ## Installation


### PR DESCRIPTION
It's not obvious that the github docs are non-exhaustive
and that the main docs are actually elsewhere