### PR TITLE
bug(fix_halyard_installer): Fix installer script.

### DIFF
--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -3,7 +3,7 @@
 set -e
 
 function check_migration_needed() {
-  set -e
+  set +e
 
   which dpkg &> /dev/null
   if [ "$?" = "0" ]; then


### PR DESCRIPTION
set -e causing execution to stop after detecting halyard is not already installed.