### PR TITLE
fix(deploy/ha): Move settings of profiles from super to child classes for SpringServiceSettings to fix env initialization.

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
@@ -135,7 +135,7 @@ abstract public class ClouddriverService extends SpringService<ClouddriverServic
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/EchoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/EchoService.java
@@ -97,7 +97,7 @@ abstract public class EchoService extends SpringService<EchoService.Echo> {
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/FiatService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/FiatService.java
@@ -97,7 +97,7 @@ abstract public class FiatService extends SpringService<FiatService.Fiat> {
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
@@ -121,7 +121,7 @@ abstract public class GateService extends SpringService<GateService.Gate> {
     }
 
     public Settings(ApiSecurity apiSecurity, List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
       setOverrideBaseUrl(apiSecurity.getOverrideBaseUrl());
       if (apiSecurity.getSsl().isEnabled()) {
         scheme = "https";

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/IgorService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/IgorService.java
@@ -97,7 +97,7 @@ abstract public class IgorService extends SpringService<IgorService.Igor> {
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -120,7 +120,7 @@ abstract public class OrcaService extends SpringService<OrcaService.Orca> {
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RoscoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RoscoService.java
@@ -144,7 +144,7 @@ abstract public class RoscoService extends SpringService<RoscoService.Rosco> {
     public Settings() {}
 
     public Settings(List<String> profiles) {
-      super(profiles);
+      setProfiles(profiles);
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpringServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpringServiceSettings.java
@@ -29,17 +29,13 @@ import java.util.stream.Collectors;
 abstract public class SpringServiceSettings extends ServiceSettings {
   SpringServiceSettings() {}
 
-  SpringServiceSettings(List<String> profiles) {
-    setProfiles(profiles);
-  }
-
   public void enableAuth() {
     setBasicAuthEnabled(true);
     setUsername(RandomStringUtils.random(10));
     setPassword(RandomStringUtils.random(10));
   }
 
-  private void setProfiles(List<String> profiles) {
+  protected void setProfiles(List<String> profiles) {
     if (profiles == null || profiles.isEmpty()) {
       return;
     }


### PR DESCRIPTION
Fixing an issue I introduced in my last commit.

env is always initialized by sub-classes, so the setProfiles method only works when called directly from the subclass.