### PR TITLE
fix(local): strip `local:` prefix before deploying, allow non-semvar …

### DIFF
--- a/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/LocalDiskProfileReaderSpec.groovy
+++ b/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/LocalDiskProfileReaderSpec.groovy
@@ -103,7 +103,7 @@ class LocalDiskProfileReaderSpec extends Specification {
                 tis.getNextEntry()
                 tarContents = IOUtils.toString(tis)
             } catch (IOException e) {
-                    throw new HalException(Problem.Severity.FATAL, "Failed to read profile entry", e);
+                    throw new HalException(Problem.Severity.FATAL, "Failed to read profile entry", e)
             }
             def fileInputStream =  localDiskProfileReader.readProfile(artifactName, version, profileName)
             def fileContents = IOUtils.toString(fileInputStream)

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentDetails.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DeploymentDetails.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.halyard.deploy.deployment.v1;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
+import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import lombok.Data;
+import org.apache.commons.lang.StringUtils;
 
 @Data
 public class DeploymentDetails {
@@ -27,6 +29,9 @@ public class DeploymentDetails {
   BillOfMaterials billOfMaterials;
 
   public String getArtifactVersion(String artifactName) {
-    return billOfMaterials.getArtifactVersion(artifactName);
+    String version = billOfMaterials.getArtifactVersion(artifactName);
+    return version.contains(Versions.LOCAL_PREFIX)
+            ? StringUtils.substringAfterLast(version, Versions.LOCAL_PREFIX)
+            : version;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.GateProfileFact
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -38,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @EqualsAndHashCode(callSuper = true)
 @Data
 @Component
@@ -84,8 +86,12 @@ abstract public class GateService extends SpringService<GateService.Gate> {
 
   private GateProfileFactory getGateProfileFactory(String deploymentName) {
     String version = artifactService.getArtifactVersion(deploymentName, SpinnakerArtifact.GATE);
-    if (Versions.lessThan(version, BOOT_UPGRADED_VERSION)) {
-      return boot128ProfileFactory;
+    try {
+      if (Versions.lessThan(version, BOOT_UPGRADED_VERSION)) {
+        return boot128ProfileFactory;
+      }
+    } catch (NumberFormatException nfe) {
+      log.warn("Could not resolve Gate version, using `boot154ProfileFactory`.");
     }
     return boot154ProfileFactory;
   }


### PR DESCRIPTION
…gate versions