### PR TITLE
fix(halyard): Allow none standard uri for github oauth2 authn

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth2/EditOAuth2Command.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth2/EditOAuth2Command.java
@@ -27,67 +27,110 @@ import lombok.Getter;
 
 @Parameters(separators = "=")
 public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
-  @Getter
-  private AuthnMethod.Method method = AuthnMethod.Method.OAuth2;
+    @Getter
+    private AuthnMethod.Method method = AuthnMethod.Method.OAuth2;
 
-  @Parameter(
-      names = "--client-id",
-      description = "The OAuth client ID you have configured with your OAuth provider."
-  )
-  private String clientId;
+    @Parameter(
+            names = "--client-id",
+            description = "The OAuth client ID you have configured with your OAuth provider."
+    )
+    private String clientId;
 
-  @Parameter(
-      names = "--client-secret",
-      description = "The OAuth client secret you have configured with your OAuth provider."
-  )
-  private String clientSecret;
+    @Parameter(
+            names = "--client-secret",
+            description = "The OAuth client secret you have configured with your OAuth provider."
+    )
+    private String clientSecret;
 
-  @Parameter(
-      names = "--provider",
-      description = "The OAuth provider handling authentication. The supported options are Google, GitHub, and Azure",
-      converter = OAuth2ProviderTypeConverter.class
-  )
-  private OAuth2.Provider provider;
+    @Parameter(
+            names = "--access-token-uri",
+            description = "The access token uri e.g https://github.example.com/login/oauth/access_token"
+    )
+    private String accessTokenUri;
 
-  @Parameter(
-      names = "--pre-established-redirect-uri",
-      description = "The externally accessible URL for Gate. For use with load balancers that " +
-          "do any kind of address manipulation for Gate traffic, such as an SSL terminating load " +
-          "balancer."
-  )
-  private String preEstablishedRedirectUri;
+    @Parameter(
+            names = "--user-authorization-uri",
+            description = "The user authorization uri e.g https://github.example.com/login/oauth/authorize"
+    )
+    private String userAuthorizationUri;
 
-  @DynamicParameter(
-      names = "--user-info-requirements",
-      description = "The map of requirements the userInfo request must have. This is used to " +
-          "restrict user login to specific domains or having a specific attribute. Use equal " +
-          "signs between key and value, and additional key/value pairs need to repeat the " +
-          "flag. Example: '--user-info-requirements foo=bar --userInfoRequirements baz=qux'."
-  )
-  private OAuth2.UserInfoRequirements userInfoRequirements = new OAuth2.UserInfoRequirements();
+    @Parameter(
+            names = "--user-info-uri",
+            description = "The user info uri e.g https://github.example.com/api/v3/user"
+    )
+    private String userInfoUri;
 
-  @Override
-  protected AuthnMethod editAuthnMethod(OAuth2 authnMethod) {
-    OAuth2.Client client = authnMethod.getClient();
-    client.setClientId(isSet(clientId) ? clientId : client.getClientId());
-    client.setClientSecret(isSet(clientSecret) ? clientSecret : client.getClientSecret());
 
-    if (isSet(preEstablishedRedirectUri)) {
-      if (preEstablishedRedirectUri.isEmpty()) {
-        client.setPreEstablishedRedirectUri(null);
-        client.setUseCurrentUri(null);
-      } else {
-        client.setPreEstablishedRedirectUri(preEstablishedRedirectUri);
-        client.setUseCurrentUri(false);
-      }
+    @Parameter(
+            names = "--provider",
+            description = "The OAuth provider handling authentication. The supported options are Google, GitHub, and Azure",
+            converter = OAuth2ProviderTypeConverter.class
+    )
+    private OAuth2.Provider provider;
+
+    @Parameter(
+            names = "--pre-established-redirect-uri",
+            description = "The externally accessible URL for Gate. For use with load balancers that " +
+                    "do any kind of address manipulation for Gate traffic, such as an SSL terminating load " +
+                    "balancer."
+    )
+    private String preEstablishedRedirectUri;
+
+    @DynamicParameter(
+            names = "--user-info-requirements",
+            description = "The map of requirements the userInfo request must have. This is used to " +
+                    "restrict user login to specific domains or having a specific attribute. Use equal " +
+                    "signs between key and value, and additional key/value pairs need to repeat the " +
+                    "flag. Example: '--user-info-requirements foo=bar --userInfoRequirements baz=qux'."
+    )
+    private OAuth2.UserInfoRequirements userInfoRequirements = new OAuth2.UserInfoRequirements();
+
+    @Override
+    protected AuthnMethod editAuthnMethod(OAuth2 authnMethod) {
+        OAuth2.Client client = authnMethod.getClient();
+        client.setClientId(isSet(clientId) ? clientId : client.getClientId());
+        client.setClientSecret(isSet(clientSecret) ? clientSecret : client.getClientSecret());
+
+        if (isSet(preEstablishedRedirectUri)) {
+            if (preEstablishedRedirectUri.isEmpty()) {
+                client.setPreEstablishedRedirectUri(null);
+                client.setUseCurrentUri(null);
+            } else {
+                client.setPreEstablishedRedirectUri(preEstablishedRedirectUri);
+                client.setUseCurrentUri(false);
+            }
+        }
+
+        if (isSet(userInfoUri)) {
+            if (userInfoUri.isEmpty()) {
+                client.setUserInfoUri(null);
+            } else {
+                client.setUserInfoUri(userInfoUri);
+            }
+        }
+
+        if (isSet(userAuthorizationUri)) {
+            if (userAuthorizationUri.isEmpty()) {
+                client.setUserAuthorizationUri(null);
+            } else {
+                client.setUserAuthorizationUri(userAuthorizationUri);
+            }
+        }
+        if (isSet(accessTokenUri)) {
+            if (userAuthorizationUri.isEmpty()) {
+                client.setAccessTokenUri(null);
+            } else {
+                client.setAccessTokenUri(accessTokenUri);
+            }
+        }
+
+
+        authnMethod.setProvider(provider != null ? provider : authnMethod.getProvider());
+
+        if (!userInfoRequirements.isEmpty()) {
+            authnMethod.setUserInfoRequirements(userInfoRequirements);
+        }
+
+        return authnMethod;
     }
-
-    authnMethod.setProvider(provider != null ? provider : authnMethod.getProvider());
-
-    if (!userInfoRequirements.isEmpty()) {
-      authnMethod.setUserInfoRequirements(userInfoRequirements);
-    }
-
-    return authnMethod;
-  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth2.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth2.java
@@ -95,6 +95,19 @@ public class OAuth2 extends AuthnMethod {
         newUserInfoMapping.setLastName("name");
         newUserInfoMapping.setUsername("login");
         break;
+      case EGITHUB:
+        newClient.setAccessTokenUri(client.getAccessTokenUri());
+        newClient.setUserAuthorizationUri(client.getUserAuthorizationUri());
+        newClient.setScope("user:email");
+        newClient.setUserInfoUri(client.getUserInfoUri());
+
+        newResource.setUserInfoUri(client.getUserInfoUri());
+
+        newUserInfoMapping.setEmail("email");
+        newUserInfoMapping.setFirstName("");
+        newUserInfoMapping.setLastName("name");
+        newUserInfoMapping.setUsername("login");
+        break;
       case AZURE:
         newClient.setAccessTokenUri("https://login.microsoftonline.com/${azureTenantId}/oauth2/token");
         newClient.setUserAuthorizationUri("https://login.microsoftonline.com/${azureTenantId}/oauth2/authorize?resource=https://graph.windows.net");
@@ -126,6 +139,7 @@ public class OAuth2 extends AuthnMethod {
     private String scope;
     private String preEstablishedRedirectUri;
     private Boolean useCurrentUri;
+    private String userInfoUri;
   }
 
   @Data
@@ -154,6 +168,7 @@ public class OAuth2 extends AuthnMethod {
   public enum Provider {
     AZURE("azure"),
     GITHUB("github"),
+    EGITHUB("egithub"),
     GOOGLE("google");
 
     private String id;


### PR DESCRIPTION
This pull request implements an EGITHUB provider for authn in halyard e.g

```
hal config security authn oauth2 edit \
--client-id YYYYYYYYYYYYYYYYY\
--client-secret XXXXXX \
--provider egithub \
--access-token-uri https://github.example.com/login/oauth/access_token \
--user-authorization-uri https://github.example.com/login/oauth/authorize \
--user-info-uri https://github.example.com/api/v3/user 

```

It allows overriding the uris to be none github. I guess this could be used as any custom provider.

I created this because of https://github.com/spinnaker/spinnaker/issues/2856

I've put this together quickly to get round the problem I have but happy to make amendments if needed/required.
