### PR TITLE
feat(customization): Enables per-service override of binary source re…

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ArtifactSourcesConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ArtifactSourcesConfig.java
@@ -28,6 +28,7 @@ import org.springframework.context.annotation.Configuration;
 @ConfigurationProperties("spinnaker.artifacts")
 @Configuration
 public class ArtifactSourcesConfig {
+  String gitPrefix = "https://github.com/spinnaker";
   String googleImageProject = "marketplace-spinnaker-release";
   String dockerRegistry = "gcr.io/spinnaker-marketplace";
   String debianRepository = "https://dl.bintray.com/spinnaker-releases/debians";
@@ -37,16 +38,20 @@ public class ArtifactSourcesConfig {
       return this;
     }
 
-    if (!StringUtils.isEmpty(artifactSources.getGoogleImageProject())) {
+    if (StringUtils.isNotEmpty(artifactSources.getGoogleImageProject())) {
       googleImageProject = artifactSources.getGoogleImageProject();
     }
 
-    if (!StringUtils.isEmpty(artifactSources.getDockerRegistry())) {
+    if (StringUtils.isNotEmpty(artifactSources.getDockerRegistry())) {
       dockerRegistry = artifactSources.getDockerRegistry();
     }
 
-    if (!StringUtils.isEmpty(artifactSources.getDebianRepository())) {
+    if (StringUtils.isNotEmpty(artifactSources.getDebianRepository())) {
       debianRepository = artifactSources.getDebianRepository();
+    }
+
+    if (StringUtils.isNotEmpty(artifactSources.getDebianRepository())) {
+      gitPrefix = artifactSources.getGitPrefix();
     }
 
     return this;

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/BillOfMaterials.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/BillOfMaterials.java
@@ -48,6 +48,10 @@ public class BillOfMaterials {
     String getArtifactCommit(String artifactName) {
       return getFieldArtifact(Dependencies.class, this, artifactName).getCommit();
     }
+
+    ArtifactSources getArtifactSources(String artifactName) {
+      return getFieldArtifact(Dependencies.class, this, artifactName).getArtifactSources();
+    }
   }
 
   @Data
@@ -85,12 +89,17 @@ public class BillOfMaterials {
     String getArtifactCommit(String artifactName) {
       return getFieldArtifact(Services.class, this, artifactName).getCommit();
     }
+
+    ArtifactSources getArtifactSources(String artifactName) {
+      return getFieldArtifact(Services.class, this, artifactName).getArtifactSources();
+    }
   }
 
   @Data
   static class Artifact {
     String version;
     String commit;
+    ArtifactSources artifactSources;
   }
 
   static private <T> Artifact getFieldArtifact(Class<T> clazz, T obj, String artifactName) {
@@ -114,7 +123,7 @@ public class BillOfMaterials {
       if (result == null && !artifactName.equals("defaultArtifact")) {
         result = getFieldArtifact(clazz, obj, "defaultArtifact");
       }
-      
+
       if (result == null) {
         result = new Artifact();
       }
@@ -159,5 +168,19 @@ public class BillOfMaterials {
     }
 
     throw new IllegalArgumentException("No artifact with name " + artifactName + " could be found in the BOM");
+  }
+
+  public ArtifactSources getArtifactSources(String artifactName) {
+    try {
+      return services.getArtifactSources(artifactName);
+    } catch (NoKnownArtifact ignored) {
+    }
+
+    try {
+      return dependencies.getArtifactSources(artifactName);
+    } catch (NoKnownArtifact ignored) {
+    }
+
+    return null;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
@@ -43,6 +43,7 @@ import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetai
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService.ResolvedConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
@@ -80,7 +81,7 @@ public interface GoogleDistributedService<T> extends DistributedService<T, Googl
   GoogleConsulServerService getConsulServerService();
   ArtifactService getArtifactService();
   ServiceInterfaceFactory getServiceInterfaceFactory();
-  String getGoogleImageProject(String deploymentName);
+  String getGoogleImageProject(String deploymentName, SpinnakerArtifact artifact);
   String getStartupScriptPath();
 
   default String getDefaultInstanceType() {
@@ -135,7 +136,7 @@ public interface GoogleDistributedService<T> extends DistributedService<T, Googl
     String artifactName = getArtifact().getName();
     String version = getArtifactService().getArtifactVersion(deploymentName, getArtifact());
     return String.format("projects/%s/global/images/%s",
-        getGoogleImageProject(deploymentName),
+        getGoogleImageProject(deploymentName, getArtifact()),
         String.join("-", "spinnaker", artifactName, version.replace(".", "-").replace(":", "-")));
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedServiceDelegate.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedServiceDelegate.java
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.go
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -63,8 +64,8 @@ public class GoogleDistributedServiceDelegate {
   @Getter
   GoogleConsulServerService consulServerService;
 
-  public String getGoogleImageProject(String deploymentName) {
-    BillOfMaterials.ArtifactSources artifactSources = artifactService.getArtifactSources(deploymentName);
+  public String getGoogleImageProject(String deploymentName, SpinnakerArtifact artifact) {
+    BillOfMaterials.ArtifactSources artifactSources = artifactService.getArtifactSources(deploymentName, artifact);
     return artifactSourcesConfig.mergeWithBomSources(artifactSources).getGoogleImageProject();
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -48,12 +48,14 @@ import com.netflix.spinnaker.halyard.core.job.v1.JobExecutor;
 import com.netflix.spinnaker.halyard.core.job.v1.JobRequest;
 import com.netflix.spinnaker.halyard.core.job.v1.JobStatus;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails.Instance;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
@@ -95,7 +97,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public interface KubernetesV1DistributedService<T> extends DistributedService<T, KubernetesAccount>, LogCollector<T, AccountDeploymentDetails<KubernetesAccount>> {
-  String getDockerRegistry(String deploymentName);
+  String getDockerRegistry(String deploymentName, SpinnakerArtifact artifact);
   ArtifactService getArtifactService();
   ServiceInterfaceFactory getServiceInterfaceFactory();
   ObjectMapper getObjectMapper();
@@ -123,8 +125,9 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
   default String getArtifactId(String deploymentName) {
     String artifactName = getArtifact().getName();
     String version = getArtifactService().getArtifactVersion(deploymentName, getArtifact());
+    version = Versions.isLocal(version) ? Versions.fromLocal(version) : version;
 
-    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry(deploymentName));
+    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry(deploymentName, getArtifact()));
     return KubernetesUtil.getImageId(image);
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedServiceDelegate.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedServiceDelegate.java
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.ku
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceInterfaceFactory;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -35,8 +36,8 @@ public class KubernetesV1DistributedServiceDelegate {
   @Getter
   KubernetesV1DistributedLogCollectorFactory logCollectorFactory;
 
-  public String getDockerRegistry(String deploymentName) {
-    BillOfMaterials.ArtifactSources artifactSources = artifactService.getArtifactSources(deploymentName);
+  public String getDockerRegistry(String deploymentName, SpinnakerArtifact artifact) {
+    BillOfMaterials.ArtifactSources artifactSources = artifactService.getArtifactSources(deploymentName, artifact);
     return artifactSourcesConfig.mergeWithBomSources(artifactSources).getDockerRegistry();
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1MonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1MonitoringDaemonService.java
@@ -51,7 +51,7 @@ public class KubernetesV1MonitoringDaemonService extends SpinnakerMonitoringDaem
     String artifactName = getArtifact().getName();
     String version = getArtifactService().getArtifactVersion(deploymentName, getArtifact());
 
-    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry(deploymentName));
+    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry(deploymentName, getArtifact()));
     return KubernetesUtil.getImageId(image);
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.halyard.core.resource.v1.TemplatedResource;
 import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
@@ -59,7 +60,7 @@ import java.util.stream.Collectors;
 
 public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   String getServiceName();
-  String getDockerRegistry(String deploymentName);
+  String getDockerRegistry(String deploymentName, SpinnakerArtifact artifact);
   String getSpinnakerStagingPath(String deploymentName);
   ArtifactService getArtifactService();
   ServiceSettings defaultServiceSettings();
@@ -300,7 +301,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     String version = getArtifactService().getArtifactVersion(deploymentName, getArtifact());
     version = Versions.isLocal(version) ? Versions.fromLocal(version) : version;
 
-    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry(deploymentName));
+    KubernetesImageDescription image = new KubernetesImageDescription(artifactName, version, getDockerRegistry(deploymentName, getArtifact()));
     return KubernetesUtil.getImageId(image);
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceDelegate.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceDelegate.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -32,8 +33,8 @@ public class KubernetesV2ServiceDelegate {
   @Autowired
   ArtifactSourcesConfig artifactSourcesConfig;
 
-  public String getDockerRegistry(String deploymentName) {
-    BillOfMaterials.ArtifactSources artifactSources = artifactService.getArtifactSources(deploymentName);
+  public String getDockerRegistry(String deploymentName, SpinnakerArtifact artifact) {
+    BillOfMaterials.ArtifactSources artifactSources = artifactService.getArtifactSources(deploymentName, artifact);
     return artifactSourcesConfig.mergeWithBomSources(artifactSources).getDockerRegistry();
   }
 

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesV1DistributedServiceSpec.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/KubernetesV1DistributedServiceSpec.groovy
@@ -216,7 +216,7 @@ class KubernetesV1DistributedServiceSpec extends Specification {
     private KubernetesV1DistributedService createServiceTestDouble() {
         new KubernetesV1DistributedService() {
             @Override
-            String getDockerRegistry(String deploymentName) {
+            String getDockerRegistry(String deploymentName, SpinnakerArtifact artifact) {
                 return null
             }
 


### PR DESCRIPTION
…pository.

Example custom BOM that replaces Rosco with my own build would look like:

```
version: 1.7.5
timestamp: '2018-05-21 14:16:06'
services:
  ...
  rosco:
    version: local:foo
    artifactSources:
      dockerRegistry: gcr.io/ttomsu-dev-spinnaker
  ...
dependencies:
  ...
artifactSources:
  debianRepository: https://dl.bintray.com/spinnaker-releases/debians
  dockerRegistry: gcr.io/spinnaker-marketplace
  googleImageProject: marketplace-spinnaker-release
  gitPrefix: https://github.com/spinnaker
```

This results in the container having image `gcr.io/ttomsu-dev-spinnaker/rosco:foo`, and Rosco configs being pulled from my local `~/.hal/.boms/bom/rosco/foo` directory. 

I only tested this against a Kubernetes V2 deployment. Additional work (and testing) will need to be done to make this work with Debian packages.

cc/ @ewiseblatt @danielpeach 