### PR TITLE
feat(legacyCanary): feature flag for legacy canary support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1095,6 +1095,7 @@ hal config features edit [parameters]
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here https://github.com/Netflix/chaosmonkey/wiki.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--jobs`: Allow Spinnaker to run containers in Kubernetes and Titus as Job stages in pipelines.
+ * `--legacyCanary`: Enable canary support. For this to work, you'll need a canary judge configured.Currently, halyard does not configure canary judge for you
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--pipeline-templates`: Enable pipeline template support. Read more at https://github.com/spinnaker/dcd-spec.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1095,7 +1095,7 @@ hal config features edit [parameters]
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here https://github.com/Netflix/chaosmonkey/wiki.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--jobs`: Allow Spinnaker to run containers in Kubernetes and Titus as Job stages in pipelines.
- * `--legacyCanary`: Enable canary support. For this to work, you'll need a canary judge configured.Currently, halyard does not configure canary judge for you
+ * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--pipeline-templates`: Enable pipeline template support. Read more at https://github.com/spinnaker/dcd-spec.
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -69,7 +69,7 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
            + "Currently, Halyard does not configure canary judge for you.",
       arity = 1
   )
-  private Boolean legacyCanary = null;
+  private Boolean mineCanary = null;
 
   @Override
   protected void executeThis() {
@@ -86,7 +86,7 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setJobs(jobs != null ? jobs : features.isJobs());
     features.setPipelineTemplates(pipelineTemplates != null ? pipelineTemplates : features.getPipelineTemplates());
     features.setArtifacts(artifacts != null ? artifacts : features.getArtifacts());
-    features.setLegacyCanary(legacyCanary != null ? legacyCanary : features.getLegacyCanary());
+    features.setMineCanary(mineCanary != null ? mineCanary : features.getMineCanary());
 
     if (originalHash == features.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -63,6 +63,14 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   )
   private Boolean artifacts = null;
 
+  @Parameter(
+      names = "--legacyCanary",
+      description = "Enable legacy canary support. For this to work, you'll need a canary judge configured." 
+           + "Currently, halyard does not configure canary judge for you",
+      arity = 1
+  )
+  private Boolean legacyCanary = null;
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -78,6 +86,7 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setJobs(jobs != null ? jobs : features.isJobs());
     features.setPipelineTemplates(pipelineTemplates != null ? pipelineTemplates : features.getPipelineTemplates());
     features.setArtifacts(artifacts != null ? artifacts : features.getArtifacts());
+    features.setLegacyCanary(legacyCanary != null ? legacyCanary : features.getLegacyCanary());
 
     if (originalHash == features.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -64,9 +64,9 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   private Boolean artifacts = null;
 
   @Parameter(
-      names = "--legacyCanary",
-      description = "Enable legacy canary support. For this to work, you'll need a canary judge configured." 
-           + "Currently, halyard does not configure canary judge for you",
+      names = "--mine-canary",
+      description = "Enable canary support. For this to work, you'll need a canary judge configured. " 
+           + "Currently, Halyard does not configure canary judge for you.",
       arity = 1
   )
   private Boolean legacyCanary = null;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -48,7 +48,7 @@ public class Features extends Node {
   @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Artifacts are not configurable prior to this release. Will be stable at a later release.")
   private Boolean artifacts;
   @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Canary is not configurable prior to this release. Will be stable at a later release.")
-  private Boolean legacyCanary;
+  private Boolean mineCanary;
 
   public boolean isAuth(DeploymentConfiguration deploymentConfiguration) {
     return deploymentConfiguration.getSecurity().getAuthn().isEnabled();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -47,6 +47,8 @@ public class Features extends Node {
   private Boolean pipelineTemplates;
   @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Artifacts are not configurable prior to this release. Will be stable at a later release.")
   private Boolean artifacts;
+  @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Canary is not configurable prior to this release. Will be stable at a later release.")
+  private Boolean legacyCanary;
 
   public boolean isAuth(DeploymentConfiguration deploymentConfiguration) {
     return deploymentConfiguration.getSecurity().getAuthn().isEnabled();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -94,7 +94,7 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     bindings.put("features.fiat", Boolean.toString(deploymentConfiguration.getSecurity().getAuthz().isEnabled()));
     bindings.put("features.pipelineTemplates", Boolean.toString(features.getPipelineTemplates() != null ? features.getPipelineTemplates() : false));
     bindings.put("features.artifacts", Boolean.toString(features.getArtifacts() != null ? features.getArtifacts() : false));
-    bindings.put("features.legacyCanary", Boolean.toString(features.getLegacyCanary() != null ? features.getLegacyCanary() : false));
+    bindings.put("features.mineCanary", Boolean.toString(features.getMineCanary() != null ? features.getMineCanary() : false));
 
     // Configure Kubernetes
     KubernetesProvider kubernetesProvider = deploymentConfiguration.getProviders().getKubernetes();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -94,6 +94,7 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     bindings.put("features.fiat", Boolean.toString(deploymentConfiguration.getSecurity().getAuthz().isEnabled()));
     bindings.put("features.pipelineTemplates", Boolean.toString(features.getPipelineTemplates() != null ? features.getPipelineTemplates() : false));
     bindings.put("features.artifacts", Boolean.toString(features.getArtifacts() != null ? features.getArtifacts() : false));
+    bindings.put("features.legacyCanary", Boolean.toString(features.getLegacyCanary() != null ? features.getLegacyCanary() : false));
 
     // Configure Kubernetes
     KubernetesProvider kubernetesProvider = deploymentConfiguration.getProviders().getKubernetes();


### PR DESCRIPTION
Update halyard command line to enable/disable canary feature flag in deck settings.js

hal config features edit --legacyCanary false
hal config features edit --legacyCanary true
