### PR TITLE
feat(provider/kubernetes) support for setting checkPermissionsOnStartup

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5643,6 +5643,8 @@ hal config provider kubernetes account add ACCOUNT [parameters]
 
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
+ * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
+during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.
  * `--configure-image-pull-secrets`: (*Default*: `true`) (Only applicable to the v1 provider). When true, Spinnaker will create & manage your image pull secrets for you; when false, you will have to create and attach them to your pod specs by hand.
  * `--context`: The kubernetes context to be managed by Spinnaker. See http://kubernetes.io/docs/user-guide/kubeconfig-file/#context for more information.
 When no context is configured for an account the 'current-context' in your kubeconfig is assumed.
@@ -5706,6 +5708,8 @@ hal config provider kubernetes account edit ACCOUNT [parameters]
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--all-kinds`: (*Default*: `false`) Set the list of kinds to cache and deploy to every kind available to your supplied credentials.
  * `--all-namespaces`: (*Default*: `false`) Set the list of namespaces to cache and deploy to every namespace available to your supplied credentials.
+ * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
+during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.
  * `--clear-context`: (*Default*: `false`) Removes the currently configured context, defaulting to 'current-context' in your kubeconfig.See http://kubernetes.io/docs/user-guide/kubeconfig-file/#context for more information.
  * `--configure-image-pull-secrets`: (Only applicable to the v1 provider). When true, Spinnaker will create & manage your image pull secrets for you; when false, you will have to create and attach them to your pod specs by hand.
  * `--context`: The kubernetes context to be managed by Spinnaker. See http://kubernetes.io/docs/user-guide/kubeconfig-file/#context for more information.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -127,6 +127,13 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
   )
   public Boolean onlySpinnakerManaged = false;
 
+  @Parameter(
+        names = "--check-permissions-on-startup",
+        arity = 1,
+        description = KubernetesCommandProperties.CHECK_PERMISSIONS_ON_STARTUP
+  )
+  public Boolean checkPermissionsOnStartup;
+
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -144,6 +151,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setNamingStrategy(namingStrategy);
     account.setSkin(skin);
     account.setOnlySpinnakerManaged(onlySpinnakerManaged);
+    account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     return account;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -47,4 +47,7 @@ public class KubernetesCommandProperties {
 
   static final String ONLY_SPINNAKER_MANAGED_DESCRIPTION = "(V2 Only) When true, Spinnaker will only cache/display applications that have been\n"
       + "created by Spinnaker; as opposed to attempting to configure applications for resources already present in Kubernetes.";
+
+  static final String CHECK_PERMISSIONS_ON_STARTUP = "When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time\n"
+      + "during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -220,6 +220,13 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
   )
   public Boolean onlySpinnakerManaged;
 
+  @Parameter(
+        names = "--check-permissions-on-startup",
+        arity = 1,
+        description = KubernetesCommandProperties.CHECK_PERMISSIONS_ON_STARTUP
+  )
+  public Boolean checkPermissionsOnStartup;
+
   @Override
   protected Account editAccount(KubernetesAccount account) {
     boolean contextSet = context != null && !context.isEmpty();
@@ -288,7 +295,7 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
     account.setNamingStrategy(isSet(namingStrategy) ? namingStrategy : account.getNamingStrategy());
     account.setSkin(isSet(skin) ? skin : account.getSkin());
     account.setOnlySpinnakerManaged(isSet(onlySpinnakerManaged) ? onlySpinnakerManaged : account.getOnlySpinnakerManaged());
-    
+    account.setCheckPermissionsOnStartup(isSet(checkPermissionsOnStartup) ? checkPermissionsOnStartup : Boolean.TRUE);
     return account;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -66,6 +66,7 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
   String kubeconfigContents;
   String kubectlPath;
   Integer kubectlRequestTimeoutSeconds;
+  Boolean checkPermissionsOnStartup;
 
   // Without the annotations, these are written as `oauthServiceAccount` and `oauthScopes`, respectively.
   @JsonProperty("oAuthServiceAccount") @LocalFile String oAuthServiceAccount;


### PR DESCRIPTION
With several kube clusters configured, clouddriver can take several
extra minutes to start up as it does the permissions checks. Multiply
that by several instances of clouddriver and rollouts start to get
unwieldy. This allows the startup permission scan to be disabled and
save lots of time.