### PR TITLE
fix(kubernetes/health): Fix Gate health check with SSL enabled

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -87,7 +87,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default List<String> getReadinessExecCommand(ServiceSettings settings) {
-    return Arrays.asList("wget", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint());
+    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint());
   }
 
   default boolean hasPreStopCommand() {


### PR DESCRIPTION
The gate health check is currently broken when SSL is enabled. The request is to the localhost domain and does not pass in any additional trusted CA's; the request will thus fail unless gate presents a certificate for localhost issued by a root CA (which I believe will never be validly issued). As the request is within the pod to localhost, validating the certificate does not have high value, so just pass a flag to wget to skip certificate validation.