### PR TITLE
fix(provider/oracle): add private key passphrase

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1521,6 +1521,7 @@ hal config artifact oracle account add ACCOUNT [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: An Oracle region (e.g., us-phoenix-1)
  * `--ssh-private-key-file-path`: Path to the private key in PEM format
+ * `--private-key-passphrase`: Passphrase used for the private key, if it is encrypted.
  * `--tenancy-id`: Provide the OCID of the Oracle Tenancy to use.
  * `--user-id`: Provide the OCID of the Oracle User you're authenticating as
 
@@ -1559,6 +1560,7 @@ hal config artifact oracle account edit ACCOUNT [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: An Oracle region (e.g., us-phoenix-1)
  * `--ssh-private-key-file-path`: Path to the private key in PEM format
+ * `--private-key-passphrase`: Passphrase used for the private key, if it is encrypted.
  * `--tenancy-id`: Provide the OCID of the Oracle Tenancy to use.
  * `--user-id`: Provide the OCID of the Oracle User you're authenticating as
 
@@ -6231,6 +6233,7 @@ hal config provider oracle account add ACCOUNT [parameters]
  * `--region`: (*Required*) An Oracle region (e.g., us-phoenix-1)
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--ssh-private-key-file-path`: (*Required*) Path to the private key in PEM format
+ * `--private-key-passphrase`: Passphrase used for the private key, if it is encrypted.
  * `--tenancyId`: (*Required*) Provide the OCID of the Oracle Tenancy to use.
  * `--user-id`: (*Required*) Provide the OCID of the Oracle User you're authenticating as
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -6280,6 +6283,7 @@ hal config provider oracle account edit ACCOUNT [parameters]
  * `--remove-write-permission`: Remove this permission to from list of write permissions.
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--ssh-private-key-file-path`: Path to the private key in PEM format
+ * `--private-key-passphrase`: Passphrase used for the private key, if it is encrypted.
  * `--tenancyId`: Provide the OCID of the Oracle Tenancy to use.
  * `--user-id`: Provide the OCID of the Oracle User you're authenticating as
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -7633,6 +7637,7 @@ hal config storage oracle edit [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: An Oracle region (e.g., us-phoenix-1)
  * `--ssh-private-key-file-path`: Path to the private key in PEM format
+ * `--private-key-passphrase`: Passphrase used for the private key, if it is encrypted.
  * `--tenancy-id`: Provide the OCID of the Oracle Tenancy to use.
  * `--user-id`: Provide the OCID of the Oracle User you're authenticating as
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/oracle/OracleAddArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/oracle/OracleAddArtifactAccountCommand.java
@@ -39,6 +39,13 @@ public class OracleAddArtifactAccountCommand extends AbstractAddArtifactAccountC
   private String sshPrivateKeyFilePath;
 
   @Parameter(
+          names = "--private-key-passphrase",
+          description = OracleCommandProperties.PRIVATE_KEY_PASSPHRASE_DESCRIPTION,
+          password = true
+  )
+  private String privateKeyPassphrase;
+
+  @Parameter(
           names = "--tenancy-id",
           description = OracleCommandProperties.TENANCY_ID_DESCRIPTION
   )
@@ -63,6 +70,7 @@ public class OracleAddArtifactAccountCommand extends AbstractAddArtifactAccountC
     account.setUserId(userId);
     account.setFingerprint(fingerprint);
     account.setSshPrivateKeyFilePath(sshPrivateKeyFilePath);
+    account.setPrivateKeyPassphrase(privateKeyPassphrase);
     account.setTenancyId(tenancyId);
     account.setRegion(region);
     account.setNamespace(namespace);

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/oracle/OracleEditArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/oracle/OracleEditArtifactAccountCommand.java
@@ -39,6 +39,13 @@ public class OracleEditArtifactAccountCommand extends AbstractArtifactEditAccoun
   private String sshPrivateKeyFilePath;
 
   @Parameter(
+          names = "--private-key-passphrase",
+          description = OracleCommandProperties.PRIVATE_KEY_PASSPHRASE_DESCRIPTION,
+          password = true
+  )
+  private String privateKeyPassphrase;
+
+  @Parameter(
           names = "--tenancy-id",
           description = OracleCommandProperties.TENANCY_ID_DESCRIPTION
   )
@@ -61,6 +68,7 @@ public class OracleEditArtifactAccountCommand extends AbstractArtifactEditAccoun
     account.setUserId(isSet(userId) ? userId : account.getUserId());
     account.setFingerprint(isSet(fingerprint) ? fingerprint : account.getFingerprint());
     account.setSshPrivateKeyFilePath(isSet(sshPrivateKeyFilePath) ? sshPrivateKeyFilePath : account.getSshPrivateKeyFilePath());
+    account.setPrivateKeyPassphrase(isSet(privateKeyPassphrase) ? privateKeyPassphrase : account.getPrivateKeyPassphrase());
     account.setTenancyId(isSet(tenancyId) ? tenancyId : account.getTenancyId());
     account.setRegion(isSet(region) ? region : account.getRegion());
     account.setNamespace(isSet(namespace) ? namespace : account.getNamespace());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/oracle/OracleEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/oracle/OracleEditCommand.java
@@ -49,6 +49,13 @@ public class OracleEditCommand extends AbstractPersistentStoreEditCommand<Oracle
   private String sshPrivateKeyFilePath;
 
   @Parameter(
+          names = "--private-key-passphrase",
+          description = OracleCommandProperties.PRIVATE_KEY_PASSPHRASE_DESCRIPTION,
+          password = true
+  )
+  private String privateKeyPassphrase;
+
+  @Parameter(
           names = "--tenancy-id",
           description = OracleCommandProperties.TENANCY_ID_DESCRIPTION
   )
@@ -78,6 +85,7 @@ public class OracleEditCommand extends AbstractPersistentStoreEditCommand<Oracle
     persistentStore.setUserId(isSet(userId) ? userId : persistentStore.getUserId());
     persistentStore.setFingerprint(isSet(fingerprint) ? fingerprint : persistentStore.getFingerprint());
     persistentStore.setSshPrivateKeyFilePath(isSet(sshPrivateKeyFilePath) ? sshPrivateKeyFilePath : persistentStore.getSshPrivateKeyFilePath());
+    persistentStore.setPrivateKeyPassphrase(isSet(privateKeyPassphrase) ? privateKeyPassphrase : persistentStore.getPrivateKeyPassphrase());
     persistentStore.setTenancyId(isSet(tenancyId) ? tenancyId : persistentStore.getTenancyId());
     persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());
     persistentStore.setBucketName(isSet(bucketName) ? bucketName : persistentStore.getBucketName());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oracle/OracleAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oracle/OracleAddAccountCommand.java
@@ -53,6 +53,13 @@ public class OracleAddAccountCommand extends AbstractAddAccountCommand {
   private String sshPrivateKeyFilePath;
 
   @Parameter(
+          names = "--private-key-passphrase",
+          description = OracleCommandProperties.PRIVATE_KEY_PASSPHRASE_DESCRIPTION,
+          password = true
+  )
+  private String privateKeyPassphrase;
+
+  @Parameter(
           names = "--tenancyId",
           description = OracleCommandProperties.TENANCY_ID_DESCRIPTION,
           required = true
@@ -74,6 +81,7 @@ public class OracleAddAccountCommand extends AbstractAddAccountCommand {
     account.setUserId(userId);
     account.setFingerprint(fingerprint);
     account.setSshPrivateKeyFilePath(sshPrivateKeyFilePath);
+    account.setPrivateKeyPassphrase(privateKeyPassphrase);
     account.setTenancyId(tenancyId);
     account.setRegion(region);
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oracle/OracleCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oracle/OracleCommandProperties.java
@@ -14,6 +14,7 @@ public class OracleCommandProperties {
   public static final String USER_ID_DESCRIPTION = "Provide the OCID of the Oracle User you're authenticating as";
   public static final String FINGERPRINT_DESCRIPTION = "Fingerprint of the public key";
   public static final String SSH_PRIVATE_KEY_FILE_PATH_DESCRIPTION = "Path to the private key in PEM format";
+  public static final String PRIVATE_KEY_PASSPHRASE_DESCRIPTION = "Passphrase used for the private key, if it is encrypted";
   public static final String TENANCY_ID_DESCRIPTION = "Provide the OCID of the Oracle Tenancy to use.";
   public static final String REGION_DESCRIPTION = "An Oracle region (e.g., us-phoenix-1)";
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oracle/OracleEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/oracle/OracleEditAccountCommand.java
@@ -49,6 +49,13 @@ public class OracleEditAccountCommand extends AbstractEditAccountCommand<OracleA
   private String sshPrivateKeyFilePath;
 
   @Parameter(
+          names = "--private-key-passphrase",
+          description = OracleCommandProperties.PRIVATE_KEY_PASSPHRASE_DESCRIPTION,
+          password = true
+  )
+  private String privateKeyPassphrase;
+
+  @Parameter(
           names = "--tenancyId",
           description = OracleCommandProperties.TENANCY_ID_DESCRIPTION
   )
@@ -66,6 +73,7 @@ public class OracleEditAccountCommand extends AbstractEditAccountCommand<OracleA
     account.setUserId(isSet(userId) ? userId : account.getUserId());
     account.setFingerprint(isSet(fingerprint) ? fingerprint : account.getFingerprint());
     account.setSshPrivateKeyFilePath(isSet(sshPrivateKeyFilePath) ? sshPrivateKeyFilePath : account.getSshPrivateKeyFilePath());
+    account.setPrivateKeyPassphrase(isSet(privateKeyPassphrase) ? privateKeyPassphrase : account.getPrivateKeyPassphrase());
     account.setTenancyId(isSet(tenancyId) ? tenancyId : account.getTenancyId());
     account.setRegion(isSet(region) ? region : account.getRegion());
     return account;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/oracle/OracleArtifactAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/oracle/OracleArtifactAccount.java
@@ -25,5 +25,6 @@ public class OracleArtifactAccount extends ArtifactAccount {
   private String fingerprint;
   @LocalFile
   private String sshPrivateKeyFilePath;
+  private String privateKeyPassphrase;
   private String tenancyId;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/OraclePersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/OraclePersistentStore.java
@@ -50,6 +50,8 @@ public class OraclePersistentStore extends PersistentStore {
   @Size(min = 1)
   private String sshPrivateKeyFilePath;
 
+  private String privateKeyPassphrase;
+
   @NotNull
   @Size(min = 1)
   private String tenancyId;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/oracle/OracleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/oracle/OracleAccount.java
@@ -23,6 +23,7 @@ public class OracleAccount extends Account {
   private String userId;
   private String fingerprint;
   @LocalFile private String sshPrivateKeyFilePath;
+  private String privateKeyPassphrase;
   private String tenancyId;
   private String region;
 


### PR DESCRIPTION
Allow Allow oracle provider/bakery/artifact/storage to use private key file with passphrase.
Related PRs are https://github.com/spinnaker/clouddriver/pull/3043, https://github.com/spinnaker/rosco/pull/294, and https://github.com/spinnaker/front50/pull/379.