### PR TITLE
Change the kubernetes proxyServiceEndpoint

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1ProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1ProviderUtils.java
@@ -70,7 +70,7 @@ class KubernetesV1ProviderUtils {
       return new URIBuilder().setPort(proxy.getPort())
           .setHost("localhost")
           .setScheme("http")
-          .setPath("/api/v1/proxy/namespaces/" + namespace + "/services/" + serviceName + ":" + servicePort)
+          .setPath("/api/v1/namespaces/" + namespace + "/services/" + serviceName + ":" + servicePort + "/proxy")
           .build();
     } catch (URISyntaxException e) {
       throw new HalException(Severity.FATAL, "Malformed service details: " + e.getMessage());


### PR DESCRIPTION
Fixed an issue https://github.com/spinnaker/spinnaker/issues/2728

hal deploy apply uses the old style proxy path for kubernetes which was removed in v1.10

