### PR TITLE
feat(deploy/kubernetes): custom sidecars secret volume mounts

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SidecarConfig.java
@@ -29,10 +29,12 @@ import java.util.Map;
 public class SidecarConfig {
   String name = "custom-sidecar";
   String dockerImage;
+  Integer port;
   Map<String, String> env = new HashMap<>();
   List<String> args = new ArrayList<>();
   List<String> command = new ArrayList<>();
   List<ConfigMapVolumeMount> configMapVolumeMounts = new ArrayList<>();
+  List<SecretVolumeMount> secretVolumeMounts = new ArrayList<>();
   String mountPath;
   SecurityContext securityContext;
 
@@ -44,6 +46,11 @@ public class SidecarConfig {
   @Data
   public static class ConfigMapVolumeMount {
     String configMapName;
+    String mountPath;
+  }
+  @Data
+  public static class SecretVolumeMount {
+    String secretName;
     String mountPath;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -228,6 +228,17 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         .map(this::getVolumeYaml)
         .collect(Collectors.toList()));
 
+    volumes.addAll(sidecarConfigs.stream()
+        .map(SidecarConfig::getSecretVolumeMounts)
+        .flatMap(Collection::stream)
+        .map(c -> new ConfigSource()
+                .setMountPath(c.getMountPath())
+                .setId(c.getSecretName())
+                .setType(ConfigSource.Type.secret)
+        )
+        .map(this::getVolumeYaml)
+        .collect(Collectors.toList()));
+
     env.putAll(settings.getEnv());
 
     Integer targetSize = settings.getTargetSize();
@@ -310,6 +321,16 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         })
         .collect(Collectors.toList()));
 
+    volumeMounts.addAll(config.getSecretVolumeMounts()
+        .stream()
+        .map( c -> {
+          TemplatedResource volume = new JinjaJarResource("/kubernetes/manifests/volumeMount.yml");
+          volume.addBinding("name", c.getSecretName());
+          volume.addBinding("mountPath", c.getMountPath());
+          return volume.toString();
+        })
+        .collect(Collectors.toList()));
+
     TemplatedResource container = new JinjaJarResource("/kubernetes/manifests/container.yml");
     if (config.getSecurityContext() != null) {
       TemplatedResource securityContext = new JinjaJarResource("/kubernetes/manifests/securityContext.yml");
@@ -317,9 +338,16 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
       container.addBinding("securityContext", securityContext.toString());
     }
 
+    if (config.getPort() != null) {
+      TemplatedResource containerPort = new JinjaJarResource("/kubernetes/manifests/port.yml");
+      containerPort.addBinding("port", config.getPort());
+      container.addBinding("port", containerPort.toString());
+    } else {
+      container.addBinding("port", null);
+    }
+
     container.addBinding("name", config.getName());
     container.addBinding("imageId", config.getDockerImage());
-    container.addBinding("port", null);
     container.addBinding("command", config.getCommand());
     container.addBinding("args", config.getArgs());
     container.addBinding("volumeMounts", volumeMounts);

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Bol.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
@@ -1,0 +1,96 @@
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration
+import com.netflix.spinnaker.halyard.config.model.v1.node.SidecarConfig
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails
+import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings
+import spock.lang.Specification
+
+class KubernetesV2ServiceTest extends Specification {
+
+    private KubernetesV2Service testService
+    private AccountDeploymentDetails details
+
+    def setup() {
+        testService = new KubernetesV2OrcaService() {
+            @Override
+            String getSpinnakerStagingPath(String deploymentName) {
+                return "/dummy/value"
+            }
+
+            @Override
+            ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
+                return Mock(ServiceSettings)
+            }
+
+            @Override
+            int hashCode() {
+                return 42
+            }
+        }
+        testService.serviceDelegate = Mock(KubernetesV2ServiceDelegate)
+        GenerateService.ResolvedConfiguration config = Mock(GenerateService.ResolvedConfiguration)
+        config.runtimeSettings = Mock(SpinnakerRuntimeSettings)
+        details = new AccountDeploymentDetails()
+    }
+    def "Can we submit an empty port?"() {
+        setup:
+        SidecarConfig car = new SidecarConfig()
+        car.setName("cloudsql-proxy")
+        car.setMountPath("/cloudsql")
+
+        when:
+        String customSidecar = testService.buildCustomSidecar(car)
+
+        then:
+        customSidecar.contains('"ports": [],')
+    }
+
+    def "Does a port get converted to a containerPort?"() {
+        setup:
+        SidecarConfig car = new SidecarConfig()
+        car.setName("cloudsql-proxy")
+        car.setMountPath("/cloudsql")
+        car.setPort(8080)
+        when:
+        String customSidecar = testService.buildCustomSidecar(car)
+
+        then:
+        customSidecar.contains('"ports": [{ "containerPort": 8080 }]')
+    }
+
+    def "Do SecretVolumeMounts end up being valid mountPaths?"() {
+        setup:
+        SidecarConfig car = new SidecarConfig()
+        car.setName("cloudsql-proxy")
+        car.setDockerImage("gcr.io/cloudsql-docker/gce-proxy:1.13")
+        car.setCommand(["/cloud_sql_proxy"])
+        car.setArgs([
+                "--dir=/cloudsql",
+                "-instances=instance-name:gcp-region:database-name=tcp:3306",
+                "-credential_file=/secrets/cloudsql/credentials-cloudsql-instance.json",
+        ])
+        car.setMountPath("/cloudsql")
+
+        SidecarConfig.SecretVolumeMount secret1 = new SidecarConfig.SecretVolumeMount()
+        secret1.mountPath = "/secrets/cloudsql"
+        secret1.secretName = "credentials-cloudsql-instance"
+
+        SidecarConfig.SecretVolumeMount secret2 = new SidecarConfig.SecretVolumeMount()
+        secret2.mountPath = "/var/run/secrets/kubernetes.io/serviceaccount"
+        secret2.secretName = "default-token-8pndx"
+
+        car.setSecretVolumeMounts([secret1, secret2])
+        details.deploymentConfiguration = new DeploymentConfiguration()
+        details.deploymentConfiguration.deploymentEnvironment.sidecars.put("spin-orca", [car])
+
+        when:
+        String customSidecar = testService.buildCustomSidecar(car)
+
+        then:
+        customSidecar.contains('"mountPath": "/secrets/cloudsql"')
+        customSidecar.contains('"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount"')
+    }
+}


### PR DESCRIPTION
Allows deployment of (for instance) `cloudsql-proxy` sidecars, which are useful when dealing with Google CloudSQL (when you're running `orca-sql` for instance)

Tested & working sample config for a `spin-orca` sidecar:

```
  deploymentEnvironment:
    sidecars:
      spin-orca:
      - name: cloudsql-proxy
        port: 3306
        dockerImage: gcr.io/cloudsql-docker/gce-proxy:1.13
        command:
          - "'/cloud_sql_proxy'"
          - "'--dir=/cloudsql'"
          - "'-instances=project-name:gcp-region:cloudsql-instance=tcp:3306'"
          - "'-credential_file=/secrets/cloudsql/credentials-cloudsql-instance.json'"
        mountPath: /cloudsql
        secretVolumeMounts:
          - mountPath: /secrets/cloudsql
            secretName: cloudsql-instance-credentials
          - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
            secretName: default-token-8pndx
```

#1080