### PR TITLE
feat(artifacts/s3): add aws keypair support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1681,6 +1681,8 @@ hal config artifact s3 account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--api-endpoint`: S3 api endpoint
  * `--api-region`: S3 api region
+ * `--aws-access-key-id`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * `--aws-secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: S3 region
@@ -1716,6 +1718,8 @@ hal config artifact s3 account edit ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--api-endpoint`: S3 api endpoint
  * `--api-region`: S3 api region
+ * `--aws-access-key-id`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+ * `--aws-secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--region`: S3 region

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/s3/S3AddArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/s3/S3AddArtifactAccountCommand.java
@@ -21,6 +21,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.s3;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.account.AbstractAddArtifactAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws.AwsCommandProperties;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.s3.S3ArtifactAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
@@ -42,13 +43,26 @@ public class S3AddArtifactAccountCommand extends AbstractAddArtifactAccountComma
       description = "S3 region"
   )
   private String region;
+  @Parameter(
+      names = "--aws-access-key-id",
+      description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
+  )
+  private String awsAccessKeyId;
+  @Parameter(
+      names = "--aws-secret-access-key",
+      description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
+      password = true
+  )
+  private String awsSecretAccessKey;
 
   @Override
   protected ArtifactAccount buildArtifactAccount(String accountName) {
     S3ArtifactAccount artifactAccount = new S3ArtifactAccount().setName(accountName);
     artifactAccount.setApiEndpoint(apiEndpoint)
         .setApiRegion(apiRegion)
-        .setRegion(region);
+        .setRegion(region)
+        .setAwsAccessKeyId(awsAccessKeyId)
+        .setAwsSecretAccessKey(awsSecretAccessKey);
     return artifactAccount;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/s3/S3EditArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/s3/S3EditArtifactAccountCommand.java
@@ -21,9 +21,11 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.s3;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.account.AbstractArtifactEditAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws.AwsCommandProperties;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.s3.S3ArtifactAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
+import org.springframework.data.repository.query.Param;
 
 @Parameters(separators = "=")
 public class S3EditArtifactAccountCommand extends AbstractArtifactEditAccountCommand<S3ArtifactAccount> {
@@ -42,13 +44,25 @@ public class S3EditArtifactAccountCommand extends AbstractArtifactEditAccountCom
       description = "S3 region"
   )
   private String region;
-
+  @Parameter(
+      names = "--aws-access-key-id",
+      description = AwsCommandProperties.ACCESS_KEY_ID_DESCRIPTION
+  )
+  private String awsAccessKeyId;
+  @Parameter(
+      names = "--aws-secret-access-key",
+      description = AwsCommandProperties.SECRET_KEY_DESCRIPTION,
+      password = true
+  )
+  private String awsSecretAccessKey;
 
   @Override
   protected ArtifactAccount editArtifactAccount(S3ArtifactAccount account) {
     account.setApiEndpoint(isSet(apiEndpoint) ? apiEndpoint : account.getApiEndpoint());
     account.setApiRegion(isSet(apiRegion) ? apiRegion : account.getApiRegion());
     account.setRegion(isSet(region) ? region : account.getRegion());
+    account.setAwsAccessKeyId(isSet(awsAccessKeyId) ? awsAccessKeyId : account.getAwsAccessKeyId());
+    account.setAwsSecretAccessKey(isSet(awsSecretAccessKey) ? awsSecretAccessKey : account.getAwsSecretAccessKey());
     return account;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/s3/S3ArtifactAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/s3/S3ArtifactAccount.java
@@ -25,4 +25,6 @@ public class S3ArtifactAccount extends ArtifactAccount {
     public String apiEndpoint;
     public String apiRegion;
     public String region;
+    public String awsAccessKeyId;
+    public String awsSecretAccessKey;
 }


### PR DESCRIPTION
adds options for setting the awsAccessKeyId and awsSecretAccessKey

Depends on spinnaker/clouddriver#3083