### PR TITLE
fix(config/account): also remove permissions from account (as well as legacy requireGroupMembership) when bootstrapifying it (fixes spinnaker/spinnaker#3074)

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
@@ -45,6 +45,7 @@ public abstract class Account extends Node implements Cloneable {
 
   // Override this method if your cloud provider account needs special settings enabled for it act as a bootstrapping account.
   public void makeBootstrappingAccount(ArtifactSourcesConfig artifactSourcesConfig) {
+    permissions.clear();
     requiredGroupMembership.clear();
   }
 

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/AccountSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/AccountSpec.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Bol.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1
+
+import com.netflix.spinnaker.fiat.model.Authorization
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account
+import spock.lang.Specification
+
+class AccountSpec extends Specification {
+
+    void "makeBootstrappingAccount clears both require groups and permissions"() {
+        setup:
+        def account = new TestAccount()
+        account.requiredGroupMembership.addAll(["foo", "bar"])
+        account.permissions.putAll([(Authorization.READ): ["foo", "bar"], (Authorization.WRITE): ["baz", "qux"]])
+
+        when:
+        account.makeBootstrappingAccount()
+
+        then:
+        account.requiredGroupMembership.isEmpty()
+        account.permissions.isEmpty()
+    }
+
+    def class TestAccount extends Account {}
+}


### PR DESCRIPTION
Halyard currently does not clear the `permissions` block config for bootstrap accounts leading clouddriver-bootstrap to check with fiat if "unknown" can deploy stuff (spoiler alert: it can't). This PR fixes that. See spinnaker/spinnaker#3074 for more details.