### PR TITLE
feat(deploy/kubernetes): support custom init containers

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -103,6 +103,7 @@ public class DeploymentEnvironment extends Node {
   private String location;
   private CustomSizing customSizing = new CustomSizing();
   private Map<String, List<SidecarConfig>> sidecars = new HashMap<>();
+  private Map<String, List<Map>> initContainers = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
   @ValidForSpinnakerVersion(lowerBound = "1.10.0", tooLowMessage = "High availability services are not available prior to this release.")
   private HaServices haServices = new HaServices();

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
@@ -5,6 +5,14 @@
     {% endfor %}
   ],
 
+  {% if initContainers != null %}
+  "initContainers": [
+    {% for c in initContainers %}
+    {{ c }} {% if not loop.last %} , {% endif %}
+    {% endfor %}
+  ],
+  {% endif %}
+
   "terminationGracePeriodSeconds": {{ terminationGracePeriodSeconds }},
 
   "volumes": [


### PR DESCRIPTION
Containers are specified in exactly the k8s container model:

```yaml
...
deploymentEnvironment:
  initContainers:
    spin-clouddriver:
    - name: init-me
      image: busybox
      volumeMounts:
      - mountPath: /config
        name: config
```

https://github.com/spinnaker/halyard/pull/1080