### PR TITLE
fix(canary/aws): Use correct impl for aws empty account

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/aws/account/AwsAddCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/aws/account/AwsAddCanaryAccountCommand.java
@@ -105,6 +105,6 @@ public class AwsAddCanaryAccountCommand extends AbstractAddCanaryAccountCommand 
 
   @Override
   protected AbstractCanaryAccount emptyAccount() {
-    return new GoogleCanaryAccount();
+    return new AwsCanaryAccount();
   }
 }


### PR DESCRIPTION
The method `emptyAccount` was returning a `GoogleCanaryAccount` instead of an `AwsCanaryAccount `. Fixed to return the correct implementation.