### PR TITLE
feat(webhooks): Allow config of custom trust store

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -101,6 +101,8 @@ public class DeploymentConfiguration extends Node {
 
   Canary canary = new Canary();
 
+  Webhook webhook;
+
   @Override
   public String getNodeName() {
     return name;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -101,7 +101,7 @@ public class DeploymentConfiguration extends Node {
 
   Canary canary = new Canary();
 
-  Webhook webhook;
+  Webhook webhook = new Webhook();
 
   @Override
   public String getNodeName() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Webhook.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Webhook.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.node;
+
+import com.netflix.spinnaker.halyard.config.model.v1.webook.WebhookTrust;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class Webhook extends Node {
+  private final String nodeName = "webhook";
+
+  WebhookTrust trust;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Webhook.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Webhook.java
@@ -25,5 +25,5 @@ import lombok.EqualsAndHashCode;
 public class Webhook extends Node {
   private final String nodeName = "webhook";
 
-  WebhookTrust trust;
+  WebhookTrust trust = new WebhookTrust();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webook/WebhookTrust.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webook/WebhookTrust.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.webook;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class WebhookTrust extends Node {
+  private final String nodeName = "trust";
+
+  @LocalFile
+  String trustStore;
+  String trustStorePassword;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webook/WebhookTrust.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/webook/WebhookTrust.java
@@ -26,6 +26,7 @@ import lombok.EqualsAndHashCode;
 public class WebhookTrust extends Node {
   private final String nodeName = "trust";
 
+  boolean enabled;
   @LocalFile
   String trustStore;
   String trustStorePassword;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -17,10 +17,15 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Component
 public class OrcaProfileFactory extends SpringProfileFactory {
@@ -32,6 +37,7 @@ public class OrcaProfileFactory extends SpringProfileFactory {
   @Override
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
+
     profile.appendContents(profile.getBaseContents());
 
     AwsProvider awsProvider = deploymentConfiguration.getProviders().getAws();
@@ -41,9 +47,22 @@ public class OrcaProfileFactory extends SpringProfileFactory {
       profile.appendContents("default.vpc.securityGroups: ");
     }
 
+    Webhook webhook = deploymentConfiguration.getWebhook();
+    if (webhook != null) {
+      List<String> files = backupRequiredFiles(webhook, deploymentConfiguration.getName());
+      profile.setRequiredFiles(files);
+      profile.appendContents(yamlToString(new WebhookWrapper(webhook)));
+    }
+
     String pipelineTemplates = Boolean.toString(deploymentConfiguration.getFeatures().getPipelineTemplates() != null ? deploymentConfiguration.getFeatures().getPipelineTemplates() : false);
     profile.appendContents("pipelineTemplates.enabled: " + pipelineTemplates);
     // For backward compatibility
     profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
+  }
+
+  @Data
+  @RequiredArgsConstructor
+  private static class WebhookWrapper {
+    private final Webhook webhook;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -48,11 +48,9 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     }
 
     Webhook webhook = deploymentConfiguration.getWebhook();
-    if (webhook != null) {
-      List<String> files = backupRequiredFiles(webhook, deploymentConfiguration.getName());
-      profile.setRequiredFiles(files);
-      profile.appendContents(yamlToString(new WebhookWrapper(webhook)));
-    }
+    List<String> files = backupRequiredFiles(webhook, deploymentConfiguration.getName());
+    profile.setRequiredFiles(files);
+    profile.appendContents(yamlToString(new WebhookWrapper(webhook)));
 
     String pipelineTemplates = Boolean.toString(deploymentConfiguration.getFeatures().getPipelineTemplates() != null ? deploymentConfiguration.getFeatures().getPipelineTemplates() : false);
     profile.appendContents("pipelineTemplates.enabled: " + pipelineTemplates);


### PR DESCRIPTION
This PR add the ability for Halyard to parse the webhook.trust configuration paramters and write them
to orca.yml (including the ability to back up the local trust store file).

Updates to add 'hal' commands to configure this will be in a later PR.