### PR TITLE
refactor(profiles): fixup bad decision around profile storage

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/VersionsService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/VersionsService.java
@@ -53,10 +53,7 @@ public class VersionsService {
 
   public Versions getVersions() {
     try {
-      return relaxedObjectMapper.convertValue(
-          yamlParser.load(profileRegistry.getObjectContents("versions.yml")),
-          Versions.class
-      );
+      return profileRegistry.readVersions();
     } catch (IOException e) {
       throw new HalException(
           new ConfigProblemBuilder(FATAL, "Could not load \"versions.yml\" from config bucket: " + e.getMessage() + ".").build());
@@ -73,14 +70,7 @@ public class VersionsService {
     }
 
     try {
-      String bomName = ProfileRegistry.bomPath(version);
-
-      BillOfMaterials bom = relaxedObjectMapper.convertValue(
-          yamlParser.load(profileRegistry.getObjectContents(bomName)),
-          BillOfMaterials.class
-      );
-
-      return bom;
+      return profileRegistry.readBom(version);
     } catch (RetrofitError | IOException e) {
       throw new HalException(
           new ConfigProblemBuilder(FATAL,

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/GoogleProfileRegistry.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/GoogleProfileRegistry.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.core.registry.v1;
+
+import com.google.api.client.http.HttpTransport;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.services.storage.Storage;
+import com.netflix.spinnaker.halyard.core.provider.v1.google.GoogleCredentials;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+@Component
+@Slf4j
+public class GoogleProfileRegistry {
+  @Autowired
+  String spinconfigBucket;
+
+  @Autowired
+  Storage googleStorage;
+
+  @Bean
+  public Storage googleStorage() {
+    HttpTransport httpTransport;
+    JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+    String applicationName = "Spinnaker/Halyard";
+
+    return new Storage.Builder(GoogleCredentials.buildHttpTransport(), jsonFactory, GoogleCredentials.retryRequestInitializer())
+        .setApplicationName(applicationName)
+        .build();
+  }
+
+  public String profilePath(String artifactName, String version, String profileFileName) {
+    return String.join("/", artifactName, version, profileFileName);
+  }
+
+  public String bomPath(String version) {
+    return String.join("/", "bom", version + ".yml");
+  }
+
+  public InputStream getObjectContents(String objectName) throws IOException {
+    ByteArrayOutputStream output = new ByteArrayOutputStream();
+    log.info("Getting object contents of " + objectName);
+    googleStorage.objects().get(spinconfigBucket, objectName).executeMediaAndDownloadTo(output);
+    return new ByteArrayInputStream(output.toByteArray());
+  }
+}

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/GoogleWriteableProfileRegistry.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/GoogleWriteableProfileRegistry.java
@@ -37,14 +37,17 @@ import java.io.IOException;
 import java.util.Collections;
 
 @Slf4j
-public class WriteableProfileRegistry {
+public class GoogleWriteableProfileRegistry {
   private Storage storage;
   private WriteableProfileRegistryProperties properties;
 
   @Autowired
   String spinconfigBucket;
 
-  WriteableProfileRegistry(WriteableProfileRegistryProperties properties) {
+  @Autowired
+  GoogleProfileRegistry googleProfileRegistry;
+
+  GoogleWriteableProfileRegistry(WriteableProfileRegistryProperties properties) {
     HttpTransport httpTransport = GoogleCredentials.buildHttpTransport();
     JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
     GoogleCredential credential;
@@ -75,13 +78,13 @@ public class WriteableProfileRegistry {
   }
 
   public void writeBom(String version, String contents) {
-    String name = ProfileRegistry.bomPath(version);
+    String name = googleProfileRegistry.bomPath(version);
     writeTextObject(name, contents);
   }
 
   public void writeArtifactConfig(BillOfMaterials bom, String artifactName, String profileName, String contents) {
     String version = bom.getArtifactVersion(artifactName);
-    String name = ProfileRegistry.profilePath(artifactName, version, profileName);
+    String name = googleProfileRegistry.profilePath(artifactName, version, profileName);
     writeTextObject(name, contents);
   }
 

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/WriteableProfileRegistryConfig.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/WriteableProfileRegistryConfig.java
@@ -29,8 +29,8 @@ import org.springframework.context.annotation.Configuration;
 @Slf4j
 public class WriteableProfileRegistryConfig {
   @Bean
-  public WriteableProfileRegistry defaultWriteableProfileRegistry(WriteableProfileRegistryProperties properties) {
-    return new WriteableProfileRegistry(properties);
+  public GoogleWriteableProfileRegistry defaultWriteableProfileRegistry(WriteableProfileRegistryProperties properties) {
+    return new GoogleWriteableProfileRegistry(properties);
   }
 }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/ArtifactService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/ArtifactService.java
@@ -26,7 +26,7 @@ import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions.Version;
-import com.netflix.spinnaker.halyard.core.registry.v1.WriteableProfileRegistry;
+import com.netflix.spinnaker.halyard.core.registry.v1.GoogleWriteableProfileRegistry;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +47,7 @@ import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.FAT
 @Component
 public class ArtifactService {
   @Autowired(required = false)
-  WriteableProfileRegistry writeableProfileRegistry;
+  GoogleWriteableProfileRegistry googleWriteableProfileRegistry;
 
   @Autowired
   Yaml yamlParser;
@@ -88,7 +88,7 @@ public class ArtifactService {
   }
 
   public void deprecateVersion(Version version, String illegalReason) {
-    if (writeableProfileRegistry == null) {
+    if (googleWriteableProfileRegistry == null) {
       throw new HalException(new ConfigProblemBuilder(FATAL,
           "You need to set the \"spinnaker.config.input.writerEnabled\" property to \"true\" to modify your halconfig bucket contents.").build());
     }
@@ -106,11 +106,11 @@ public class ArtifactService {
       versionsCollection.setIllegalVersions(illegalVersions);
     }
 
-    writeableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
+    googleWriteableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
   }
 
   public void publishVersion(Version version) {
-    if (writeableProfileRegistry == null) {
+    if (googleWriteableProfileRegistry == null) {
       throw new HalException(new ConfigProblemBuilder(FATAL,
           "You need to set the \"spinnaker.config.input.writerEnabled\" property to \"true\" to modify your halconfig bucket contents.").build());
     }
@@ -119,11 +119,11 @@ public class ArtifactService {
     deleteVersion(versionsCollection, version.getVersion());
     versionsCollection.getVersions().add(version);
 
-    writeableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
+    googleWriteableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
   }
 
   public void publishLatestSpinnaker(String latestSpinnaker) {
-    if (writeableProfileRegistry == null) {
+    if (googleWriteableProfileRegistry == null) {
       throw new HalException(new ConfigProblemBuilder(FATAL,
           "You need to set the \"spinnaker.config.input.writerEnabled\" property to \"true\" to modify BOM contents.").build());
     }
@@ -136,11 +136,11 @@ public class ArtifactService {
 
     versionsCollection.setLatestSpinnaker(latestSpinnaker);
 
-    writeableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
+    googleWriteableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
   }
 
   public void publishLatestHalyard(String latestHalyard) {
-    if (writeableProfileRegistry == null) {
+    if (googleWriteableProfileRegistry == null) {
       throw new HalException(new ConfigProblemBuilder(FATAL,
           "You need to set the \"spinnaker.config.input.writerEnabled\" property to \"true\" to modify BOM contents.").build());
     }
@@ -149,11 +149,11 @@ public class ArtifactService {
 
     versionsCollection.setLatestHalyard(latestHalyard);
 
-    writeableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
+    googleWriteableProfileRegistry.writeVersions(yamlParser.dump(relaxedObjectMapper.convertValue(versionsCollection, Map.class)));
   }
 
   public void writeBom(String bomPath) {
-    if (writeableProfileRegistry == null) {
+    if (googleWriteableProfileRegistry == null) {
       throw new HalException(new ConfigProblemBuilder(FATAL,
           "You need to set the \"spinnaker.config.input.writerEnabled\" property to \"true\" to modify BOM contents.").build());
     }
@@ -178,11 +178,11 @@ public class ArtifactService {
       throw new HalException(new ConfigProblemBuilder(FATAL, "No version was supplied in this BOM.").build());
     }
 
-    writeableProfileRegistry.writeBom(bom.getVersion(), bomContents);
+    googleWriteableProfileRegistry.writeBom(bom.getVersion(), bomContents);
   }
 
   public void writeArtifactConfig(String bomPath, String artifactName, String profilePath) {
-    if (writeableProfileRegistry == null) {
+    if (googleWriteableProfileRegistry == null) {
       throw new HalException(new ConfigProblemBuilder(FATAL,
           "You need to set the \"spinnaker.config.input.writerEnabled\" property to \"true\" to modify base-profiles.").build());
     }
@@ -209,6 +209,6 @@ public class ArtifactService {
       );
     }
 
-    writeableProfileRegistry.writeArtifactConfig(bom, artifactName, profileFile.getName(), profileContents);
+    googleWriteableProfileRegistry.writeArtifactConfig(bom, artifactName, profileFile.getName(), profileContents);
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RegistryBackedArchiveProfileBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RegistryBackedArchiveProfileBuilder.java
@@ -49,13 +49,12 @@ public class RegistryBackedArchiveProfileBuilder {
 
   public List<Profile> build(DeploymentConfiguration deploymentConfiguration, String baseOutputPath, SpinnakerArtifact artifact, String archiveName) {
     String version = artifactService.getArtifactVersion(deploymentConfiguration.getName(), artifact);
-    String archiveObjectName = ProfileRegistry.profilePath(artifact.getName(), version, archiveName + ".tar.gz");
 
     InputStream is;
     try {
-      is = profileRegistry.getObjectContents(archiveObjectName);
+      is = profileRegistry.readArchiveProfile(artifact.getName(), version, archiveName);
     } catch (IOException e) {
-      throw new HalException(Problem.Severity.FATAL, "Error retrieving contents of archive " + archiveObjectName, e);
+      throw new HalException(Problem.Severity.FATAL, "Error retrieving contents of archive " + archiveName + ".tar.gz", e);
     }
 
     TarArchiveInputStream tis;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RegistryBackedProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RegistryBackedProfileFactory.java
@@ -34,18 +34,18 @@ abstract public class RegistryBackedProfileFactory extends ProfileFactory {
 
   @Override
   protected Profile getBaseProfile(String name, String version, String outputFile) {
-    String path = ProfileRegistry.profilePath(getArtifact().getName(), version, name);
     try {
       return new Profile(name,
           version,
           outputFile,
-          IOUtils.toString(profileRegistry.getObjectContents(path))
+          IOUtils.toString(profileRegistry.readProfile(getArtifact().getName(), version, name))
       );
     } catch (RetrofitError | IOException e) {
       throw new HalException(
           new ConfigProblemBuilder(FATAL,
-              "Unable to retrieve profile \"" + path + "\": " + e.getMessage())
-              .build()
+              "Unable to retrieve profile \"" + name + "\": " + e.getMessage())
+              .build(),
+          e
       );
     }
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RoscoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RoscoProfileFactory.java
@@ -17,7 +17,12 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.halyard.config.model.v1.node.*;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.HasImageProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeIterator;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.registry.v1.ProfileRegistry;
@@ -52,7 +57,7 @@ public class RoscoProfileFactory extends SpringProfileFactory {
   protected Providers getImageProviders(String version) {
     InputStream is;
     try {
-      is = profileRegistry.getObjectContents(ProfileRegistry.profilePath(getArtifact().getName(), version, "images.yml"));
+      is = profileRegistry.readProfile(getArtifact().getName(), version, "images.yml");
     } catch (IOException e) {
       throw new HalException(Problem.Severity.FATAL, "Unable to read images.yml for rosco: " + e.getMessage(), e);
     }


### PR DESCRIPTION
It was a bad idea to give the profile storage the ability to read anything with 'getObjectContents', since not all interfaces will be able to satisfy that. This is the first step in cleaning that up.