### PR TITLE
fix(version/bom): BOM version command displays message if Spinnaker version is not properly formatted.

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
@@ -64,25 +64,17 @@ public class BomVersionCommand extends AbstractConfigCommand {
   }
 
   public String getVersion() {
-    String version;
     switch (versions.size()) {
       case 0:
-        version = new OperationHandler<String>()
+        return new OperationHandler<String>()
             .setOperation(Daemon.getVersion(getCurrentDeployment(), false))
             .setFailureMesssage("Failed to get version of Spinnaker configured in your halconfig.")
             .get();
-        break;
       case 1:
-        version = versions.get(0);
-        break;
+        return versions.get(0);
       default:
         throw new IllegalArgumentException("More than one version supplied");
     }
-
-    if (!BomVersionCommand.isProjectVersionFormat(version)) {
-      throw new RuntimeException(String.format("Failed to get BOM versions because Spinnaker version is not properly formatted in halconfig: version='%s'", version));
-    }
-    return version;
   }
 
   @Override
@@ -104,10 +96,5 @@ public class BomVersionCommand extends AbstractConfigCommand {
     }
 
     AnsiPrinter.out.println(result);
-  }
-
-  private static boolean isProjectVersionFormat(String version) {
-    // Matches #, #.#, #.#.#, ...
-    return version.matches("\\d+(\\.\\d+)*");
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
@@ -64,17 +64,25 @@ public class BomVersionCommand extends AbstractConfigCommand {
   }
 
   public String getVersion() {
+    String version;
     switch (versions.size()) {
       case 0:
-        return new OperationHandler<String>()
+        version = new OperationHandler<String>()
             .setOperation(Daemon.getVersion(getCurrentDeployment(), false))
             .setFailureMesssage("Failed to get version of Spinnaker configured in your halconfig.")
             .get();
+        break;
       case 1:
-        return versions.get(0);
+        version = versions.get(0);
+        break;
       default:
         throw new IllegalArgumentException("More than one version supplied");
     }
+
+    if (!BomVersionCommand.isProjectVersionFormat(version)) {
+      throw new RuntimeException(String.format("Failed to get BOM versions because Spinnaker version is not properly formatted in halconfig: version='%s'", version));
+    }
+    return version;
   }
 
   @Override
@@ -96,5 +104,10 @@ public class BomVersionCommand extends AbstractConfigCommand {
     }
 
     AnsiPrinter.out.println(result);
+  }
+
+  private static boolean isProjectVersionFormat(String version) {
+    // Matches #, #.#, #.#.#, ...
+    return version.matches("\\d+(\\.\\d+)*");
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -773,7 +773,7 @@ public class Daemon {
 
   public static Supplier<BillOfMaterials> getBillOfMaterials(String version) {
     return () -> {
-      Object rawBillOfMaterials = ResponseUnwrapper.get(getService().getBillOfMaterials(version));
+      Object rawBillOfMaterials = ResponseUnwrapper.get(getService().getBillOfMaterialsV2(version));
       return getObjectMapper().convertValue(rawBillOfMaterials, BillOfMaterials.class);
     };
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -727,6 +727,9 @@ public interface DaemonService {
   @GET("/v1/versions/bom/{version}")
   DaemonTask<Halconfig, Object> getBillOfMaterials(@Path("version") String version);
 
+  @GET("/v1/versions/bom")
+  DaemonTask<Halconfig, Object> getBillOfMaterialsV2(@Query("version") String version);
+
   @PUT("/v1/admin/publishProfile/{artifactName}")
   DaemonTask<Halconfig, Void> publishProfile(
       @Query("bomPath") String bomPath,

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -724,9 +724,14 @@ public interface DaemonService {
   @GET("/v1/versions/latest/")
   DaemonTask<Halconfig, String> getLatest();
 
+  @Deprecated
   @GET("/v1/versions/bom/{version}")
   DaemonTask<Halconfig, Object> getBillOfMaterials(@Path("version") String version);
 
+  /**
+   * This method should be used in place of getBillOfMaterials because of Spring's inability to
+   * receive encoded forward slashes in a path variable.
+   */
   @GET("/v1/versions/bom")
   DaemonTask<Halconfig, Object> getBillOfMaterialsV2(@Query("version") String version);
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/VersionsService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/VersionsService.java
@@ -17,6 +17,8 @@
 
 package com.netflix.spinnaker.halyard.config.services.v1;
 
+import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.FATAL;
+
 import com.netflix.spinnaker.halyard.config.config.v1.RelaxedObjectMapper;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
@@ -24,15 +26,12 @@ import com.netflix.spinnaker.halyard.core.memoize.v1.ExpiringConcurrentMap;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
 import com.netflix.spinnaker.halyard.core.registry.v1.ProfileRegistry;
 import com.netflix.spinnaker.halyard.core.registry.v1.Versions;
+import java.io.IOException;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.Yaml;
 import retrofit.RetrofitError;
-
-import java.io.IOException;
-import java.util.Optional;
-
-import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.FATAL;
 
 @Component
 public class VersionsService {
@@ -65,6 +64,22 @@ public class VersionsService {
       throw new HalException(
           new ConfigProblemBuilder(FATAL,
               "You must pick a version of Spinnaker to deploy.")
+              .build()
+      );
+    }
+
+    if (Versions.isBranch(version)) {
+      throw new HalException(
+          new ConfigProblemBuilder(FATAL,
+              "Version prefixed with \"branch:\" does not have a BOM")
+              .build()
+      );
+    }
+
+    if (Versions.isLocal(version)) {
+      throw new HalException(
+          new ConfigProblemBuilder(FATAL,
+              "Version prefixed with \"local:\" does not have a BOM")
               .build()
       );
     }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/VersionsController.java
@@ -27,6 +27,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -49,8 +50,23 @@ public class VersionsController {
     return DaemonTaskHandler.submitTask(builder::build, "Get latest released version");
   }
 
+  /**
+   * This method is deprecated because of the inability to handle encoded forward slashes in the
+   * path variable. Although it is possible to configure Spring to allow this, it is recommended
+   * that the variable be moved to a request variable:
+   *
+   * https://stackoverflow.com/questions/13482020/encoded-slash-2f-with-spring-requestmapping-path-param-gives-http-400
+   *
+   * Please use bomV2 instead.
+   */
+  @Deprecated
   @RequestMapping(value = "/bom/{version:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, BillOfMaterials> bom(@PathVariable String version) {
+    return bomV2(version);
+  }
+
+  @RequestMapping(value = "/bom", method = RequestMethod.GET)
+  DaemonTask<Halconfig, BillOfMaterials> bomV2(@RequestParam(value = "version") String version) {
     DaemonResponse.StaticRequestBuilder<BillOfMaterials> builder = new DaemonResponse.StaticRequestBuilder<>(
             () -> versionsService.getBillOfMaterials(version));
     return DaemonTaskHandler.submitTask(builder::build, "Get BOM for " + version);


### PR DESCRIPTION
* When calling `hal version bom`, checks to make sure that the Spinnaker version in the halconfig file is a properly formatted version (string of numbers with 0 or more dots in between, with no dots directly next to each other).

Before:
```
➜  hal version bom        
+ Get current deployment
  Success
+ Get Spinnaker version
  Success
+ Get current deployment
  Success
+ Get Spinnaker version
  Success
! ERROR 400 
```

After:
```
➜  ./hal version bom                                                                                             
+ Get current deployment
  Success
+ Get Spinnaker version
  Success
! ERROR Failed to get BOM versions because Spinnaker version is not
  properly formatted in halconfig: version='branch:upstream/master'
```