### PR TITLE
bug(halyard_install): Prevent install failure if no hash.

### DIFF
--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -6,7 +6,7 @@ function check_migration_needed() {
   set -e
 
   which dpkg &> /dev/null
-  if [ "$?" != "0" ]; then
+  if [ "$?" = "0" ]; then
     dpkg -s spinnaker-halyard &> /dev/null
 
     if [ "$?" != "1" ]; then

--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -4,6 +4,7 @@ set -e
 
 function check_migration_needed() {
   set -e
+<<<<<<< HEAD
   hash dpkg &> /dev/null
 
   if [ "$?" = "0" ]; then
@@ -14,6 +15,14 @@ function check_migration_needed() {
       >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
       exit 1
     fi
+=======
+  dpkg -s spinnaker-halyard &> /dev/null
+
+  if [ "$?" != "1" ]; then
+    >&2 echo "Attempting to install halyard while a debian installation is present."
+    >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
+    exit 1
+>>>>>>> feat(halyard_installation): Prevent accidental second install.
   fi
   set -e
 }

--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -4,10 +4,9 @@ set -e
 
 function check_migration_needed() {
   set -e
-<<<<<<< HEAD
-  hash dpkg &> /dev/null
 
-  if [ "$?" = "0" ]; then
+  which dpkg &> /dev/null
+  if [ "$?" != "0" ]; then
     dpkg -s spinnaker-halyard &> /dev/null
 
     if [ "$?" != "1" ]; then
@@ -15,14 +14,6 @@ function check_migration_needed() {
       >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
       exit 1
     fi
-=======
-  dpkg -s spinnaker-halyard &> /dev/null
-
-  if [ "$?" != "1" ]; then
-    >&2 echo "Attempting to install halyard while a debian installation is present."
-    >&2 echo "Please visit: http://spinnaker.io/setup/install/halyard_migration"
-    exit 1
->>>>>>> feat(halyard_installation): Prevent accidental second install.
   fi
   set -e
 }


### PR DESCRIPTION
It seems that Amazon Ubuntu 14.04 doesn't have "hash", but which returns equal error codes and is present in more places it seems.