### PR TITLE
fix(authn/oauth) copy/paste bug in setting username in oauth user info mapping

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth2/EditOAuth2Command.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth2/EditOAuth2Command.java
@@ -150,7 +150,7 @@ public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
     userInfoMapping.setEmail(isSet(userInfoMappingEmail) ? userInfoMappingEmail : userInfoMapping.getEmail()); 
     userInfoMapping.setFirstName(isSet(userInfoMappingFirstName) ? userInfoMappingFirstName : userInfoMapping.getFirstName()); 
     userInfoMapping.setLastName(isSet(userInfoMappingLastName) ? userInfoMappingLastName : userInfoMapping.getLastName()); 
-    userInfoMapping.setUsername(isSet(userInfoMappingUsername) ? userInfoMappingLastName : userInfoMapping.getUsername()); 
+    userInfoMapping.setUsername(isSet(userInfoMappingUsername) ? userInfoMappingUsername : userInfoMapping.getUsername()); 
     
     authnMethod.setProvider(provider != null ? provider : authnMethod.getProvider());
 


### PR DESCRIPTION
Fixing a small copy/paste error on setting the username field mapping in oauth. The expected behavior is that it sets the username field as entered in the CLI but due to a bug it instead sets it to the field specified for the last-name (if set).

Here's the command for reference:
https://www.spinnaker.io/reference/halyard/commands/#hal-config-security-authn-oauth2-edit