### PR TITLE
fix(deploy): fix deploys prior to 1.7

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/BillOfMaterials.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/BillOfMaterials.java
@@ -76,7 +76,7 @@ public class BillOfMaterials {
     Artifact monitoringDaemon;
     Artifact spinnaker;
 
-    Artifact defaultArtifact;
+    Artifact defaultArtifact = new Artifact();
 
     String getArtifactVersion(String artifactName) {
       return getFieldArtifact(Services.class, this, artifactName).getVersion();


### PR DESCRIPTION
kayenta service prior to 1.7 was not enabled, and needs a safe default to lookup instead. @duftler FYI