### PR TITLE
fix(igor/travis): Set artifact.decorator.enabled: true when Travis CI is enabled

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/IgorProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/IgorProfileFactory.java
@@ -45,5 +45,8 @@ public class IgorProfileFactory extends SpringProfileFactory {
     profile.appendContents(yamlToString(cis))
         .appendContents(profile.getBaseContents())
         .setRequiredFiles(files);
+    if (cis.getTravis().isEnabled()) {
+      profile.appendContents("artifact.decorator.enabled: true");
+    }
   }
 }


### PR DESCRIPTION
@gardleopard @lwander 

This is a fix for Igor finding itself in a non-starting state once Travis is enabled. The manual workaround is detailed here: https://github.com/spinnaker/spinnaker/issues/2918

Let me know if you would prefer it be fixed in another manner (hardcoding the configuration in igor.yml, for example).