### PR TITLE
Trivial Doc update: use api key instead of password

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1922,7 +1922,7 @@ hal config ci jenkins master add MASTER [parameters]
  * `--csrf`: Whether or not to negotiate CSRF tokens when calling Jenkins.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--password`: (*Sensitive data* - user will be prompted on standard input) The password of the jenkins user to authenticate as.
+ * `--password`: (*Sensitive data* - user will be prompted on standard input) The api key of the jenkins user to authenticate as.
  * `--username`: The username of the jenkins user to authenticate as.
 
 
@@ -1958,7 +1958,7 @@ hal config ci jenkins master edit MASTER [parameters]
  * `--csrf`: Whether or not to negotiate CSRF tokens when calling Jenkins.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--password`: (*Sensitive data* - user will be prompted on standard input) The password of the jenkins user to authenticate as.
+ * `--password`: (*Sensitive data* - user will be prompted on standard input) The api key of the jenkins user to authenticate as.
  * `--username`: The username of the jenkins user to authenticate as.
 
 


### PR DESCRIPTION
Halyard command documentation says _password_ where one should get the APIKEY for the user per IGOR's own documentation. 

Keeps the password flag (to not break anyone's scripting), just updates the documentation to say **api key** in the description for the flag in commands.md 

