### PR TITLE
fix(deploy/kubernetes): Allow container specific custom sizing.

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -181,7 +181,9 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     CustomSizing customSizing = details.getDeploymentConfiguration().getDeploymentEnvironment().getCustomSizing();
     TemplatedResource resources = new JinjaJarResource("/kubernetes/manifests/resources.yml");
     if (customSizing != null) {
-      Map componentSizing = customSizing.getOrDefault(getService().getServiceName(), new HashMap());
+      // Look for container specific sizing otherwise fall back to service sizing
+      Map componentSizing = customSizing.getOrDefault(name,
+          customSizing.getOrDefault(getService().getServiceName(), new HashMap()));
       resources.addBinding("requests", componentSizing.getOrDefault("requests", new HashMap()));
       resources.addBinding("limits", componentSizing.getOrDefault("limits", new HashMap()));
     }


### PR DESCRIPTION
Specifying the container name (`orca`) instead of the service
name (`spin-orca`) will enable sizing only for that container
i.e. other containers in the pod will not inherit the sizing.

Fixes spinnaker/spinnaker#3020

Doc update in https://github.com/spinnaker/spinnaker.github.io/pull/927