### PR TITLE
bug(click_to_deploy): 1.5.2 click to deploy not properly restarting apache

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianService.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalService;
 import io.fabric8.utils.Strings;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -55,7 +56,10 @@ public interface LocalDebianService<T> extends LocalService<T> {
     // pin as well as install at a particular version to ensure `apt-get uprade` doesn't accidentally upgrade to `nightly`
     TemplatedResource pinResource = new JarResource("/debian/pin.sh");
     TemplatedResource installResource = new JarResource("/debian/install-component.sh");
-    String ensureStopped = String.join("\n", "set +e", "service " + getUpstartServiceName() + " stop", "set -e");
+    String upstartServiceName = getUpstartServiceName();
+    String ensureStopped = StringUtils.isEmpty(upstartServiceName) ? "" :
+        String.join("\n",
+            "set +e", String.join(" ", "service" + upstartServiceName + "stop"), "set -e");
 
     pinResource.setBindings(bindings);
     installResource.setBindings(bindings);

--- a/halyard-deploy/src/main/resources/debian/install.sh
+++ b/halyard-deploy/src/main/resources/debian/install.sh
@@ -139,5 +139,5 @@ chown spinnaker /opt/spinnaker-monitoring/registry
 set +e
 service spinnaker {%service-action%}
 
-# Ensure apache is started for deck
-service apache2 start
+# Ensure apache is started for deck. Restart to ensure enabled site is loaded.
+service apache2 restart


### PR DESCRIPTION
Apache start is failing to pick up the site if its newly enabled.
Also fixing stop command that is failing with: "stop: Unknown instance:" since it is executing "service stop", instead of the intended "service apache2 stop".