### PR TITLE
Add support for Java version 11

### DIFF
--- a/install/macos/InstallHalyard.sh
+++ b/install/macos/InstallHalyard.sh
@@ -152,6 +152,7 @@ function install_java() {
   if [[ "$java_version" == *"1.8"* ]] || \
      [[ "$java_version" == *"9.0"* ]] || \
      [[ "$java_version" == *"10.0"* ]] || \
+     [[ "$java_version" == *"11"* ]] || \
      [[ "$java_version" == "java version \"10\""* ]]; then
     echo "Java is already installed & at the right version"
     return 0;


### PR DESCRIPTION
Add support for Java 11.

`p:~ bje$ java_version=$(java -version 2>&1 head -1)
p:~ bje$ echo $java_version
java version "11" 2018-09-25 Java(TM) SE Runtime Environment 18.9 (build 11+28) Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11+28, mixed mode)

p:~ bje$ hal -v
1.11.0-20181005142503`