### PR TITLE
feat(halyard): Add support for deprecating flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ out/
 .settings/
 .classpath
 .project
+.DS_Store

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -104,7 +104,7 @@ public class DeploymentEnvironment extends Node {
   private CustomSizing customSizing = new CustomSizing();
   private Map<String, List<SidecarConfig>> sidecars = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
-  @ValidForSpinnakerVersion(lowerBound = "1.10.0", message = "High availability services are not available prior to this release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.10.0", tooLowMessage = "High availability services are not available prior to this release.")
   private HaServices haServices = new HaServices();
 
   public Boolean getUpdateVersions() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -43,19 +43,24 @@ public class Features extends Node {
   private boolean chaos;
   private boolean entityTags;
   private boolean jobs;
-  @ValidForSpinnakerVersion(lowerBound = "1.2.0", message = "Pipeline templates are not stable prior to this release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.2.0", tooLowMessage = "Pipeline templates are not stable prior to this release.")
   private Boolean pipelineTemplates;
-  @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Artifacts are not configurable prior to this release. Will be stable at a later release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.5.0", tooLowMessage = "Artifacts are not configurable prior to this release. Will be stable at a later release.")
   private Boolean artifacts;
-  @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Canary is not configurable prior to this release. Will be stable at a later release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.5.0", tooLowMessage = "Canary is not configurable prior to this release. Will be stable at a later release.")
   private Boolean mineCanary;
-  @ValidForSpinnakerVersion(lowerBound = "1.7.0", message = "Appengine container URL deployments were not supported prior to this release.")
+  @ValidForSpinnakerVersion(
+          lowerBound = "1.7.0",
+          upperBound = "1.11.0",
+          tooLowMessage = "Appengine container URL deployments were not supported prior to this version.",
+          tooHighMessage = "Appengine container URL deployments are stable; the feature flag will be removed in a future version of Halyard."
+  )
   private Boolean appengineContainerImageUrlDeployments;
-  @ValidForSpinnakerVersion(lowerBound = "1.7.0", message = "Infrastructure Stages is not configurable prior to this release. Will be stable at a later release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.7.0", tooLowMessage = "Infrastructure Stages is not configurable prior to this release. Will be stable at a later release.")
   private Boolean infrastructureStages;
-  @ValidForSpinnakerVersion(lowerBound = "1.9.0", message = "Travis stage is not available prior to this release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.9.0", tooLowMessage = "Travis stage is not available prior to this release.")
   private Boolean travis;
-  @ValidForSpinnakerVersion(lowerBound = "1.9.0", message = "Wercker stage is not available prior to this release.")
+  @ValidForSpinnakerVersion(lowerBound = "1.9.0", tooLowMessage = "Wercker stage is not available prior to this release.")
   private Boolean wercker;
 
   public boolean isAuth(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Notification.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Notification.java
@@ -26,7 +26,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public abstract class Notification extends Node implements Cloneable {
-  @ValidForSpinnakerVersion(lowerBound = "1.4.0", message = "Spinnaker's base configuration is missing components required to enable notifications with Halyard.")
+  @ValidForSpinnakerVersion(lowerBound = "1.4.0", tooLowMessage = "Spinnaker's base configuration is missing components required to enable notifications with Halyard.")
   boolean enabled;
 
   @JsonIgnore

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/ValidForSpinnakerVersion.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/ValidForSpinnakerVersion.java
@@ -28,5 +28,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface ValidForSpinnakerVersion {
   String lowerBound();
-  String message();
+  String upperBound() default "";
+  String tooLowMessage();
+  String tooHighMessage() default "";
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/appengine/AppengineAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/appengine/AppengineAccount.java
@@ -35,7 +35,7 @@ public class AppengineAccount extends CommonGoogleAccount {
   private boolean sshTrustUnknownHosts;
   @ValidForSpinnakerVersion(
       lowerBound = "1.6.0",
-      message = "The gcloud release track that Spinnaker will use when deploying to App Engine"
+      tooLowMessage = "The gcloud release track that Spinnaker will use when deploying to App Engine"
                 + " is not configurable prior to this release."
   )
   private GcloudReleaseTrack gcloudReleaseTrack;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -47,19 +47,19 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
   String context;
   String cluster;
   String user;
-  @ValidForSpinnakerVersion(lowerBound = "1.5.0", message = "Spinnaker does not support configuring this behavior before that version.")
+  @ValidForSpinnakerVersion(lowerBound = "1.5.0", tooLowMessage = "Spinnaker does not support configuring this behavior before that version.")
   Boolean configureImagePullSecrets;
   Boolean serviceAccount;
   int cacheThreads = 1;
   List<String> namespaces = new ArrayList<>();
   List<String> omitNamespaces = new ArrayList<>();
-  @ValidForSpinnakerVersion(lowerBound = "1.7.0", message = "Configuring kind caching behavior is not supported yet.")
+  @ValidForSpinnakerVersion(lowerBound = "1.7.0", tooLowMessage = "Configuring kind caching behavior is not supported yet.")
   List<String> kinds = new ArrayList<>();
-  @ValidForSpinnakerVersion(lowerBound = "1.7.0", message = "Configuring kind caching behavior is not supported yet.")
+  @ValidForSpinnakerVersion(lowerBound = "1.7.0", tooLowMessage = "Configuring kind caching behavior is not supported yet.")
   List<String> omitKinds = new ArrayList<>();
-  @ValidForSpinnakerVersion(lowerBound = "1.6.0", message = "Custom kinds and resources are not supported yet.")
+  @ValidForSpinnakerVersion(lowerBound = "1.6.0", tooLowMessage = "Custom kinds and resources are not supported yet.")
   List<CustomKubernetesResource> customResources = new ArrayList<>();
-  @ValidForSpinnakerVersion(lowerBound = "1.8.0", message = "Caching policies are not supported yet.")
+  @ValidForSpinnakerVersion(lowerBound = "1.8.0", tooLowMessage = "Caching policies are not supported yet.")
   List<KubernetesCachingPolicy> cachingPolicies = new ArrayList<>();
 
   @LocalFile String kubeconfigFile;

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
@@ -160,4 +160,8 @@ public class Versions {
   public static boolean lessThan(String v1, String v2) {
     return orderBySemVer().compare(v1, v2) < 0;
   }
+
+  public static boolean greaterThanEqual(String v1, String v2) {
+    return orderBySemVer().compare(v1, v2) >= 0;
+  }
 }


### PR DESCRIPTION
Twin of https://github.com/spinnaker/deck/pull/5894

Appengine Container URL deploys will now always be available in deck.