### PR TITLE
feat(deploy/kubernetes): custom volume mnt per svc

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -30,5 +30,5 @@ import java.util.Map;
 public class KubernetesSettings {
   List<String> imagePullSecrets = new ArrayList<>();
   Map<String, String> podAnnotations = new HashMap<>();
-
+  List<ConfigSource> volumes = new ArrayList<>();
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -217,6 +217,13 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         .map(this::getVolumeYaml)
         .collect(Collectors.toList());
 
+    volumes.addAll(settings.getKubernetes().getVolumes().stream()
+        .collect(Collectors.toMap(ConfigSource::getId, (i) -> i, (a, b) -> a))
+        .values()
+        .stream()
+        .map(this::getVolumeYaml)
+        .collect(Collectors.toList()));
+
     volumes.addAll(sidecarConfigs.stream()
         .map(SidecarConfig::getConfigMapVolumeMounts)
         .flatMap(Collection::stream)
@@ -339,6 +346,14 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
           volume.addBinding("mountPath", c.getMountPath());
           return volume.toString();
         }).collect(Collectors.toList());
+
+    volumeMounts.addAll(settings.getKubernetes().getVolumes().stream()
+      .map(c -> {
+        TemplatedResource volume = new JinjaJarResource("/kubernetes/manifests/volumeMount.yml");
+        volume.addBinding("name", c.getId());
+        volume.addBinding("mountPath", c.getMountPath());
+        return volume.toString();
+      }).collect(Collectors.toList()));
 
     TemplatedResource probe;
     if (StringUtils.isNotEmpty(settings.getHealthEndpoint())) {


### PR DESCRIPTION
add custom `ConfigMap` or `Secret` volume mounts at the service level.
This allows you to mount extra config or secrets as needed.