### PR TITLE
fix(localbom): path to local bom should be consistent

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
@@ -44,8 +44,8 @@ public class ResourceConfig {
   }
 
   @Bean
-  String localBomPath(@Value("${halyard.halconfig.directory:~/.hal/.boms}") String path) {
-    return normalizePath(path);
+  String localBomPath(@Value("${halyard.halconfig.directory:~/.hal}") String path) {
+    return normalizePath(Paths.get(path, ".boms").toString());
   }
   
   /**


### PR DESCRIPTION
If `halyard.halconfig.directory` isn't set, boms live under `halconfigDir/.boms/bom/`. 

If it is set, then boms live under `halconfigDir/bom/`. 