### PR TITLE
fix(changelog): Stop fetching placeholder changelog

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -82,11 +82,14 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
 
     Optional<Versions.Version> validatedVersion = versionsService.getVersions().getVersion(version);
 
-    validatedVersion.ifPresent(v -> {
-      String changelog = v.getChangelog();
+    if (validatedVersion.isPresent()) {
+      String changelog = validatedVersion.get().getChangelog();
       bindings.put("changelog.gist.id", changelog.substring(changelog.lastIndexOf("/") + 1));
       bindings.put("changelog.gist.name", "changelog.md");
-    });
+    } else {
+      bindings.put("changelog.gist.id", "");
+      bindings.put("changelog.gist.name", "");
+    }
 
     // Configure feature-flags
     bindings.put("features.auth", Boolean.toString(features.isAuth(deploymentConfiguration)));


### PR DESCRIPTION
When running an unvalidated version of spinnaker, set the changelog
to an empty string so we skip changelog fetching rather than try to
fetch the placeholder {%changelog.gist.id%} from GitHub.