### PR TITLE
feat(artifacts): Add support for GitHub artifact account

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/ArtifactProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/ArtifactProviderCommand.java
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.gcs.GcsArtifactProviderCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.github.GitHubArtifactProviderCommand;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -39,6 +40,7 @@ public class ArtifactProviderCommand extends NestableCommand {
 
   public ArtifactProviderCommand() {
     registerSubcommand(new GcsArtifactProviderCommand());
+    registerSubcommand(new GitHubArtifactProviderCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubAddArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubAddArtifactAccountCommand.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.github;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.account.AbstractAddArtifactAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
+import com.netflix.spinnaker.halyard.config.model.v1.artifacts.github.GitHubArtifactAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
+
+@Parameters(separators = "=")
+public class GitHubAddArtifactAccountCommand extends AbstractAddArtifactAccountCommand {
+  @Parameter(
+      names = "--username",
+      description = "GitHub username"
+  )
+  private String username;
+  @Parameter(
+      names = "--password",
+      password = true,
+      description = "GitHub password"
+  )
+  private String password;
+  @Parameter(
+      names = "--username-password-file",
+      converter = PathExpandingConverter.class,
+      description = "File containing \"username:password\" to use for GitHub authentication"
+  )
+  private String usernamePasswordFile;
+  @Parameter(
+      names = "--token",
+      password = true,
+      description = "GitHub token"
+  )
+  private String token;
+  @Parameter(
+      names = "--token-file",
+      converter = PathExpandingConverter.class,
+      description = "File containing a GitHub authentication token"
+  )
+  private String tokenFile;
+
+  @Override
+  protected ArtifactAccount buildArtifactAccount(String accountName) {
+    GitHubArtifactAccount artifactAccount = new GitHubArtifactAccount().setName(accountName);
+    artifactAccount.setUsername(username)
+        .setPassword(password)
+        .setUsernamePasswordFile(usernamePasswordFile)
+        .setToken(token)
+        .setTokenFile(tokenFile);
+    return artifactAccount;
+  }
+
+
+  @Override
+  protected ArtifactAccount emptyArtifactAccount() {
+    return new GitHubArtifactAccount();
+  }
+
+  @Override
+  protected String getArtifactProviderName() {
+    return "github";
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubArtifactAccountCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.github;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.AbstractArtifactAccountCommand;
+
+@Parameters(separators = "=")
+public class GitHubArtifactAccountCommand extends AbstractArtifactAccountCommand {
+  @Override
+  protected String getArtifactProviderName() {
+    return "github";
+  }
+
+  public GitHubArtifactAccountCommand() {
+    registerSubcommand(new GitHubAddArtifactAccountCommand());
+    registerSubcommand(new GitHubEditArtifactAccountCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubArtifactProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubArtifactProviderCommand.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.github;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.AbstractNamedArtifactProviderCommand;
+
+@Parameters(separators = "=")
+public class GitHubArtifactProviderCommand extends AbstractNamedArtifactProviderCommand {
+  @Override
+  protected String getArtifactProviderName() {
+    return "github";
+  }
+
+  public GitHubArtifactProviderCommand() {
+    registerSubcommand(new GitHubArtifactAccountCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubEditArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/github/GitHubEditArtifactAccountCommand.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2017 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.github;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.account.AbstractArtifactEditAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.PathExpandingConverter;
+import com.netflix.spinnaker.halyard.config.model.v1.artifacts.github.GitHubArtifactAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
+
+@Parameters(separators = "=")
+public class GitHubEditArtifactAccountCommand extends AbstractArtifactEditAccountCommand<GitHubArtifactAccount> {
+  @Parameter(
+      names = "--username",
+      description = "GitHub username"
+  )
+  private String username;
+  @Parameter(
+      names = "--password",
+      password = true,
+      description = "GitHub password"
+  )
+  private String password;
+  @Parameter(
+      names = "--username-password-file",
+      converter = PathExpandingConverter.class,
+      description = "File containing \"username:password\" to use for GitHub authentication"
+  )
+  private String usernamePasswordFile;
+  @Parameter(
+      names = "--token",
+      password = true,
+      description = "GitHub token"
+  )
+  private String token;
+  @Parameter(
+      names = "--token-file",
+      converter = PathExpandingConverter.class,
+      description = "File containing a GitHub authentication token"
+  )
+  private String tokenFile;
+
+  @Override
+  protected ArtifactAccount editArtifactAccount(GitHubArtifactAccount account) {
+    account.setUsername(isSet(username) ? username : account.getUsername());
+    account.setPassword(isSet(password) ? password : account.getPassword());
+    account.setUsernamePasswordFile(isSet(usernamePasswordFile) ? usernamePasswordFile : account.getUsernamePasswordFile());
+    account.setToken(isSet(token) ? token : account.getToken());
+    account.setTokenFile(isSet(tokenFile) ? tokenFile : account.getTokenFile());
+    return account;
+  }
+
+  @Override
+  protected String getArtifactProviderName() {
+    return "github";
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/github/GitHubArtifactAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/github/GitHubArtifactAccount.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.artifacts.github;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import lombok.Data;
+
+@Data
+public class GitHubArtifactAccount extends ArtifactAccount {
+  String name;
+  String username;
+  String password;
+  @LocalFile
+  String usernamePasswordFile;
+  String token;
+  @LocalFile
+  String tokenFile;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/github/GitHubArtifactProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/github/GitHubArtifactProvider.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Joel Wilsson
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.artifacts.github;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode(callSuper = true)
+@Data
+public class GitHubArtifactProvider extends ArtifactProvider<GitHubArtifactAccount> {
+  @Override
+  public ProviderType providerType() {
+    return ProviderType.GITHUB;
+  }
+
+  @Override
+  public void accept(ConfigProblemSetBuilder psBuilder, Validator v) {
+    v.validate(psBuilder, this);
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/ArtifactProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/ArtifactProvider.java
@@ -49,7 +49,8 @@ abstract public class ArtifactProvider<A extends ArtifactAccount> extends Node {
   abstract public ProviderType providerType();
 
   public enum ProviderType {
-    GCS("gcs");
+    GCS("gcs"),
+    GITHUB("github");
 
     @Getter
     final private String name;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Artifacts.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Artifacts.java
@@ -19,6 +19,7 @@
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.gcs.GcsArtifactProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.artifacts.github.GitHubArtifactProvider;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -31,6 +32,7 @@ import java.util.Optional;
 @Data
 public class Artifacts extends Node {
   GcsArtifactProvider gcs = new GcsArtifactProvider();
+  GitHubArtifactProvider github = new GitHubArtifactProvider();
 
   @Override
   public String getNodeName() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ArtifactProviderService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ArtifactProviderService.java
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.halyard.config.services.v1;
 import com.netflix.spinnaker.halyard.config.error.v1.ConfigNotFoundException;
 import com.netflix.spinnaker.halyard.config.error.v1.IllegalConfigException;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.gcs.GcsArtifactProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.artifacts.github.GitHubArtifactProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Artifacts;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
@@ -87,6 +88,9 @@ public class ArtifactProviderService {
     switch (provider.providerType()) {
       case GCS:
         artifacts.setGcs((GcsArtifactProvider) provider);
+        break;
+      case GITHUB:
+        artifacts.setGithub((GitHubArtifactProvider) provider);
         break;
       default:
         throw new IllegalArgumentException("Unknonwn provider type " + provider.providerType());


### PR DESCRIPTION
Allows Halyard to configure clouddriver to download artifacts from GitHub, see https://github.com/spinnaker/clouddriver/pull/2231