### PR TITLE
feat(deploy): specify custom sidecars for k8s v2

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -101,7 +102,7 @@ public class DeploymentEnvironment extends Node {
   private Vault vault = new Vault();
   private String location;
   private CustomSizing customSizing = new CustomSizing();
-  private Map<String, SidecarConfig> sidecars = new HashMap<>();
+  private Map<String, List<SidecarConfig>> sidecars = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
   @ValidForSpinnakerVersion(lowerBound = "1.10.0", message = "High availability services are not available prior to this release.")
   private HaServices haServices = new HaServices();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -27,6 +27,7 @@ import java.util.Map;
 
 @Data
 public class SidecarConfig {
+  String name = "custom-sidecar";
   String dockerImage;
   Map<String, String> env = new HashMap<>();
   List<String> args = new ArrayList<>();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConfigSource.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConfigSource.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public class ConfigSource {
   String id;
   String mountPath;
+  boolean empty = false;
   Map<String, String> env = new HashMap<>();
 }
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
@@ -5,6 +5,22 @@
 
   "ports": [{{ port }}],
 
+  {% if command != null %}
+  "command": [
+    {% for c in command %}
+    {{ c }} {% if not loop.last %} , {% endif %}
+    {% endfor %}
+  ],
+  {% endif %}
+
+  {% if args != null %}
+  "args": [
+    {% for arg in args %}
+    {{ arg }} {% if not loop.last %} , {% endif %}
+    {% endfor %}
+  ],
+  {% endif %}
+
   "readinessProbe": {{ probe }},
 
   "volumeMounts": [


### PR DESCRIPTION
Sample config for a clouddriver sidecar:
```yaml
...
deploymentEnvironment:
  spin-clouddriver:
  - name: creds
    env:
      one: two
    command:
      - custom
    args:
      - build
      - credentials
    mountPath: /home/spinnaker/.aws
    dockerImage: busybox
  - name: dns
    dockerImage: busybox
...
```

@ethanfrogers fyi