### PR TITLE
fix(deploy/kubernetes): fix mounting of v2 aws creds

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
@@ -86,6 +86,7 @@ abstract public class ClouddriverService extends SpringService<ClouddriverServic
   }
 
   protected Optional<Profile> generateAwsProfile(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints, String spinnakerHome) {
+    String name = "aws/clouddriver-credentials" + spinnakerHome.replace("/", "_");
     AwsProvider awsProvider = deploymentConfiguration.getProviders().getAws();
     if (awsProvider.isEnabled()
         && !StringUtils.isEmpty(awsProvider.getAccessKeyId())
@@ -96,7 +97,7 @@ abstract public class ClouddriverService extends SpringService<ClouddriverServic
           .setAccessKeyId(awsProvider.getAccessKeyId())
           .setSecretAccessKey(awsProvider.getSecretAccessKey())
           .build()
-          .getProfile("aws/clouddriver-credentials", outputFile, deploymentConfiguration, endpoints));
+          .getProfile(name, outputFile, deploymentConfiguration, endpoints));
     } else {
       return Optional.empty();
     }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
@@ -77,6 +77,7 @@ abstract public class Front50Service extends SpringService<Front50Service.Front5
   }
 
   protected Optional<Profile> generateAwsProfile(DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints, String spinnakerHome) {
+    String name = "aws/front50-credentials" + spinnakerHome.replace("/", "_");
     PersistentStore.PersistentStoreType type = deploymentConfiguration.getPersistentStorage().getPersistentStoreType();
     S3PersistentStore store = deploymentConfiguration.getPersistentStorage().getS3();
     if (type == PersistentStore.PersistentStoreType.S3
@@ -88,7 +89,7 @@ abstract public class Front50Service extends SpringService<Front50Service.Front5
           .setAccessKeyId(store.getAccessKeyId())
           .setSecretAccessKey(store.getSecretAccessKey())
           .build()
-          .getProfile("aws/front50-credentials", outputFile, deploymentConfiguration, endpoints));
+          .getProfile(name, outputFile, deploymentConfiguration, endpoints));
     } else {
       return Optional.empty();
     }


### PR DESCRIPTION
The aws credentials were deduped by name, causing front50 to only mount
one of the spinnaker/root creds

closes https://github.com/spinnaker/spinnaker/issues/2642