### PR TITLE
fix(localgit): Remove and then add git remote

### DIFF
--- a/halyard-deploy/src/main/resources/git/prep-component.sh
+++ b/halyard-deploy/src/main/resources/git/prep-component.sh
@@ -29,7 +29,7 @@ git remote get-url upstream 2> /dev/null
 ERR=$?
 
 if [ "$ERR" -ne 0 ]; then
-  git remote add upstream $UPSTREAM_URL
+  git remote remove upstream && git remote add upstream $UPSTREAM_URL
 else
   git remote set-url upstream $UPSTREAM_URL
 fi


### PR DESCRIPTION
If we run `git remote add upstream` when `upstream` already
exists, we get the annoying output `fatal: remote upstream already exists.`
for every component.

Run `git remote remove upstream` first to avoid printing this error.
This also mimics the behavior of the newer git command `git remote
set-url` that we use when git is above a certain version.