### PR TITLE
feat(halyard_installation): Prevent accidental second install.

### DIFF
--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -6,7 +6,7 @@ function check_migration_needed() {
   set -e
   hash dpkg &> /dev/null
 
-  if [ "$?" != "0" ]; then
+  if [ "$?" = "0" ]; then
     dpkg -s spinnaker-halyard &> /dev/null
 
     if [ "$?" != "1" ]; then

--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -4,12 +4,16 @@ set -e
 
 function check_migration_needed() {
   set -e
-  dpkg -s spinnaker-halyard &> /dev/null
+  hash dpkg &> /dev/null
 
-  if [ "$?" != "1" ]; then
-    >&2 echo "Attempting to install halyard while a debian installation is present."
-    >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
-    exit 1
+  if [ "$?" != "0" ]; then
+    dpkg -s spinnaker-halyard &> /dev/null
+
+    if [ "$?" != "1" ]; then
+      >&2 echo "Attempting to install halyard while a debian installation is present."
+      >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
+      exit 1
+    fi
   fi
   set -e
 }

--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -2,6 +2,18 @@
 
 set -e
 
+function check_migration_needed() {
+  set -e
+  dpkg -s spinnaker-halyard &> /dev/null
+
+  if [ "$?" != "1" ]; then
+    >&2 echo "Attempting to install halyard while a debian installation is present."
+    >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
+    exit 1
+  fi
+  set -e
+}
+
 function process_args() {
   while [ "$#" -gt "0" ]
   do
@@ -220,6 +232,8 @@ function install_halyard() {
   popd
   rm -rf $TEMPDIR
 }
+
+check_migration_needed
 
 process_args $@
 configure_defaults


### PR DESCRIPTION
In the jar based installation, first check to make sure the debian package is not installed. If it is, provide a link to the user to migrate.