### PR TITLE
fix(provider/kubernetes): use the right URL to download heptio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 MAINTAINER delivery-engineering@netflix.com
 
-ENV KUBECTL_RELEASE=v1.10.3
+ENV KUBECTL_RELEASE=1.10.3
 ENV HEPTIO_BINARY_RELEASE_DATE=2018-06-05
 
 COPY . workdir/
@@ -19,7 +19,7 @@ RUN echo '#!/usr/bin/env bash' | tee /usr/local/bin/hal > /dev/null && \
 
 RUN chmod +x /usr/local/bin/hal
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 MAINTAINER delivery-engineering@netflix.com
 
-ENV KUBECTL_RELEASE=v1.10.3
+ENV KUBECTL_RELEASE=1.10.3
 ENV HEPTIO_BINARY_RELEASE_DATE=2018-06-05
 
 COPY . workdir/
@@ -18,7 +18,7 @@ RUN echo '#!/usr/bin/env bash' | tee /usr/local/bin/hal > /dev/null && \
 
 RUN chmod +x /usr/local/bin/hal
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
Hi - the Dockerfiles seem have a typo in the URL that is used to download the heptio-authenticator-aws binary.

Currently, the URL resolves to
`https://amazon-eks.s3-us-west-2.amazonaws.com/v1.10.3/2018-06-05/bin/linux/amd64/heptio-authenticator-aws`
which returns a "NoSuchKey" error and dumps a non-working file into the Docker image at /usr/local/bin/heptio-authenticator-aws

The correct URL should be
`https://amazon-eks.s3-us-west-2.amazonaws.com/1.10.3/2018-06-05/bin/linux/amd64/heptio-authenticator-aws`

The difference is that the "v" in front of the Kubectl version number must be dropped from this URL.