### PR TITLE
fix(cli): Allow --client-auth to be entered on the command line

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6432,7 +6432,7 @@ hal config security api ssl edit [parameters]
 ```
 
 #### Parameters
- * `--client-auth`: (*Sensitive data* - user will be prompted on standard input) Declare 'WANT' when client auth is wanted but not mandatory, or 'NEED', when client auth is mandatory.
+ * `--client-auth`: Declare 'WANT' when client auth is wanted but not mandatory, or 'NEED', when client auth is mandatory.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--key-alias`: Name of your keystore entry as generated with your keytool.
  * `--keystore`: Path to the keystore holding your security certificates.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/SpringSslEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/SpringSslEditCommand.java
@@ -88,7 +88,6 @@ public class SpringSslEditCommand extends AbstractConfigCommand {
 
   @Parameter(
       names = "--client-auth",
-      password = true,
       description = "Declare 'WANT' when client auth is wanted but not mandatory, "
           + "or 'NEED', when client auth is mandatory."
   )


### PR DESCRIPTION
The --client-auth parameter is incorrectly marked as a password, forcing the user to enter it at a prompt.