### PR TITLE
fix(Halyard): s3 --bucket not accept s3:// prefix

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
@@ -81,6 +81,9 @@ public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3Persiste
 
   @Override
   protected S3PersistentStore editPersistentStore(S3PersistentStore persistentStore) {
+    if(isSet(bucket) && bucket.startsWith("s3://")){
+      bucket = bucket.substring(5); //Line to edit out the "s3://" part of the bucket string
+    }
     persistentStore.setBucket(isSet(bucket) ? bucket : persistentStore.getBucket());
     persistentStore.setRootFolder(isSet(rootFolder) ? rootFolder : persistentStore.getRootFolder());
     persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());


### PR DESCRIPTION
Solution to "Halyard: s3 --bucket will not accetp s3:// prefix #2408"

fixes #2408

Better solution might be is to find out why the parameter cannot be stored with the s3:// because it should be needed to access the s3 bucket. Possibly the validate function cannot handle the s3:// prefix and the code needed when the bucket is accessed would need updating so this might be the easiest solution.