### PR TITLE
feat(halyard): Halyard configures filters on monitoring-daemons.

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerMonitoringDaemonService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerMonitoringDaemonService.java
@@ -41,6 +41,7 @@ import java.util.*;
 abstract public class SpinnakerMonitoringDaemonService extends SpinnakerService<SpinnakerMonitoringDaemonService.SpinnakerMonitoringDaemon> implements SidecarService {
   protected final String CONFIG_OUTPUT_PATH = "/opt/spinnaker-monitoring/config/";
   protected final String REGISTRY_OUTPUT_PATH = "/opt/spinnaker-monitoring/registry/";
+  protected final String FILTERS_OUTPUT_PATH = "/opt/spinnaker-monitoring/filters/";
 
   @Autowired
   SpinnakerMonitoringDaemonProfileFactory spinnakerMonitoringDaemonProfileFactory;
@@ -130,6 +131,9 @@ abstract public class SpinnakerMonitoringDaemonService extends SpinnakerService<
 
   @Override
   protected Optional<String> customProfileOutputPath(String profileName) {
+    if ("monitoring-daemon/filters/default.yml".equalsIgnoreCase(profileName)) {
+      return Optional.of(Paths.get(FILTERS_OUTPUT_PATH ,"default.yml").toString());
+    }
     return Optional.empty();
   }
 }


### PR DESCRIPTION
Halyard will look for ~/.hal/default/profiles/monitoring-daemon/filters/default.yml, and if it exists will mount it stage it. 

This PR will be followed by lwander mapping that staged copy onto all monitoring-daemons.