### PR TITLE
feat(named ports): Adds names to service ports and service labels for better Prometheus …

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/DistributedService.java
@@ -63,6 +63,7 @@ public interface DistributedService<T, A extends Account> extends HasServiceSett
   Provider.ProviderType getProviderType();
   RunningServiceDetails getRunningServiceDetails(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings);
   String getServiceName();
+  String getCanonicalName();
   SpinnakerMonitoringDaemonService getMonitoringDaemonService();
   <S> S connectToService(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings, SpinnakerService<S> sidecar);
   <S> S connectToInstance(AccountDeploymentDetails<A> details, SpinnakerRuntimeSettings runtimeSettings, SpinnakerService<S> sidecar, String instanceId);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedService.java
@@ -199,8 +199,15 @@ public interface KubernetesDistributedService<T> extends DistributedService<T, K
     servicePort.setName("http");
     servicePort.setProtocol("TCP");
 
+    KubernetesNamedServicePort monitoringPort = new KubernetesNamedServicePort();
+    monitoringPort.setPort(8008);
+    monitoringPort.setTargetPort(8008);
+    monitoringPort.setName("monitoring");
+    monitoringPort.setProtocol("TCP");
+
     List<KubernetesNamedServicePort> servicePorts = new ArrayList<>();
     servicePorts.add(servicePort);
+    servicePorts.add(monitoringPort);
     description.setPorts(servicePorts);
 
     return getObjectMapper().convertValue(description, new TypeReference<Map<String, Object>>() { });
@@ -478,6 +485,9 @@ public interface KubernetesDistributedService<T> extends DistributedService<T, K
     String replicaSetName = serviceName + "-v000";
     int port = settings.getPort();
 
+    SpinnakerMonitoringDaemonService monitoringService = getMonitoringDaemonService();
+    ServiceSettings monitoringSettings = runtimeSettings.getServiceSettings(monitoringService);
+
     KubernetesClient client = KubernetesProviderUtils.getClient(details);
     KubernetesProviderUtils.createNamespace(details, namespace);
 
@@ -491,15 +501,21 @@ public interface KubernetesDistributedService<T> extends DistributedService<T, K
     podLabels.putAll(replicaSetSelector);
     podLabels.putAll(serviceSelector);
 
+    Map<String, String> serviceLabels = new HashMap<>();
+    serviceLabels.put("app", "spin");
+    serviceLabels.put("stack", getCanonicalName());
+
     ServiceBuilder serviceBuilder = new ServiceBuilder();
     serviceBuilder = serviceBuilder
         .withNewMetadata()
         .withName(serviceName)
         .withNamespace(namespace)
+        .withLabels(serviceLabels)
         .endMetadata()
         .withNewSpec()
         .withSelector(serviceSelector)
-        .withPorts(new ServicePortBuilder().withPort(port).build())
+        .withPorts(new ServicePortBuilder().withPort(port).withName("http").build(),
+                   new ServicePortBuilder().withPort(monitoringSettings.getPort()).withName("monitoring").build())
         .endSpec();
 
     boolean create = true;

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceSpec.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesDistributedServiceSpec.groovy
@@ -249,6 +249,11 @@ class KubernetesDistributedServiceSpec extends Specification {
             }
 
             @Override
+            String getCanonicalName() {
+                return null
+            }
+
+            @Override
             SpinnakerMonitoringDaemonService getMonitoringDaemonService() {
                 return null
             }


### PR DESCRIPTION
…integration.

Prometheus Operator allows a user to define a set of label selectors to match _services_ that front the _pods_ that should be monitored. This means that the monitoring port needs to be exposed on the service, and the service needs labels pre-added in order to work out of the box.