### PR TITLE
Add aws cli to container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,10 @@ RUN curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.c
 
 ENV PATH "$PATH:/usr/local/bin/heptio-authenticator-aws"
 
+RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
+    python /tmp/get-pip.py && \
+    pip install awscli --upgrade
+
 RUN useradd -m spinnaker
 
 USER spinnaker


### PR DESCRIPTION
Per discussion in spinnaker/spinnaker#2394, adding awscli to container
such that the features added in spinnaker/spinnaker#2941 to enable
an external passwordCommand for a docker registry can be utilized by
AWS users wishing to add their ECR-based docker registries.

Signed-off-by: Joe Hohertz <joe@viafoura.com>