### PR TITLE
fix(gradle): useLastTag to appease nebula on spinnaker branches.

### DIFF
--- a/halyard-cli/Makefile
+++ b/halyard-cli/Makefile
@@ -1,5 +1,5 @@
 all:
-	../gradlew installDist
+	../gradlew installDist -Prelease.useLastTag=true
 	./hal --docs > ../docs/commands.md
 
 complete:
@@ -7,4 +7,4 @@ complete:
 	@echo 'Run this: source complete && PATH=$$PATH:`pwd`'
 
 clean:
-	../gradlew clean
+	../gradlew clean -Prelease.useLastTag=true


### PR DESCRIPTION
@lwander 
Without something like this, I cannot build a release branch because of nebula constraints.