### PR TITLE
Fix usermod group append in Installer.sh

### DIFF
--- a/install/Installer.sh
+++ b/install/Installer.sh
@@ -390,7 +390,7 @@ fi
 echo "$(tput bold)Installing Halyard...$(tput sgr0)"
 install_halyard
 groupadd spinnaker || true
-usermod -G spinnaker $HAL_USER || true
+usermod -G spinnaker -a $HAL_USER || true
 
 configure_bash_completion
 


### PR DESCRIPTION
The `-a` arg is missing in the usermod command. When I run the installer on Ubuntu 14.04, this replaces all of my user's groups with just `spinnaker`. 
Adding the `-a` argument so that the `spinnaker` group is appended.