### PR TITLE
feat(deploy/kubernetes): custom sidecars configmaps

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -32,11 +32,18 @@ public class SidecarConfig {
   Map<String, String> env = new HashMap<>();
   List<String> args = new ArrayList<>();
   List<String> command = new ArrayList<>();
+  List<ConfigMapVolumeMount> configMapVolumeMounts = new ArrayList<>();
   String mountPath;
   SecurityContext securityContext;
 
   @Data
   public static class SecurityContext {
     boolean privileged = false;
+  }
+
+  @Data
+  public static class ConfigMapVolumeMount {
+    String configMapName;
+    String mountPath;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConfigSource.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConfigSource.java
@@ -26,7 +26,11 @@ import java.util.Map;
 public class ConfigSource {
   String id;
   String mountPath;
-  boolean empty = false;
+  Type type = Type.secret;
   Map<String, String> env = new HashMap<>();
+
+  public enum Type {
+    emptyDir, configMap, secret
+  }
 }
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/configMapVolume.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/configMapVolume.yml
@@ -1,0 +1,6 @@
+{
+  "name": "{{ name }}",
+  "configMap": {
+    "name": "{{ name }}"
+  }
+}


### PR DESCRIPTION
```yaml
...
deploymentEnvironment:
  sidecars:  
    spin-clouddriver:
    - name: creds
      env:
        one: two
      command:
      - custom
      args:
      - build
      - credentials
      mountPath: /home/spinnaker/.aws
      dockerImage: busybox
      configMapVolumeMounts:
      - configMapName: demo
        mountPath: /path/to/config
```

#1080 