### PR TITLE
feat(security): Moves Gate's management endpoints off of the default …

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1645,6 +1645,7 @@ hal config canary aws account add ACCOUNT [parameters]
  * `--access-key-id`: The default access key used to communicate with AWS.
  * `--bucket`: The name of a storage bucket that your specified account has access to. If you specify a globally unique bucket name that doesn't exist yet, Kayenta will create that bucket for you.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--endpoint`: The endpoint used to reach the service implementing the AWS api. Typical use is with Minio.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--root-folder`: The root folder in the chosen bucket to place all of the canary service's persistent data in (*Default*: `kayenta`).
  * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) The secret key used to communicate with AWS.
@@ -1681,6 +1682,7 @@ hal config canary aws account edit ACCOUNT [parameters]
  * `--access-key-id`: The default access key used to communicate with AWS.
  * `--bucket`: The name of a storage bucket that your specified account has access to. If you specify a globally unique bucket name that doesn't exist yet, Kayenta will create that bucket for you.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--endpoint`: The endpoint used to reach the service implementing the AWS api. Typical use is with Minio.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--root-folder`: The root folder in the chosen bucket to place all of the canary service's persistent data in (*Default*: `kayenta`).
  * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) The secret key used to communicate with AWS.

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateBoot154ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateBoot154ProfileFactory.java
@@ -41,6 +41,13 @@ public class GateBoot154ProfileFactory extends GateProfileFactory {
       config.x509 = new X509Config(security);
     }
 
+    if (security.getAuthn().isEnabled()) {
+      config.management = new Management();
+      config.spring = new SpringConfig();
+      config.endpoints = new GateConfig.Endpoints();
+      gate.setHealthPort(config.management.port);
+    }
+
     return config;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
@@ -63,6 +63,9 @@ public abstract class GateProfileFactory extends SpringProfileFactory {
     X509Config x509;
     GoogleConfig google = new GoogleConfig();
 
+    Management management;
+    Endpoints endpoints;
+
     GateConfig(ServiceSettings gate, Security security) {
       super(gate);
       server.ssl = security.getApiSecurity().getSsl();
@@ -83,6 +86,11 @@ public abstract class GateProfileFactory extends SpringProfileFactory {
     @Data
     static class GoogleConfig {
       IAPConfig iap;
+    }
+
+    @Data
+    static class Endpoints {
+      boolean sensitive = false;
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Management.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Management.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google, Inc.
+ * Copyright 2018 Netflix, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -12,40 +12,25 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSetter;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.netflix.spinnaker.halyard.config.model.v1.security.OAuth2;
-import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.Collections;
+import java.util.List;
+
 @EqualsAndHashCode(callSuper = false)
 @Data
-class SpringConfig {
-  OAuth2 oauth2;
-  Hateoas hateos;
-
-  SpringConfig() {
-    this.hateos = new Hateoas();
-  }
-
-  SpringConfig(Security security) {
-    OAuth2 oauth2 = security.getAuthn().getOauth2();
-    if (oauth2.isEnabled()) {
-      this.oauth2 = oauth2;
-    }
-  }
+class Management {
+  int port = 8085;
+  Security security = new Security();
 
   @Data
-  static class Hateoas {
-    @JsonProperty("use-hal-as-default-json-media-type")
-    boolean useHal = false;
+  static class Security {
+    boolean enabled = true;
+    List<String> roles = Collections.singletonList("ANONYMOUS");
   }
 }
-

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public class ServiceSettings {
   Integer port;
   // A port open only to the internal network
-  Integer internalPort;
+  Integer healthPort;
   String address;
   String host;
   String scheme;
@@ -137,5 +137,13 @@ public class ServiceSettings {
     } catch (URISyntaxException e) {
       throw new HalException(Problem.Severity.FATAL, "Could not build metrics endpoint. This is probably a bug.", e);
     }
+  }
+
+  public ServiceSettings setPort(Integer port) {
+    this.port = port;
+    if (this.healthPort == null) {
+      this.healthPort = this.port;
+    }
+    return this;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -384,6 +384,7 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
     KubernetesProbe readinessProbe = new KubernetesProbe();
     KubernetesHandler handler = new KubernetesHandler();
     int port = settings.getPort();
+    int healthPort = settings.getHealthPort();
     String scheme = settings.getScheme();
     if (StringUtils.isNotEmpty(scheme)) {
       scheme = scheme.toUpperCase();
@@ -396,13 +397,13 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
       handler.setType(KubernetesHandlerType.HTTP);
       KubernetesHttpGetAction action = new KubernetesHttpGetAction();
       action.setPath(healthEndpoint);
-      action.setPort(port);
+      action.setPort(healthPort);
       action.setUriScheme(scheme);
       handler.setHttpGetAction(action);
     } else {
       handler.setType(KubernetesHandlerType.TCP);
       KubernetesTcpSocketAction action = new KubernetesTcpSocketAction();
-      action.setPort(port);
+      action.setPort(healthPort);
       handler.setTcpSocketAction(action);
     }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -72,7 +72,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default List<String> getReadinessExecCommand(ServiceSettings settings) {
-    return Arrays.asList("wget", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint());
+    return Arrays.asList("wget", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getHealthPort() + settings.getHealthEndpoint());
   }
 
   default String getRootHomeDirectory() {


### PR DESCRIPTION
…port (8084) onto a new port (8085) that is not exposed through the loadbalancer, and turns off security for this port.

This implements the settings described in https://github.com/spinnaker/gate/pull/557, and should fix https://github.com/spinnaker/spinnaker/issues/2765. This PR should not be submitted until that Gate PR is submitted.