### PR TITLE
docs(halyard_k8s): Add more detail to deploy edit cmd

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1208,7 +1208,7 @@ This is only required when Spinnaker is being deployed in non-Kubernetes cluster
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--git-origin-user`: This is the git user your github fork exists under.
  * `--git-upstream-user`: This is the upstream git user you are configuring to pull changes from & push PRs to.
- * `--location`: This is the location spinnaker will be deployed to.
+ * `--location`: This is the location spinnaker will be deployed to. When deploying to Kubernetes, use this flag to specify the namespace to deploy to (defaults to 'spinnaker')
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--type`: Distributed: Deploy Spinnaker with one server group per microservice, and a single shared Redis.
 LocalDebian: Download and run the Spinnaker debians on the machine running the Daemon.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -96,7 +96,8 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
 
   @Parameter(
       names = "--location",
-      description = "This is the location spinnaker will be deployed to."
+      description = "This is the location spinnaker will be deployed to. When deploying to "
+          + "Kubernetes, use this flag to specify the namespace to deploy to (defaults to 'spinnaker')"
   )
   private String location;
 


### PR DESCRIPTION
Explain how `--location` is used to specify the k8s namespace Spinnaker
will be deployed to when using k8s as the deployment environment.