### PR TITLE
fix(core): Fix NPE when no clean step provided

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/DaemonResponse.java
@@ -139,7 +139,7 @@ public class DaemonResponse<T> {
   @Data
   public static class UpdateRequestBuilder {
     private Runnable stage = () -> {};
-    private Runnable clean;
+    private Runnable clean = () -> {};
     private Runnable revert;
     private Runnable save;
     private Runnable update;


### PR DESCRIPTION
I'm not sure if this is correct "long term" fix, but it at least allows us to run requests that don't have a "clean" step specified.