### PR TITLE
fix(eks): Use latest aws authenticator 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM openjdk:8
 MAINTAINER delivery-engineering@netflix.com
 
 ENV KUBECTL_RELEASE=1.10.3
-ENV HEPTIO_BINARY_RELEASE_DATE=2018-06-05
+ENV AWS_BINARY_RELEASE_DATE=2018-07-26
 
 COPY . workdir/
 
@@ -23,11 +23,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 
-RUN curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_RELEASE}/${HEPTIO_BINARY_RELEASE_DATE}/bin/linux/amd64/heptio-authenticator-aws && \
-  chmod +x ./heptio-authenticator-aws && \
-  mv ./heptio-authenticator-aws /usr/local/bin/heptio-authenticator-aws
+RUN curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_RELEASE}/${AWS_BINARY_RELEASE_DATE}/bin/linux/amd64/aws-iam-authenticator && \
+  chmod +x ./aws-iam-authenticator && \
+  mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
 
-ENV PATH "$PATH:/usr/local/bin/heptio-authenticator-aws"
+ENV PATH "$PATH:/usr/local/bin/aws-iam-authenticator"
 
 RUN wget -O /tmp/get-pip.py https://bootstrap.pypa.io/get-pip.py && \
     python /tmp/get-pip.py && \

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -3,7 +3,7 @@ FROM openjdk:8
 MAINTAINER delivery-engineering@netflix.com
 
 ENV KUBECTL_RELEASE=1.10.3
-ENV HEPTIO_BINARY_RELEASE_DATE=2018-06-05
+ENV AWS_BINARY_RELEASE_DATE=2018-07-26
 
 COPY . workdir/
 
@@ -22,11 +22,11 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 
-RUN curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_RELEASE}/${HEPTIO_BINARY_RELEASE_DATE}/bin/linux/amd64/heptio-authenticator-aws && \
-  chmod +x ./heptio-authenticator-aws && \
-  mv ./heptio-authenticator-aws /usr/local/bin/heptio-authenticator-aws
+RUN curl -o heptio-authenticator-aws https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_RELEASE}/${AWS_BINARY_RELEASE_DATE}/bin/linux/amd64/aws-iam-authenticator && \
+  chmod +x ./aws-iam-authenticator && \
+  mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
 
-ENV PATH "$PATH:/usr/local/bin/heptio-authenticator-aws"
+ENV PATH "$PATH:/usr/local/bin/aws-iam-authenticator"
 
 RUN useradd -m spinnaker
 


### PR DESCRIPTION
- Use latest version of the aws authenticator
- Use aws-iam-authenticator instead of deprecated heptio-authenticator-aws
See - https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html
Signed-off-by: S.Cavallo <smcavallo@hotmail.com>