### PR TITLE
fix(install): Halyard startup should use a login shell

### DIFF
--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -368,6 +368,6 @@ configure_defaults
 install_java
 install_halyard
 
-su -c "hal -v" -s /bin/bash $HAL_USER
+su -l -c "hal -v" -s /bin/bash $HAL_USER
 
 configure_bash_completion

--- a/install/macos/InstallHalyard.sh
+++ b/install/macos/InstallHalyard.sh
@@ -195,4 +195,4 @@ configure_defaults
 install_java
 install_halyard
 
-su $HAL_USER -c "hal -v" -s /bin/bash
+su $HAL_USER -l -c "hal -v" -s /bin/bash

--- a/startup/debian/update-halyard
+++ b/startup/debian/update-halyard
@@ -93,6 +93,6 @@ configure_defaults
 
 install_halyard
 
-su -c "hal -v" -s /bin/bash $HAL_USER
+su -l -c "hal -v" -s /bin/bash $HAL_USER
 
 configure_bash_completion

--- a/startup/macos/update-halyard
+++ b/startup/macos/update-halyard
@@ -75,4 +75,4 @@ configure_defaults
 
 install_halyard
 
-su $HAL_USER -c "hal -v" -s /bin/bash
+su $HAL_USER -l -c "hal -v" -s /bin/bash


### PR DESCRIPTION
On Ubuntu 18.04 on GCE, gcloud is installed by snap in /snap/bin. There is an entry to add /snap/bin to the path in /etc/profile.d but this only runs for login shells, so if halyard runs in a non-login shell it is unable to find gcloud. Rather than address the specific case, we should start the halyard daemon in a login shell.