### PR TITLE
fix(authz): allow anonymous LDAP bind

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapRoleProviderValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapRoleProviderValidator.java
@@ -29,10 +29,10 @@ public class LdapRoleProviderValidator extends Validator<LdapRoleProvider> {
     if (l.getUrl() == null) {
       p.addProblem(Severity.ERROR, "No url specified.");
     }
-    if (StringUtils.isEmpty(l.getManagerDn())) {
+    if (StringUtils.isEmpty(l.getManagerDn()) && !StringUtils.isEmpty(l.getManagerPassword())) {
       p.addProblem(Problem.Severity.ERROR, "No manager dn specified.");
     }
-    if (StringUtils.isEmpty(l.getManagerPassword())) {
+    if (StringUtils.isEmpty(l.getManagerPassword()) && !StringUtils.isEmpty(l.getManagerDn())) {
       p.addProblem(Problem.Severity.ERROR, "No manager password specified.");
     }
   }


### PR DESCRIPTION
This PR is to allow anonymous LDAP search (managerDn and manager password both empty). Fiat supports it but Halyard doesn't allow that configuration.