### PR TITLE
fix(localgit): Do not fail if removing git remote fails

### DIFF
--- a/halyard-deploy/src/main/resources/git/prep-component.sh
+++ b/halyard-deploy/src/main/resources/git/prep-component.sh
@@ -29,7 +29,8 @@ git remote get-url upstream 2> /dev/null
 ERR=$?
 
 if [ "$ERR" -ne 0 ]; then
-  git remote remove upstream && git remote add upstream $UPSTREAM_URL
+  git remote remove upstream 2> /dev/null
+  git remote add upstream $UPSTREAM_URL
 else
   git remote set-url upstream $UPSTREAM_URL
 fi


### PR DESCRIPTION
The remote "upstream" might not exist. Do not fail if so.

fixes bug introduced in https://github.com/spinnaker/halyard/pull/818