### PR TITLE
install(docker): run Halyard as spinnaker user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 
+RUN useradd spinnaker
+
+USER spinnaker
+
 CMD "/opt/halyard/bin/halyard"

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -21,4 +21,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 
+RUN useradd spinnaker
+
+USER spinnaker
+
 CMD "/opt/halyard/bin/halyard"


### PR DESCRIPTION
BREAKING CHANGE: For anyone mounting halyard configuration, it will now go under /home/spinnaker rather than /root