### PR TITLE
fix(basicAuth): Remove `JsonIgnore`s from username/password in Servic…

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -48,8 +48,8 @@ public class ServiceSettings {
   String host;
   String scheme;
   String healthEndpoint;
-  @JsonIgnore String username;
-  @JsonIgnore String password;
+  String username;
+  String password;
   Map<String, String> env;
   String artifactId;
   String overrideBaseUrl;


### PR DESCRIPTION
…eSettings

The `@JsonIgnore` breaks being able to set this from YAML, which breaks the monitoring daemons access to Gate.