### PR TITLE
Create a default GlobalApplicationOptions instance if no config file.

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/GlobalApplicationOptions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/GlobalApplicationOptions.java
@@ -63,7 +63,7 @@ public class GlobalApplicationOptions {
             GlobalApplicationOptions.class
         );
       } catch (IOException e) {
-        e.printStackTrace();
+        GlobalApplicationOptions.options = new GlobalApplicationOptions();
       }
     }
     return GlobalApplicationOptions.options;


### PR DESCRIPTION
This is not a complete solution yet, but this seems to correct one of the issues I'm seeing when running a local halyard on macOS.

Still getting this error when trying to set the version via CLI:
```
$ hal config version edit --version 1.5.4
+ Get current deployment
  Success
- Edit Spinnaker version
  Failure
Problems in Global:
! ERROR Unexpected exception: java.lang.NullPointerException

- Failed to update version.
```

Meanwhie, the daemon spits this out to its console:
```
2018-01-19 17:58:57.182  WARN 37078 --- [       Thread-6] c.n.s.h.core.tasks.v1.TaskRepository     : Task [Edit Spinnaker version] (56525576-c51a-4d43-825c-499d5a0e1595) - RUNNING failed with unexpected reason: 

java.lang.NullPointerException: null
	at com.netflix.spinnaker.halyard.core.DaemonResponse$UpdateRequestBuilder.build(DaemonResponse.java:168) ~[halyard-core-0.31.0-SNAPSHOT.jar:0.31.0-SNAPSHOT]
	at com.netflix.spinnaker.halyard.core.tasks.v1.TaskRepository.lambda$submitTask$1(TaskRepository.java:48) ~[halyard-core-0.31.0-SNAPSHOT.jar:0.31.0-SNAPSHOT]
	at java.lang.Thread.run(Thread.java:748) ~[na:1.8.0_141]

2018-01-19 17:58:57.183  INFO 37078 --- [       Thread-6] c.n.s.halyard.core.tasks.v1.DaemonTask   : [Edit Spinnaker version] (56525576-c51a-4d43-825c-499d5a0e1595) - FAILED killing all jobs created by this task 
2018-01-19 17:58:57.183  INFO 37078 --- [       Thread-6] c.n.s.h.core.tasks.v1.TaskRepository     : Task [Edit Spinnaker version] (56525576-c51a-4d43-825c-499d5a0e1595) - FAILED completed
```

