### PR TITLE
Fix moniker annotations

### DIFF
--- a/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
@@ -4,8 +4,8 @@ metadata:
   name: spin-{{ name }}
   namespace: {{ namespace }}
   annotations:
-    moniker.spinnaker.io/application: "'spin'"
-    moniker.spinnaker.io/cluster: "'{{ name }}'"
+    moniker.spinnaker.io/application: '"spin"'
+    moniker.spinnaker.io/cluster: '"{{ name }}"'
   labels:
     app: spin
     cluster: spin-{{ name }}


### PR DESCRIPTION
The annotations should include the double quotes to make the value a string according to Jackon's rules.

Fixes warnings like
```text
2018-02-17 17:52:38.276  WARN 1 --- [ecutionAction-7] .s.c.k.v.d.m.KubernetesManifestAnnotater : Illegally annotated resource for 'moniker.spinnaker.io/cluster': com.fasterxml.jackson.core.JsonParseException: Unexpected character (''' (code 39)): expected a valid value (number, String, array, object, 'true', 'false' or 'null') at [Source: 'front50'; line: 1, column: 2]`
```

The previous values created `moniker.spinnaker.io/application: '''spin'''`, as could be seen using `kubectl edit -n spinnaker deploy/spin-orca`