### PR TITLE
feat(provider/docker): Configure passwordCommand for docker registry

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4756,6 +4756,7 @@ hal config provider docker-registry account add ACCOUNT [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--paginate-size`: (*Default*: `100`) Paginate size for the docker repository _catalog endpoint.
  * `--password`: (*Sensitive data* - user will be prompted on standard input) Your docker registry password
+ * `--password-command`: Command to retrieve docker token/password, commands must be available in environment
  * `--password-file`: The path to a file containing your docker password in plaintext (not a docker/config.json file)
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
@@ -4816,6 +4817,7 @@ hal config provider docker-registry account edit ACCOUNT [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--paginate-size`: Paginate size for the docker repository _catalog endpoint.
  * `--password`: (*Sensitive data* - user will be prompted on standard input) Your docker registry password
+ * `--password-command`: Command to retrieve docker token/password, commands must be available in environment
  * `--password-file`: The path to a file containing your docker password in plaintext (not a docker/config.json file)
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryAddAccountCommand.java
@@ -53,6 +53,12 @@ class DockerRegistryAddAccountCommand extends AbstractAddAccountCommand {
   private String password;
 
   @Parameter(
+      names = "--password-command",
+      description = DockerRegistryCommandProperties.PASSWORD_COMMAND_DESCRIPTION
+  )
+  private String passwordCommand;
+
+  @Parameter(
       names = "--password-file",
       converter = LocalFileConverter.class,
       description = DockerRegistryCommandProperties.PASSWORD_FILE_DESCRIPTION
@@ -123,6 +129,7 @@ class DockerRegistryAddAccountCommand extends AbstractAddAccountCommand {
     account.setAddress(address)
         .setRepositories(repositories)
         .setPassword(password)
+        .setPasswordCommand(passwordCommand)
         .setPasswordFile(passwordFile)
         .setUsername(username)
         .setEmail(email)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryCommandProperties.java
@@ -32,6 +32,8 @@ class DockerRegistryCommandProperties {
 
   static final String PASSWORD_DESCRIPTION = "Your docker registry password";
 
+  static final String PASSWORD_COMMAND_DESCRIPTION = "Command to retrieve docker token/password, commands must be available in environment";
+
   static final String PASSWORD_FILE_DESCRIPTION =
       "The path to a file containing your docker password in plaintext "
           + "(not a docker/config.json file)";

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryEditAccountCommand.java
@@ -64,6 +64,12 @@ public class DockerRegistryEditAccountCommand extends AbstractEditAccountCommand
   private String password;
 
   @Parameter(
+      names = "--password-command",
+      description = DockerRegistryCommandProperties.PASSWORD_COMMAND_DESCRIPTION
+  )
+  private String passwordCommand;
+
+  @Parameter(
       names = "--password-file",
       converter = LocalFileConverter.class,
       description = DockerRegistryCommandProperties.PASSWORD_FILE_DESCRIPTION
@@ -140,15 +146,22 @@ public class DockerRegistryEditAccountCommand extends AbstractEditAccountCommand
 
     boolean passwordSet = isSet(password);
     boolean passwordFileSet = isSet(passwordFile);
+    boolean passwordCommandSet = isSet(passwordCommand);
 
-    if (passwordSet && passwordFileSet) {
-      throw new IllegalArgumentException("Set either --password or --password-file");
+    if (passwordSet && passwordFileSet || passwordSet && passwordCommandSet || passwordCommandSet && passwordFileSet)  {
+      throw new IllegalArgumentException("Set either --password or --password-command or --password-file");
     } else if (passwordSet) {
       account.setPassword(password);
+      account.setPasswordCommand(null);
       account.setPasswordFile(null);
     } else if (passwordFileSet) {
       account.setPassword(null);
+      account.setPasswordCommand(null);
       account.setPasswordFile(passwordFile);
+    } else if (passwordCommandSet) {
+      account.setPassword(null);
+      account.setPasswordCommand(passwordCommand);
+      account.setPasswordFile(null);
     }
 
     account.setUsername(isSet(username) ? username : account.getUsername());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dockerRegistry/DockerRegistryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dockerRegistry/DockerRegistryAccount.java
@@ -32,6 +32,7 @@ public class DockerRegistryAccount extends Account {
   private String address;
   private String username;
   private String password;
+  private String passwordCommand;
   private String email;
   private Long cacheIntervalSeconds = 30L;
   private Long clientTimeoutMillis = 60_000L;


### PR DESCRIPTION
Adds the passwordCommand option to halyard, https://github.com/spinnaker/clouddriver/pull/2837