### PR TITLE
fix(cli/accounts): Allows specifying environments for accounts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3478,6 +3478,7 @@ hal config provider appengine account add ACCOUNT [parameters]
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--gcloud-release-track`: The gcloud release track (ALPHA, BETA, or STABLE) that Spinnaker will use when deploying to App Engine.
  * `--git-https-password`: (*Sensitive data* - user will be prompted on standard input) A password to be used when connecting with a remote git repository server over HTTPS.
  * `--git-https-username`: A username to be used when connecting with a remote git repository server over HTTPS.
@@ -3528,6 +3529,7 @@ hal config provider appengine account edit ACCOUNT [parameters]
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--gcloud-release-track`: The gcloud release track (ALPHA, BETA, or STABLE) that Spinnaker will use when deploying to App Engine.
  * `--git-https-password`: (*Sensitive data* - user will be prompted on standard input) A password to be used when connecting with a remote git repository server over HTTPS.
  * `--git-https-username`: A username to be used when connecting with a remote git repository server over HTTPS.
@@ -3677,6 +3679,7 @@ Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2
 
 Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See https://github.com/Netflix/edda for more information.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
@@ -3729,6 +3732,7 @@ Example: http://{{region}}.eureka.url.to.use:8080/eureka-server/v2
 
 Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See https://github.com/Netflix/edda for more information.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
@@ -3917,6 +3921,7 @@ hal config provider azure account add ACCOUNT [parameters]
  * `--default-key-vault`: (*Required*) The name of a KeyVault that contains the default user name and password used to create VMs
  * `--default-resource-group`: (*Required*) The default resource group to contain any non-application specific resources.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--object-id`: The objectId of your service principal. This is only required if using Packer to bake Windows images.
  * `--packer-resource-group`: The resource group to use if baking images with Packer.
@@ -3965,6 +3970,7 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--default-key-vault`: The name of a KeyVault that contains the default user name and password used to create VMs
  * `--default-resource-group`: The default resource group to contain any non-application specific resources.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--object-id`: The objectId of your service principal. This is only required if using Packer to bake Windows images.
  * `--packer-resource-group`: The resource group to use if baking images with Packer.
@@ -4248,6 +4254,7 @@ hal config provider dcos account add ACCOUNT [parameters]
  * `--cluster`: (*Required*) Reference to the name of the cluster from the set of clusters defined for this provider
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) (*Required*) Provide the list of docker registries to use with this DC/OS account
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: Password for a user account
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
@@ -4292,6 +4299,7 @@ hal config provider dcos account edit ACCOUNT [parameters]
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) Provide the list of docker registries to use with this DC/OS account
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
@@ -4546,6 +4554,7 @@ hal config provider docker-registry account add ACCOUNT [parameters]
  * `--client-timeout-millis`: (*Default*: `60000`) Timeout time in milliseconds for this repository.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--email`: (*Default*: `fake.email@spinnaker.io`) Your docker registry email (often this only needs to be well-formed, rather than be a real address)
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--insecure-registry`: (*Default*: `false`) Treat the docker registry as insecure (don't validate the ssl cert).
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--paginate-size`: (*Default*: `100`) Paginate size for the docker repository _catalog endpoint.
@@ -4605,6 +4614,7 @@ hal config provider docker-registry account edit ACCOUNT [parameters]
  * `--client-timeout-millis`: Timeout time in milliseconds for this repository.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--email`: Your docker registry email (often this only needs to be well-formed, rather than be a real address)
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--insecure-registry`: Treat the docker registry as insecure (don't validate the ssl cert).
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--paginate-size`: Paginate size for the docker repository _catalog endpoint.
@@ -4740,6 +4750,7 @@ hal config provider ecs account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--aws-account`: (*Required*) Provide the name of the AWS account associated with this ECS account.See https://github.com/spinnaker/clouddriver/blob/master/clouddriver-ecs/README.md for more information.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
@@ -4780,6 +4791,7 @@ hal config provider ecs account edit ACCOUNT [parameters]
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--aws-account`: Provide the name of the AWS account associated with this ECS account.See https://github.com/spinnaker/clouddriver/blob/master/clouddriver-ecs/README.md for more information.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
@@ -4908,6 +4920,7 @@ hal config provider google account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--alpha-listed`: (*Default*: `false`) Enable this flag if your project has access to alpha features and you want Spinnaker to take advantage of them.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--image-projects`: (*Default*: `[]`) A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See https://cloud.google.com/compute/docs/images/sharing-images-across-projects for more information about sharing images across GCP projects.
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See https://cloud.google.com/compute/docs/access/service-accounts for more information.
  * `--no-validate`: (*Default*: `false`) Skip validation.
@@ -4954,6 +4967,7 @@ hal config provider google account edit ACCOUNT [parameters]
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--image-projects`: A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See https://cloud.google.com/compute/docs/images/sharing-images-across-projects for more information about sharing images across GCP projects.
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See https://cloud.google.com/compute/docs/access/service-accounts for more information.
  * `--no-validate`: (*Default*: `false`) Skip validation.
@@ -5267,6 +5281,7 @@ hal config provider kubernetes account add ACCOUNT [parameters]
 When no context is configured for an account the 'current-context' in your kubeconfig is assumed.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) A list of the Spinnaker docker registry account names this Spinnaker account can use as image sources. These docker registry accounts must be registered in your halconfig before you can add them here.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--kinds`: (*Default*: `[]`) (V2 Only) A list of resource kinds this Spinnaker account can deploy to and will cache.
 When no kinds are configured, this defaults to 'all kinds described here https://spinnaker.io/reference/providers/kubernetes-v2'.
  * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
@@ -5328,6 +5343,7 @@ hal config provider kubernetes account edit ACCOUNT [parameters]
 When no context is configured for an account the 'current-context' in your kubeconfig is assumed.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) A list of the Spinnaker docker registry account names this Spinnaker account can use as image sources. These docker registry accounts must be registered in your halconfig before you can add them here.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--kinds`: (*Default*: `[]`) (V2 Only) A list of resource kinds this Spinnaker account can deploy to and will cache.
 When no kinds are configured, this defaults to 'all kinds described here https://spinnaker.io/reference/providers/kubernetes-v2'.
  * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
@@ -5488,7 +5504,7 @@ hal config provider openstack account add ACCOUNT [parameters]
  * `--consul-config`: This is the path for your consul config file
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--domain-name`: (*Required*) The domain of the cloud. Can be found in the RC file.
- * `--environment`: The name of your Openstack environment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--heat-template-location`: The location of your heat template file. (Replacing the Heat template is not recommended)
  * `--insecure`: (*Default*: `false`) Disable certificate validation on SSL connections. Needed if certificates are self signed. Default false.
  * `--lbaas-poll-interval`: Interval in seconds to poll octavia when an entity is created, updated, or deleted. Default 5.
@@ -5542,7 +5558,7 @@ hal config provider openstack account edit ACCOUNT [parameters]
  * `--consul-config`: This is the path for your consul config file
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--domain-name`: The domain of the cloud. Can be found in the RC file.
- * `--environment`: The name of your Openstack environment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--heat-template-location`: The location of your heat template file. (Replacing the Heat template is not recommended)
  * `--insecure`: Disable certificate validation on SSL connections. Needed if certificates are self signed. Default false.
  * `--lbaas-poll-interval`: Interval in seconds to poll octavia when an entity is created, updated, or deleted. Default 5.
@@ -5839,6 +5855,7 @@ hal config provider oracle account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--compartment-id`: (*Required*) Provide the OCID of the Oracle Compartment to use.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--fingerprint`: (*Required*) Fingerprint of the public key
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
@@ -5884,6 +5901,7 @@ hal config provider oracle account edit ACCOUNT [parameters]
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--compartment-id`: Provide the OCID of the Oracle Compartment to use.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--fingerprint`: Fingerprint of the public key
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
@@ -69,6 +69,13 @@ public abstract class AbstractAddAccountCommand extends AbstractHasAccountComman
   )
   private Provider.ProviderVersion providerVersion;
 
+  @Parameter(
+        names = "--environment",
+        arity = 1,
+        description = AccountCommandProperties.ENVIRONMENT_DESCRIPTION
+  )
+  private String environment;
+
   protected abstract Account buildAccount(String accountName);
 
   protected abstract Account emptyAccount();
@@ -98,6 +105,7 @@ public abstract class AbstractAddAccountCommand extends AbstractHasAccountComman
     account.getPermissions().add(Authorization.READ, readPermissions);
     account.getPermissions().add(Authorization.WRITE, writePermissions);
     account.setProviderVersion(providerVersion);
+    account.setEnvironment(isSet(environment) ? environment : account.getEnvironment());
     String providerName = getProviderName();
 
     String currentDeployment = getCurrentDeployment();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractEditAccountCommand.java
@@ -109,6 +109,13 @@ public abstract class AbstractEditAccountCommand<T extends Account> extends Abst
   )
   private Provider.ProviderVersion providerVersion;
 
+  @Parameter(
+        names = "--environment",
+        arity = 1,
+        description = AccountCommandProperties.ENVIRONMENT_DESCRIPTION
+  )
+  private String environment;
+
   protected abstract Account editAccount(T account);
 
   public String getDescription() {
@@ -157,6 +164,8 @@ public abstract class AbstractEditAccountCommand<T extends Account> extends Abst
     permissions.add(Authorization.WRITE, resolvedWritePermissions);
 
     account.setProviderVersion(isSet(providerVersion) ? providerVersion : account.getProviderVersion());
+
+    account.setEnvironment(isSet(environment) ? environment : account.getEnvironment());
 
     if (originaHash == account.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AccountCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AccountCommandProperties.java
@@ -25,4 +25,6 @@ public class AccountCommandProperties {
   public static final String READ_PERMISSION_DESCRIPTION = "A user must have at least one of these roles in order to view this account's cloud resources.";
 
   public static final String WRITE_PERMISSION_DESCRIPTION = "A user must have at least one of these roles in order to make changes to this account's cloud resources.";
+
+  public static final String ENVIRONMENT_DESCRIPTION = "The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackAddAccountCommand.java
@@ -16,11 +16,6 @@ public class OpenstackAddAccountCommand extends AbstractAddAccountCommand {
     return "openstack";
   }
 
-  @Parameter(
-      names = "--environment",
-      description = OpenstackCommandProperties.ENVIRONMENT_DESCRIPTION
-  )
-  private String environment;
 
   @Parameter(
       names = "--account-type",
@@ -126,7 +121,6 @@ public class OpenstackAddAccountCommand extends AbstractAddAccountCommand {
     account.setAuthUrl(authUrl)
         .setUsername(username)
         .setPassword(password)
-        .setEnvironment(environment)
         .setAccountType(accountType)
         .setHeatTemplateLocation(heatTemplateLocation)
         .setProjectName(projectName)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackCommandProperties.java
@@ -1,8 +1,6 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.openstack;
 
 public class OpenstackCommandProperties {
-  static final String ENVIRONMENT_DESCRIPTION = "The name of your Openstack environment.";
-
   static final String ACCOUNT_TYPE_DESCRIPTION = "The type of Openstack account.";
 
   static final String AUTH_URL_DESCRIPTION = "The auth url of your cloud, usually found in the Horizon console under Compute > Access & Security > API Access > url for Identity. Must be Keystone v3";

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackEditAccountCommand.java
@@ -17,12 +17,6 @@ public class OpenstackEditAccountCommand extends AbstractEditAccountCommand<Open
   }
 
   @Parameter(
-          names = "--environment",
-          description = OpenstackCommandProperties.ENVIRONMENT_DESCRIPTION
-  )
-  private String environment;
-
-  @Parameter(
           names = "--account-type",
           description = OpenstackCommandProperties.ACCOUNT_TYPE_DESCRIPTION
   )
@@ -120,7 +114,6 @@ public class OpenstackEditAccountCommand extends AbstractEditAccountCommand<Open
     account.setHeatTemplateLocation(isSet(heatTemplateLocation) ? heatTemplateLocation : account.getHeatTemplateLocation());
     account.setConsulConfig(isSet(consulConfig) ? consulConfig : account.getConsulConfig());
     account.setAccountType(isSet(accountType) ? accountType : account.getAccountType());
-    account.setEnvironment(isSet(environment) ? environment : account.getEnvironment());
     account.setAuthUrl(isSet(authUrl) ? authUrl : account.getAuthUrl());
     account.setUsername(isSet(username) ? username : account.getUsername());
     account.setPassword(isSet(password) ? password : account.getPassword());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
@@ -29,6 +29,7 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = false)
 public abstract class Account extends Node implements Cloneable {
   String name;
+  String environment;
   List<String> requiredGroupMembership = new ArrayList<>();
   Provider.ProviderVersion providerVersion = Provider.ProviderVersion.V1;
   Permissions.Builder permissions = new Permissions.Builder();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/openstack/OpenstackAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/openstack/OpenstackAccount.java
@@ -14,7 +14,6 @@ import java.util.List;
 @EqualsAndHashCode(callSuper = true)
 public class OpenstackAccount extends Account {
   private String accountName;
-  private String environment;
   private String accountType;
   private String authUrl;
   private String username;


### PR DESCRIPTION
The `credentials.challengeDestructiveActionsEnvironments` setting in
clouddriver controls a few features in deck. This setting is based off
the configured environment for an account. Adding environment to the
add and edit account commands allows use of halyard to take advantage of
those deck features.

Moving the environment flag up from the Openstack subclasses makes it
available to all account types.