### PR TITLE
feat(backup): allow long filenames

### DIFF
--- a/halyard-backup/src/main/java/com/netflix/spinnaker/halyard/backup/services/v1/BackupService.java
+++ b/halyard-backup/src/main/java/com/netflix/spinnaker/halyard/backup/services/v1/BackupService.java
@@ -137,6 +137,7 @@ public class BackupService {
       tarOutput = new FileOutputStream(new File(halconfigTar));
       bufferedTarOutput = new BufferedOutputStream(tarOutput);
       tarArchiveOutputStream = new TarArchiveOutputStream(bufferedTarOutput);
+      tarArchiveOutputStream.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
       TarArchiveOutputStream finalTarArchiveOutputStream = tarArchiveOutputStream;
       Arrays.stream(new File(halconfigDir).listFiles())
           .filter(Objects::nonNull)


### PR DESCRIPTION
I was getting errors like
```
java.lang.RuntimeException: file name '....' is too long ( > 100 bytes)
```

Looking at the docs, http://commons.apache.org/proper/commons-compress/tar.html#Long_File_Names 
>LONGFILE_POSIX: use a PAX extended header as defined by POSIX 1003.1. Most modern tar implementations are able to extract such archives. since Commons Compress 1.4

`hal backup restore` works fine with long filenames without a problem.