### PR TITLE
fix(build) Fix build warnings

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractEditProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractEditProviderCommand.java
@@ -25,9 +25,11 @@ import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 
 @Data
 @Parameters(separators = "=")
+@EqualsAndHashCode(callSuper = false)
 abstract public class AbstractEditProviderCommand<A extends Account, P extends Provider<A>> extends AbstractProviderCommand {
   String commandName = "edit";
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSAccount.java
@@ -53,6 +53,7 @@ public class DCOSAccount extends Account {
   }
 
   @Data
+  @EqualsAndHashCode(callSuper = false)
   public static class ClusterCredential extends Node implements Cloneable {
     private final String name;
     private final String uid;

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
@@ -55,8 +55,6 @@ public class Versions {
     String reason; // Why is this version illegal
   }
 
-  @Deprecated
-  String latest;
   String latestHalyard;
   String latestSpinnaker;
   List<Version> versions = new ArrayList<>();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/ArtifactService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/ArtifactService.java
@@ -130,7 +130,6 @@ public class ArtifactService {
       throw new HalException(FATAL, "Version " + latestSpinnaker + " does not exist in the list of published versions");
     }
 
-    versionsCollection.setLatest(latestSpinnaker);
     versionsCollection.setLatestSpinnaker(latestSpinnaker);
 
     writeableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));


### PR DESCRIPTION
Quick fix for a the loudest of the warnings that come up when building halyard.

The deprecated member seems to only be used in one place, where it is set. So removing it should have no functional effect.

The two @EqualsAndHashCode changes only make explicit what is already being built. If these _should_ be calling super, then we have a sneaky bug in the current master.