### PR TITLE
fix(run): Pass argument escaping through startup script

### DIFF
--- a/startup/debian/hal
+++ b/startup/debian/hal
@@ -63,4 +63,4 @@ else
     fi
 fi
 
-$HAL $@
+$HAL "$@"

--- a/startup/macos/hal
+++ b/startup/macos/hal
@@ -63,4 +63,4 @@ else
     fi
 fi
 
-$HAL $@
+$HAL "$@"


### PR DESCRIPTION
The startup script is breaking apart arguments with spaces in them. Spaces in arguments become important when configuring docker-registry with a `--password-command`. The lack of argument escaping was causing errors as actual hal tried to parse the password-command arguments as its own.

Brief explanation of the specific shell syntax: https://stackoverflow.com/a/905910