### PR TITLE
fix(kubernetes/v2): Adds imagePullSecrets to podSpec.yml for V2 Kubernetes deployments

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -255,6 +255,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         .addBinding("containers", containers)
         .addBinding("initContainers", initContainers)
         .addBinding("hostAliases", hostAliases)
+        .addBinding("imagePullSecrets", settings.getKubernetes().getImagePullSecrets())
         .addBinding("terminationGracePeriodSeconds", terminationGracePeriodSeconds())
         .addBinding("volumes", volumes);
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
@@ -5,6 +5,14 @@
     {% endfor %}
   ],
 
+  {% if imagePullSecrets != null %}
+  "imagePullSecrets": [
+    {% for secret in imagePullSecrets %}
+    "name": "{{ secret }}" {% if not loop.last %} , {% endif %}
+    {% endfor %}
+  ],
+  {% endif %}
+
   {% if initContainers != null %}
   "initContainers": [
     {% for c in initContainers %}


### PR DESCRIPTION
Ran into this recently when trying to deploy to an EKS cluster using manifest-based deployments. 