### PR TITLE
fix(deploy/kubernetes): fix empty kubeconfig in account definition

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.jgit.util.StringUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -421,6 +422,13 @@ abstract public class Node implements Validatable {
       try {
         f.setAccessible(true);
         String fPath = (String) f.get(n);
+        if (fPath == null) {
+          try {
+            fPath = (String) n.getClass().getMethod("get" + StringUtils.capitalize(f.getName())).invoke(n);
+          } catch (NoSuchMethodException | InvocationTargetException ignored) {
+          }
+        }
+
         if (fPath == null) {
           return null;
         }


### PR DESCRIPTION
Since we find a "default" kubeconfig using a "getter", the file was
incorrectly being ignored as "not set" when someone manually removes it
from their halconfig. This can only happen when someone edits their
halconfig by hand.