### PR TITLE
fix(rosco): Fix localgit rosco deployment when pointing at a branch

### DIFF
--- a/halyard-core/halyard-core.gradle
+++ b/halyard-core/halyard-core.gradle
@@ -8,4 +8,5 @@ dependencies {
   compile 'com.beust:jcommander:1.48'
   compile 'com.hubspot.jinjava:jinjava:2.2.3'
   compile 'com.google.api.grpc:grpc-google-common-protos:1.0.5'
+  compile 'org.apache.commons:commons-compress:1.14'
 }


### PR DESCRIPTION
Rosco deployment currently fails when halyard is configured as localgit
and is pointed at a non-release branch.  This change updates the way
that haylard reads the rosco profile files in this situation and
addresses the issue.