### PR TITLE
Kubernetes URL fixed

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3154,7 +3154,7 @@ hal config provider google enable [parameters]
 
 The Kubernetes provider is used to deploy Kubernetes resources to any number of Kubernetes clusters. Spinnaker assumes you have a Kubernetes cluster already running. If you don't, you must configure one: https://kubernetes.io/docs/getting-started-guides/. 
 
-Before proceeding, please visit https://kubernetes.io/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/to make sure you're familiar with the authentication terminology. For more information on how to configure individual accounts, or how to deploy to multiple clusters, please read the documentation under `hal config provider kubernetes account -h`.
+Before proceeding, please visit https://kubernetes.io/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/ to make sure you're familiar with the authentication terminology. For more information on how to configure individual accounts, or how to deploy to multiple clusters, please read the documentation under `hal config provider kubernetes account -h`.
 
 #### Usage
 ```

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommand.java
@@ -34,7 +34,7 @@ public class KubernetesCommand extends AbstractNamedProviderCommand {
         "The Kubernetes provider is used to deploy Kubernetes resources to any number of Kubernetes clusters. ",
         "Spinnaker assumes you have a Kubernetes cluster already running. If you don't, you must configure one: ",
         "https://kubernetes.io/docs/getting-started-guides/. \n\nBefore proceeding, please visit ",
-        "https://kubernetes.io/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/",
+        "https://kubernetes.io/docs/concepts/cluster-administration/authenticate-across-clusters-kubeconfig/ ",
         "to make sure you're familiar with the authentication terminology. For more information on how to ",
         "configure individual accounts, or how to deploy to multiple clusters, please read the documentation ",
         "under `hal config provider kubernetes account -h`.");


### PR DESCRIPTION
Was:
https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/to

Should be:
https://kubernetes.io/docs/tasks/access-application-cluster/configure-access-multiple-clusters/