### PR TITLE
fix(authz/ldap): Fix incorrect node name for ldap role provider.

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/LdapRoleProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/LdapRoleProvider.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 public class LdapRoleProvider extends RoleProvider {
   private final GroupMembership.RoleProviderType roleProviderType = GroupMembership.RoleProviderType.LDAP;
 
-  private final String nodeName = "github";
+  private final String nodeName = "ldap";
 
   URI url;
   String managerDn;


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3154