### PR TITLE
feat(kubernetes): safely shutdown clouddriver as well

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ClouddriverService.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @Slf4j
@@ -41,6 +42,14 @@ public class KubernetesV2ClouddriverService extends ClouddriverService implement
 
   @Autowired
   KubernetesV2ClouddriverProfileFactory kubernetesV2ClouddriverProfileFactory;
+
+  @Override
+  public int terminationGracePeriodSeconds() {
+    // This is intended to be way longer than any task should take to complete.
+    // See how clouddriver holds off termination while tasks are running here:
+    // https://github.com/spinnaker/clouddriver/pull/2882
+    return (int) TimeUnit.MINUTES.toSeconds(12);
+  }
 
   protected ClouddriverProfileFactory getClouddriverProfileFactory() {
     return kubernetesV2ClouddriverProfileFactory;


### PR DESCRIPTION
This is effectively a no-op until spinnaker 1.10

Sample of logs during shutdown:

```
2018-08-17 14:27:00.530  INFO 1 --- [pool-3-thread-1] c.n.s.c.data.task.jedis.JedisTask        : [DEPLOY_KUBERNETES_MANIFEST] - Submitting manifest deployment nginx-deployment2 to kubernetes master...
2018-08-17 14:27:01.571  INFO 1 --- [       Thread-3] ationConfigEmbeddedWebApplicationContext : Closing org.springframework.boot.context.embedded.AnnotationConfigEmbeddedWebApplicationContext@3bc735b3: startup date [Fri Aug 17 14:22:07 GMT 2018]; root of context hierarchy
2018-08-17 14:27:01.606  INFO 1 --- [       Thread-3] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 2147483647
2018-08-17 14:27:01.608  INFO 1 --- [       Thread-3] o.s.c.support.DefaultLifecycleProcessor  : Stopping beans in phase 0
2018-08-17 14:27:01.612  INFO 1 --- [       Thread-3] o.s.j.e.a.AnnotationMBeanExporter        : Unregistering JMX-exposed beans on shutdown
2018-08-17 14:27:01.624  INFO 1 --- [       Thread-3] c.n.s.c.controllers.TaskController       : There are 1 task(s) still running... sleeping before shutting down
2018-08-17 14:27:01.634  INFO 1 --- [pool-3-thread-1] c.n.s.c.data.task.jedis.JedisTask        : [ORCHESTRATION] - Orchestration completed.
0 10:27:04 ~/d/s/deck [master] $ 
```