### PR TITLE
fix(localgit): Pass deck host as environment variable

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/git/LocalGitDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/git/LocalGitDeckService.java
@@ -68,6 +68,7 @@ public class LocalGitDeckService extends DeckService implements LocalGitService<
     }
     if (security.getAuthn().isEnabled()) {
       setEnvTrue("AUTH_ENABLED");
+      setEnv("DECK_HOST", "0.0.0.0");
     }
     if (security.getAuthz().isEnabled()) {
       setEnvTrue("FIAT_ENABLED");


### PR DESCRIPTION
Our webpack config is expecting the deck host as an environment variable.