### PR TITLE
feat(kubernetes): Allow custom pod annotations for spinnaker services

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -20,11 +20,15 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class KubernetesSettings {
   List<String> imagePullSecrets = new ArrayList<>();
+  Map<String, String> podAnnotations = new HashMap<>();
+
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -348,6 +348,7 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
     }
 
     description.setVolumeSources(volumeSources);
+    description.setPodAnnotations(settings.getKubernetes().getPodAnnotations());
 
     List<String> loadBalancers = new ArrayList<>();
     loadBalancers.add(name);
@@ -568,6 +569,7 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
         .endSelector()
         .withNewTemplate()
         .withNewMetadata()
+        .withAnnotations(settings.getKubernetes().getPodAnnotations())
         .withLabels(podLabels)
         .endMetadata()
         .withNewSpec()

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -140,6 +140,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         .addBinding("name", getService().getCanonicalName())
         .addBinding("namespace", namespace)
         .addBinding("replicas", settings.getTargetSize())
+        .addBinding("podAnnotations", settings.getKubernetes().getPodAnnotations())
         .addBinding("podSpec", podSpec.toString())
         .toString();
   }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
@@ -17,6 +17,10 @@ spec:
       cluster: spin-{{ name }}
   template:
     metadata:
+      annotations: {
+      {% for key, value in podAnnotations.items() %}
+              "{{ key }}" : "{{ value }}"{% if not loop.last %}, {% endif %}
+      {% endfor %}}
       labels:
         app: spin
         cluster: spin-{{ name }}


### PR DESCRIPTION
When deploying spinnaker to kubernetes, it is sometimes necessary for
some of the services to have extra annotations. For example when using
kube2iam to specify the role certain pods should get. This change adds a
map for podAnnotations to the KubernetesSettings and applies it to both
the replicasets in the v1 provider and the deployments for the v2
provider.