### PR TITLE
fix(deploy): fix regex for illegal char replace

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -195,7 +195,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default String makeValidLabel(String value) {
-    value = value.replaceAll("/[^A-Za-z0-9-_.]/", "");
+    value = value.replaceAll("[^A-Za-z0-9-_.]", "");
     while (!value.isEmpty() && !characterAlphanumeric(value, 0)) {
       value = value.substring(1);
     }


### PR DESCRIPTION
the regex used in `replaceAll` in `makeValidLabel` was incorrect not
replacing chararacters. the intent was to remove all characters that are
not `A-Za-z0-9-_.` but using a leading and trailing `/` broke it. by
removing the `/`, we get the desired effect.

@lwander PTAL :)