### PR TITLE
feat(bootstrapping): Adds --bootstrap-only flag to accounts, which re…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -842,6 +842,7 @@ hal config deploy edit [parameters]
 
 #### Parameters
  * `--account-name`: The Spinnaker account that Spinnaker will be deployed to, assuming you are runninga deployment of Spinnaker that requires an active cloud provider.
+ * `--bootstrap-only`: A bootstrap-only account is the account in which Spinnaker itself is deployed. When true, this account will not be included the accounts managed by Spinnaker.
  * `--consul-address`: The address of a running Consul cluster. See https://www.consul.io/.
 This is only required when Spinnaker is being deployed in non-Kubernetes clustered configuration.
  * `--consul-enabled`: Whether or not to use Consul as a service discovery mechanism to deploy Spinnaker.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AccountCommandProperties;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.DeploymentTypeConverter;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
@@ -42,6 +43,13 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
           + "a deployment of Spinnaker that requires an active cloud provider."
   )
   private String accountName;
+
+  @Parameter(
+      names = "--bootstrap-only",
+      description = "A bootstrap-only account is the account in which Spinnaker itself is deployed. " +
+          "When true, this account will not be included the accounts managed by Spinnaker."
+  )
+  Boolean bootstrapOnly;
 
   @Parameter(
       names = "--type",
@@ -107,6 +115,7 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
     }
 
     deploymentEnvironment.setAccountName(isSet(accountName) ? accountName : deploymentEnvironment.getAccountName());
+    deploymentEnvironment.setBootstrapOnly(isSet(bootstrapOnly) ? bootstrapOnly : deploymentEnvironment.getBootstrapOnly());
     deploymentEnvironment.setType(type != null ? type : deploymentEnvironment.getType());
 
     consul.setAddress(isSet(consulAddress) ? consulAddress : consul.getAddress());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/DCOSAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/DCOSAddAccountCommand.java
@@ -7,9 +7,9 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.Abs
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount.ClusterCredential;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DockerRegistryReference;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/DCOSEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/DCOSEditAccountCommand.java
@@ -5,8 +5,8 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DockerRegistryReference;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.DockerRegistryReference;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 import java.util.ArrayList;
 import java.util.List;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -21,7 +21,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.DockerRegistryReference;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 
 import java.util.ArrayList;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -92,6 +92,7 @@ public class DeploymentEnvironment extends Node {
   private Size size = Size.SMALL;
   private DeploymentType type = DeploymentType.LocalDebian;
   private String accountName;
+  private Boolean bootstrapOnly;
   private Consul consul = new Consul();
   private Vault vault = new Vault();
   private String location;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/containers/ContainerAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/containers/ContainerAccount.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.providers.containers;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ContainerAccount extends Account {
+
+  List<DockerRegistryReference> dockerRegistries = new ArrayList<>();
+
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/containers/DockerRegistryReference.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/containers/DockerRegistryReference.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google, Inc.
+ * Copyright 2017 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes;
+package com.netflix.spinnaker.halyard.config.model.v1.providers.containers;
 
 import lombok.Data;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSAccount.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.dcos;
 
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -13,14 +14,12 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class DCOSAccount extends Account {
-  private List<DockerRegistryReference> dockerRegistries = new ArrayList<>();
+public class DCOSAccount extends ContainerAccount {
   private List<ClusterCredential> clusters;
 
   @Override

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DockerRegistryReference.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DockerRegistryReference.java
@@ -1,9 +1,0 @@
-package com.netflix.spinnaker.halyard.config.model.v1.providers.dcos;
-
-import lombok.Data;
-
-@Data
-public class DockerRegistryReference {
-  String accountName;
-}
-

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
 import io.fabric8.kubernetes.api.model.Config;
@@ -40,13 +41,13 @@ import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.ERR
 
 @Data
 @EqualsAndHashCode(callSuper = true)
-public class KubernetesAccount extends Account implements Cloneable {
+public class KubernetesAccount extends ContainerAccount implements Cloneable {
   String context;
   String cluster;
   String user;
   List<String> namespaces = new ArrayList<>();
   List<String> omitNamespaces = new ArrayList<>();
-  List<DockerRegistryReference> dockerRegistries = new ArrayList<>();
+
   @LocalFile String kubeconfigFile;
 
   public String getKubeconfigFile() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSAccountValidator.java
@@ -7,12 +7,11 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIterator;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSCluster;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
-
 import org.springframework.stereotype.Component;
 
 import java.util.HashSet;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -21,7 +21,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguratio
 import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.DockerRegistryReference;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ClouddriverProfileFactory.java
@@ -16,16 +16,34 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIterator;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
+import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Component
 public class ClouddriverProfileFactory extends SpringProfileFactory {
+
+  @Autowired
+  AccountService accountService;
+
   @Override
   public SpinnakerArtifact getArtifact() {
     return SpinnakerArtifact.CLOUDDRIVER;
@@ -34,10 +52,75 @@ public class ClouddriverProfileFactory extends SpringProfileFactory {
   @Override
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
-    Providers providers = deploymentConfiguration.getProviders();
-    List<String> files = backupRequiredFiles(providers, deploymentConfiguration.getName());
-    profile.appendContents(yamlToString(providers))
+
+    // We need to make modifications to this deployment configuration, but can't use helpful objects
+    // like the accountService on a clone. Therefore, we'll make the modifications in place and
+    // restore to the original state when the modifications are written out.
+    Providers originalProviders = deploymentConfiguration.getProviders().cloneNode(Providers.class);
+    Providers modifiedProviders = deploymentConfiguration.getProviders();
+
+    DeploymentEnvironment deploymentEnvironment = deploymentConfiguration.getDeploymentEnvironment();
+    if (deploymentEnvironment.getBootstrapOnly()) {
+      String bootstrapAccountName = deploymentEnvironment.getAccountName();
+      removeBootstrapOnlyAccount(modifiedProviders, deploymentConfiguration.getName(), bootstrapAccountName);
+    }
+
+    List<String> files = backupRequiredFiles(modifiedProviders, deploymentConfiguration.getName());
+    profile.appendContents(yamlToString(modifiedProviders))
         .appendContents(profile.getBaseContents())
         .setRequiredFiles(files);
+
+    deploymentConfiguration.setProviders(originalProviders);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void removeBootstrapOnlyAccount(Providers providers, String deploymentName, String bootstrapAccountName) {
+
+    Account bootstrapAccount = accountService.getAnyProviderAccount(deploymentName, bootstrapAccountName);
+    Provider bootstrapProvider = ((Provider) bootstrapAccount.getParent());
+
+    bootstrapProvider.getAccounts().remove(bootstrapAccount);
+    if (bootstrapProvider.getAccounts().isEmpty()) {
+      bootstrapProvider.setEnabled(false);
+
+      if (bootstrapAccount instanceof ContainerAccount) {
+        ContainerAccount containerAccount = (ContainerAccount) bootstrapAccount;
+        DockerRegistryAccountReverseIndex revIndex = new DockerRegistryAccountReverseIndex(providers);
+
+        containerAccount.getDockerRegistries().forEach(reg -> {
+          Set<Account> dependentAccounts = revIndex.get(reg.getAccountName());
+          if (dependentAccounts == null || dependentAccounts.isEmpty()) {
+            DockerRegistryAccount regAcct = (DockerRegistryAccount) accountService.getAnyProviderAccount(deploymentName, reg.getAccountName());
+            ((DockerRegistryProvider) regAcct.getParent()).getAccounts().remove(regAcct);
+          }
+        });
+
+        if (providers.getDockerRegistry().getAccounts().isEmpty()) {
+          providers.getDockerRegistry().setEnabled(false);
+        }
+      }
+    }
+  }
+
+  // Registry name -> Docker/DCOS accounts that use it.
+  @Slf4j
+  private static class DockerRegistryAccountReverseIndex extends HashMap<String, Set<Account>> {
+
+    @SuppressWarnings("unchecked")
+    DockerRegistryAccountReverseIndex(Providers providers) {
+      super();
+
+      NodeIterator providerNodes = providers.getChildren();
+      Provider provider;
+      while ((provider = (Provider) providerNodes.getNext()) != null) {
+        for (Account a : (List<? extends Account>) provider.getAccounts()) {
+          if (a instanceof ContainerAccount) {
+            ContainerAccount account = (ContainerAccount) a;
+            List<DockerRegistryReference> registries = account.getDockerRegistries();
+            registries.forEach(reg -> this.computeIfAbsent(reg.getAccountName(), ignored -> new HashSet<>()).add(account));
+          }
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
…moves the flagged account from the deployed Spinnaker instance.

cc: @edwinavalos This isn't exactly what your group was looking for, but it's a jumping off point to pare down the unnecessary docker registries.