### PR TITLE
fix(install): Fix macosx-install-script's Java version confirmation.

### DIFF
--- a/install/macos/InstallHalyard.sh
+++ b/install/macos/InstallHalyard.sh
@@ -149,12 +149,14 @@ function install_java() {
   local java_version=$(java -version 2>&1 head -1)
   set -e
 
-  if [[ "$java_version" == *"1.8"* ]]; then
+  if [[ "$java_version" == *"1.8"* ]] || \
+     [[ "$java_version" == *"9.0"* ]] || \
+     [[ "$java_version" == *"10.0"* ]]; then
     echo "Java is already installed & at the right version"
     return 0;
   fi
 
-  >&2 echo "Java 8 not yet installed - please install java 8."
+  >&2 echo "Java >=8 not yet installed - please install java >=8."
   >&2 echo "  Try using brew or jenv"
   exit 1
 }


### PR DESCRIPTION
Thanks for your document. I installed halyard in my Mac.
https://www.spinnaker.io/setup/install/halyard/

That original script accepts only java8. So I fixed that and I installed latest halyard in my Mac running Java10. 
If you have no problem about compatibility, could you merge this PR?