### PR TITLE
fix(README): Fix InstallHalyard scripts' URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A tool for configuring, installing, and updating Spinnaker.
 > [slack](http://join.spinnaker.io).
 
 ```
-$ curl -O https://raw.githubusercontent.com/spinnaker/halyard/master/install/stable/InstallHalyard.sh
+$ curl -O https://raw.githubusercontent.com/spinnaker/halyard/master/install/debian/InstallHalyard.sh
 $ sudo bash InstallHalyard.sh
 ```
 


### PR DESCRIPTION
Current scripts' URL can't be installed on Ubuntu 16.04.
[In Spinnaker's documentation](https://www.spinnaker.io/setup/install/halyard/#install-on-ubuntu-14041604), installation on Ubuntu 16.04 is shown, and the URL is also displayed differently.