### PR TITLE
Add nodeSelector in .hal/config file kubernetes v1

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -97,6 +97,7 @@ public class DeploymentEnvironment extends Node {
   private Map<String, List<SidecarConfig>> sidecars = new HashMap<>();
   private Map<String, List<Map>> initContainers = new HashMap<>();
   private Map<String, List<Map>> hostAliases = new HashMap<>();
+  private Map<String, String> nodeSelectors = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
   @ValidForSpinnakerVersion(lowerBound = "1.10.0", tooLowMessage = "High availability services are not available prior to this release.")
   private HaServices haServices = new HaServices();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -335,7 +335,6 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
     DeploymentEnvironment deploymentEnvironment = details
         .getDeploymentConfiguration()
         .getDeploymentEnvironment();
-
     String accountName = details.getAccount().getName();
     String namespace = getNamespace(settings);
     String name = getServiceName();
@@ -361,6 +360,7 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
 
     description.setVolumeSources(volumeSources);
     description.setPodAnnotations(settings.getKubernetes().getPodAnnotations());
+    description.setNodeSelector(deploymentEnvironment.getNodeSelectors());
 
     List<String> loadBalancers = new ArrayList<>();
     loadBalancers.add(name);


### PR DESCRIPTION
Config will now allow nodeSelectors to be added to the deployed spinnaker nodes. (Tested in kubernetes v1)

```
  deploymentEnvironment:
    ...
    nodeSelectors:
       service_type: api

```