### PR TITLE
 refactor(controller): Refactor common logic in controller GET handling

### DIFF
--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
@@ -25,20 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.core.DaemonOptions;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -60,40 +56,28 @@ public class AccountController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonTask<Halconfig, List<Account>> accounts(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, List<Account>> accounts(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<Account>> builder = new StaticRequestBuilder<>(
-        () -> accountService.getAllAccounts(deploymentName, providerName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> accountService.validateAllAccounts(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all " + providerName + " accounts");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Account>>builder()
+        .getter(() -> accountService.getAllAccounts(deploymentName, providerName))
+        .validator(() -> accountService.validateAllAccounts(deploymentName, providerName))
+        .description("Get all " + providerName + " accounts")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/account/{accountName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Account> account(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Account> account(@PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Account> builder = new StaticRequestBuilder<>(
-        () -> accountService.getProviderAccount(deploymentName, providerName, accountName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> accountService.validateAccount(deploymentName, providerName, accountName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + accountName + " account");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Account>builder()
+        .getter(() -> accountService.getProviderAccount(deploymentName, providerName, accountName))
+        .validator(() -> accountService.validateAccount(deploymentName, providerName, accountName))
+        .description("Get " + accountName + " account")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/options", method = RequestMethod.POST)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/AccountController.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,8 +63,8 @@ public class AccountController {
   DaemonTask<Halconfig, List<Account>> accounts(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<Account>> builder = new StaticRequestBuilder<>(
         () -> accountService.getAllAccounts(deploymentName, providerName));
     builder.setSeverity(severity);
@@ -81,8 +82,8 @@ public class AccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Account> builder = new StaticRequestBuilder<>(
         () -> accountService.getProviderAccount(deploymentName, providerName, accountName));
     builder.setSeverity(severity);
@@ -99,7 +100,7 @@ public class AccountController {
   DaemonTask<Halconfig, List<String>> newAccountOptions(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody DaemonOptions rawAccountOptions) {
     String fieldName = rawAccountOptions.getField();
     Account account = objectMapper.convertValue(
@@ -122,7 +123,7 @@ public class AccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody DaemonOptions rawAccountOptions) {
     String fieldName = rawAccountOptions.getField();
     DaemonResponse.StaticOptionsRequestBuilder builder = new DaemonResponse.StaticOptionsRequestBuilder();
@@ -139,8 +140,8 @@ public class AccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
     builder
@@ -166,8 +167,8 @@ public class AccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawAccount) {
     Account account = objectMapper.convertValue(
         rawAccount,
@@ -200,8 +201,8 @@ public class AccountController {
   DaemonTask<Halconfig, Void> addAccount(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawAccount) {
     Account account = objectMapper.convertValue(
         rawAccount,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactAccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactAccountController.java
@@ -32,6 +32,8 @@ import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import java.nio.file.Path;
+
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,8 +64,8 @@ public class ArtifactAccountController {
   DaemonTask<Halconfig, List<ArtifactAccount>> accounts(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<ArtifactAccount>> builder = new StaticRequestBuilder<>(
             () -> accountService.getAllArtifactAccounts(deploymentName, providerName));
     builder.setSeverity(severity);
@@ -80,8 +82,8 @@ public class ArtifactAccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<ArtifactAccount> builder = new StaticRequestBuilder<>(
             () -> accountService.getArtifactProviderArtifactAccount(deploymentName, providerName, accountName));
     builder.setSeverity(severity);
@@ -98,8 +100,8 @@ public class ArtifactAccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
     builder.setUpdate(() -> accountService.deleteArtifactAccount(deploymentName, providerName, accountName));
@@ -124,8 +126,8 @@ public class ArtifactAccountController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawArtifactAccount) {
     ArtifactAccount account = objectMapper.convertValue(
         rawArtifactAccount,
@@ -156,8 +158,8 @@ public class ArtifactAccountController {
   DaemonTask<Halconfig, Void> addArtifactAccount(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawArtifactAccount) {
     ArtifactAccount account = objectMapper.convertValue(
         rawArtifactAccount,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactAccountController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactAccountController.java
@@ -25,23 +25,18 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Artifacts;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.ArtifactAccountService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
-import java.nio.file.Path;
-
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -61,38 +56,28 @@ public class ArtifactAccountController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonTask<Halconfig, List<ArtifactAccount>> accounts(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, List<ArtifactAccount>> accounts(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<ArtifactAccount>> builder = new StaticRequestBuilder<>(
-            () -> accountService.getAllArtifactAccounts(deploymentName, providerName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> accountService.validateAllArtifactAccounts(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all " + providerName + " artifact accounts");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<ArtifactAccount>>builder()
+        .getter(() -> accountService.getAllArtifactAccounts(deploymentName, providerName))
+        .validator(() -> accountService.validateAllArtifactAccounts(deploymentName, providerName))
+        .description("Get all " + providerName + " artifact accounts")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/account/{accountName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, ArtifactAccount> account(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, ArtifactAccount> account(@PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<ArtifactAccount> builder = new StaticRequestBuilder<>(
-            () -> accountService.getArtifactProviderArtifactAccount(deploymentName, providerName, accountName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> accountService.validateArtifactAccount(deploymentName, providerName, accountName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + accountName + " artifact account");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<ArtifactAccount>builder()
+        .getter(() -> accountService.getArtifactProviderArtifactAccount(deploymentName, providerName, accountName))
+        .validator(() -> accountService.validateArtifactAccount(deploymentName, providerName, accountName))
+        .description("Get " + accountName + " artifact account")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/account/{accountName:.+}", method = RequestMethod.DELETE)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactProviderController.java
@@ -25,20 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Artifacts;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.ArtifactProviderService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -61,22 +57,15 @@ public class ArtifactProviderController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/{providerName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, ArtifactProvider> get(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, ArtifactProvider> get(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<ArtifactProvider> builder = new StaticRequestBuilder<>(
-        () -> providerService.getArtifactProvider(deploymentName, providerName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> providerService.validateArtifactProvider(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get the " + providerName + " provider");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<ArtifactProvider>builder()
+        .getter(() -> providerService.getArtifactProvider(deploymentName, providerName))
+        .validator(() -> providerService.validateArtifactProvider(deploymentName, providerName))
+        .description("Get the " + providerName + " provider")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{providerName:.+}", method = RequestMethod.PUT)
@@ -137,18 +126,12 @@ public class ArtifactProviderController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<ArtifactProvider>> providers(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<ArtifactProvider>> builder = new StaticRequestBuilder<>(
-        () -> providerService.getAllArtifactProviders(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder
-          .setValidateResponse(() -> providerService.validateAllArtifactProviders(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all providers");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<ArtifactProvider>>builder()
+        .getter(() -> providerService.getAllArtifactProviders(deploymentName))
+        .validator(() -> providerService.validateAllArtifactProviders(deploymentName))
+        .description("Get all providers")
+        .build()
+        .execute(validationSettings);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ArtifactProviderController.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,8 +64,8 @@ public class ArtifactProviderController {
   DaemonTask<Halconfig, ArtifactProvider> get(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<ArtifactProvider> builder = new StaticRequestBuilder<>(
         () -> providerService.getArtifactProvider(deploymentName, providerName));
 
@@ -82,8 +83,8 @@ public class ArtifactProviderController {
   DaemonTask<Halconfig, Void> setArtifactProvider(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawArtifactProvider) {
     ArtifactProvider provider = objectMapper.convertValue(
         rawArtifactProvider,
@@ -114,8 +115,8 @@ public class ArtifactProviderController {
   DaemonTask<Halconfig, Void> setEnabled(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -136,8 +137,8 @@ public class ArtifactProviderController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<ArtifactProvider>> providers(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<ArtifactProvider>> builder = new StaticRequestBuilder<>(
         () -> providerService.getAllArtifactProviders(deploymentName));
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
@@ -25,21 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.BaseImage;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.config.services.v1.BakeryService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -64,18 +59,13 @@ public class BakeryController {
   @RequestMapping(value = "/defaults/", method = RequestMethod.GET)
   DaemonTask<Halconfig, BakeryDefaults> getBakeryDefaults(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<BakeryDefaults> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> bakeryService.getBakeryDefaults(deploymentName, providerName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> bakeryService.validateBakeryDefaults(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + providerName + " bakery defaults");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<BakeryDefaults>builder()
+        .getter(() -> bakeryService.getBakeryDefaults(deploymentName, providerName))
+        .validator(() -> bakeryService.validateBakeryDefaults(deploymentName, providerName))
+        .description("Get " + providerName + " bakery defaults")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/defaults/", method = RequestMethod.PUT)
@@ -115,37 +105,26 @@ public class BakeryController {
   @RequestMapping(value = "/defaults/baseImage/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<BaseImage>> images(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<BaseImage>> builder = new StaticRequestBuilder<>(
-        () -> bakeryService.getAllBaseImages(deploymentName, providerName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> bakeryService.validateAllBaseImages(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + providerName + " base images");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<BaseImage>>builder()
+        .getter(() -> bakeryService.getAllBaseImages(deploymentName, providerName))
+        .validator(() -> bakeryService.validateAllBaseImages(deploymentName, providerName))
+        .description("Get " + providerName + " base images")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/defaults/baseImage/{baseImageId:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, BaseImage> baseImage(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, BaseImage> baseImage(@PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String baseImageId,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<BaseImage> builder = new StaticRequestBuilder<>(
-        () -> bakeryService.getProviderBaseImage(deploymentName, providerName, baseImageId));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> bakeryService.validateBaseImage(deploymentName, providerName, baseImageId));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + baseImageId + " base image");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<BaseImage>builder()
+        .getter(() -> bakeryService.getProviderBaseImage(deploymentName, providerName, baseImageId))
+        .validator(() -> bakeryService.validateBaseImage(deploymentName, providerName, baseImageId))
+        .description("Get \" + baseImageId + \" base image")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/defaults/baseImage/{baseImageId:.+}", method = RequestMethod.DELETE)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
@@ -122,7 +122,7 @@ public class BakeryController {
     return GenericGetRequest.<BaseImage>builder()
         .getter(() -> bakeryService.getProviderBaseImage(deploymentName, providerName, baseImageId))
         .validator(() -> bakeryService.validateBaseImage(deploymentName, providerName, baseImageId))
-        .description("Get \" + baseImageId + \" base image")
+        .description("Get " + baseImageId + " base image")
         .build()
         .execute(validationSettings);
   }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/BakeryController.java
@@ -32,6 +32,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,8 +64,8 @@ public class BakeryController {
   @RequestMapping(value = "/defaults/", method = RequestMethod.GET)
   DaemonTask<Halconfig, BakeryDefaults> getBakeryDefaults(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<BakeryDefaults> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> bakeryService.getBakeryDefaults(deploymentName, providerName));
     builder.setSeverity(severity);
@@ -80,8 +81,8 @@ public class BakeryController {
   @RequestMapping(value = "/defaults/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setBakeryDefaults(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawBakeryDefaults) {
     BakeryDefaults bakeryDefaults = objectMapper.convertValue(
         rawBakeryDefaults,
@@ -114,8 +115,8 @@ public class BakeryController {
   @RequestMapping(value = "/defaults/baseImage/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<BaseImage>> images(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<BaseImage>> builder = new StaticRequestBuilder<>(
         () -> bakeryService.getAllBaseImages(deploymentName, providerName));
     builder.setSeverity(severity);
@@ -133,8 +134,8 @@ public class BakeryController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String baseImageId,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<BaseImage> builder = new StaticRequestBuilder<>(
         () -> bakeryService.getProviderBaseImage(deploymentName, providerName, baseImageId));
     builder.setSeverity(severity);
@@ -152,8 +153,8 @@ public class BakeryController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String baseImageId,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
     builder
@@ -179,8 +180,8 @@ public class BakeryController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String baseImageId,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawBaseImage) {
     BaseImage baseImage = objectMapper.convertValue(
         rawBaseImage,
@@ -213,8 +214,8 @@ public class BakeryController {
   DaemonTask<Halconfig, Void> addBaseImage(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawBaseImage) {
     BaseImage baseImage = objectMapper.convertValue(
         rawBaseImage,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CanaryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CanaryController.java
@@ -24,20 +24,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.CanaryAccountService;
 import com.netflix.spinnaker.halyard.config.services.v1.CanaryService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.function.Supplier;
@@ -63,18 +59,13 @@ public class CanaryController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Canary> getCanary(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Canary> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> canaryService.getCanary(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> canaryService.validateCanary(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all canary settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Canary>builder()
+        .getter(() -> canaryService.getCanary(deploymentName))
+        .validator(() -> canaryService.validateCanary(deploymentName))
+        .description("Get all canary settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
@@ -127,21 +118,16 @@ public class CanaryController {
   }
 
   @RequestMapping(value = "/{serviceIntegrationName:.+}/accounts/account/{accountName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, AbstractCanaryAccount> getCanaryAccount(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, AbstractCanaryAccount> getCanaryAccount(@PathVariable String deploymentName,
       @PathVariable String serviceIntegrationName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<AbstractCanaryAccount> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> canaryAccountService.getCanaryAccount(deploymentName, serviceIntegrationName, accountName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> canaryService.validateCanary(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + accountName + " canary account");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<AbstractCanaryAccount>builder()
+        .getter(() -> canaryAccountService.getCanaryAccount(deploymentName, serviceIntegrationName, accountName))
+        .validator(() -> canaryService.validateCanary(deploymentName))
+        .description("Get " + accountName + " canary account")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{serviceIntegrationName:.+}/accounts/account/{accountName:.+}", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CanaryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CanaryController.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,8 +63,8 @@ public class CanaryController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Canary> getCanary(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<Canary> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> canaryService.getCanary(deploymentName));
 
@@ -78,8 +79,8 @@ public class CanaryController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setCanary(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawCanary) {
     Canary canary = objectMapper.convertValue(rawCanary, Canary.class);
 
@@ -105,8 +106,8 @@ public class CanaryController {
 
   @RequestMapping(value = "/enabled/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setEnabled(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -130,8 +131,8 @@ public class CanaryController {
       @PathVariable String deploymentName,
       @PathVariable String serviceIntegrationName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<AbstractCanaryAccount> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> canaryAccountService.getCanaryAccount(deploymentName, serviceIntegrationName, accountName));
     builder.setSeverity(severity);
@@ -148,8 +149,8 @@ public class CanaryController {
       @PathVariable String deploymentName,
       @PathVariable String serviceIntegrationName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawCanaryAccount) {
     AbstractCanaryAccount canaryAccount = objectMapper.convertValue(
         rawCanaryAccount,
@@ -181,8 +182,8 @@ public class CanaryController {
   DaemonTask<Halconfig, Void> addCanaryAccount(
       @PathVariable String deploymentName,
       @PathVariable String serviceIntegrationName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawCanaryAccount) {
     AbstractCanaryAccount canaryAccount = objectMapper.convertValue(
         rawCanaryAccount,
@@ -215,8 +216,8 @@ public class CanaryController {
       @PathVariable String deploymentName,
       @PathVariable String serviceIntegrationName,
       @PathVariable String accountName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
     builder.setUpdate(() -> canaryAccountService.deleteAccount(deploymentName, serviceIntegrationName, accountName));

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CiController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CiController.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -51,8 +52,8 @@ public class CiController {
   DaemonTask<Halconfig, Ci> ci(
       @PathVariable String deploymentName,
       @PathVariable String ciName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Ci> builder = new StaticRequestBuilder<>(() -> ciService.getCi(deploymentName, ciName));
     builder.setSeverity(severity);
 
@@ -67,8 +68,8 @@ public class CiController {
   DaemonTask<Halconfig, Void> setEnabled(
       @PathVariable String deploymentName,
       @PathVariable String ciName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -89,8 +90,8 @@ public class CiController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Ci>> cis(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<Ci>> builder = new StaticRequestBuilder<>(() -> ciService.getAllCis(deploymentName));
     builder.setSeverity(severity);
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CiController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/CiController.java
@@ -21,20 +21,16 @@ import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.CiService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -49,19 +45,15 @@ public class CiController {
   CiService ciService;
 
   @RequestMapping(value = "/{ciName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Ci> ci(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Ci> ci(@PathVariable String deploymentName,
       @PathVariable String ciName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Ci> builder = new StaticRequestBuilder<>(() -> ciService.getCi(deploymentName, ciName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> ciService.validateCi(deploymentName, ciName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + ciName + " ci");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Ci>builder()
+        .getter(() -> ciService.getCi(deploymentName, ciName))
+        .validator(() -> ciService.validateCi(deploymentName, ciName))
+        .description("Get " + ciName + " ci")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{ciName:.+}/enabled", method = RequestMethod.PUT)
@@ -90,15 +82,12 @@ public class CiController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Ci>> cis(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<Ci>> builder = new StaticRequestBuilder<>(() -> ciService.getAllCis(deploymentName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> ciService.validateAllCis(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all Continuous Integration services");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Ci>>builder()
+        .getter(() -> ciService.getAllCis(deploymentName))
+        .validator(() -> ciService.validateAllCis(deploymentName))
+        .description("Get all Continuous Integration services")
+        .build()
+        .execute(validationSettings);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ClusterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ClusterController.java
@@ -24,7 +24,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Cluster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.config.services.v1.ClusterService;
-import com.netflix.spinnaker.halyard.controllers.v1.DefaultControllerValues;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
@@ -59,8 +59,8 @@ public class ClusterController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Cluster>> clusters(@PathVariable String deploymentName, @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
     DaemonResponse.StaticRequestBuilder<List<Cluster>> builder = new DaemonResponse.StaticRequestBuilder<>(
             () -> clusterService.getAllClusters(deploymentName, providerName));
     builder.setSeverity(severity);
@@ -77,8 +77,8 @@ public class ClusterController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String clusterName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
     DaemonResponse.StaticRequestBuilder<Cluster> builder = new DaemonResponse.StaticRequestBuilder<>(
             () -> clusterService.getProviderCluster(deploymentName, providerName, clusterName));
     builder.setSeverity(severity);
@@ -95,8 +95,8 @@ public class ClusterController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String clusterName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
     DaemonResponse.UpdateRequestBuilder builder = new DaemonResponse.UpdateRequestBuilder();
 
     builder.setUpdate(() -> clusterService.deleteCluster(deploymentName, providerName, clusterName));
@@ -119,8 +119,8 @@ public class ClusterController {
       @PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String clusterName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity,
       @RequestBody Object rawCluster) {
     Cluster cluster = objectMapper.convertValue(
         rawCluster,
@@ -148,8 +148,8 @@ public class ClusterController {
   DaemonTask<Halconfig, Void> addCluster(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity,
       @RequestBody Object rawCluster) {
     Cluster cluster = objectMapper.convertValue(
         rawCluster,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ClusterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ClusterController.java
@@ -24,20 +24,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Cluster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.config.services.v1.ClusterService;
-import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
-
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.function.Supplier;
@@ -58,36 +54,28 @@ public class ClusterController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonTask<Halconfig, List<Cluster>> clusters(@PathVariable String deploymentName, @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
-    DaemonResponse.StaticRequestBuilder<List<Cluster>> builder = new DaemonResponse.StaticRequestBuilder<>(
-            () -> clusterService.getAllClusters(deploymentName, providerName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> clusterService.validateAllClusters(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all " + providerName + " clusters");
+  DaemonTask<Halconfig, List<Cluster>> clusters(@PathVariable String deploymentName,
+      @PathVariable String providerName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Cluster>>builder()
+        .getter(() -> clusterService.getAllClusters(deploymentName, providerName))
+        .validator(() -> clusterService.validateAllClusters(deploymentName, providerName))
+        .description("Get all " + providerName + " clusters")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/cluster/{clusterName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Cluster> cluster(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Cluster> cluster(@PathVariable String deploymentName,
       @PathVariable String providerName,
       @PathVariable String clusterName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Cluster> builder = new DaemonResponse.StaticRequestBuilder<>(
-            () -> clusterService.getProviderCluster(deploymentName, providerName, clusterName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> clusterService.validateCluster(deploymentName, providerName, clusterName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + clusterName + " cluster");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Cluster>builder()
+        .getter(() -> clusterService.getProviderCluster(deploymentName, providerName, clusterName))
+        .validator(() -> clusterService.validateCluster(deploymentName, providerName, clusterName))
+        .description("Get " + clusterName + " cluster")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/cluster/{clusterName:.+}", method = RequestMethod.DELETE)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.DeployService;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.RunningServiceDetails;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import com.netflix.spinnaker.halyard.proto.DeploymentsGrpc;
 import org.lognet.springboot.grpc.GRpcService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -81,8 +82,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
   @RequestMapping(value = "/{deploymentName:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, DeploymentConfiguration> deploymentConfiguration(
       @PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<DeploymentConfiguration> builder = new StaticRequestBuilder<>(
         () -> deploymentService.getDeploymentConfiguration(deploymentName));
     builder.setSeverity(severity);
@@ -96,8 +97,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> deploymentConfiguration(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawDeployment) {
     DeploymentConfiguration deploymentConfiguration = objectMapper.convertValue(
         rawDeployment,
@@ -127,8 +128,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<DeploymentConfiguration>> deploymentConfigurations(
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<DeploymentConfiguration>> builder = new StaticRequestBuilder<>(
         () -> deploymentService.getAllDeploymentConfigurations());
     builder.setSeverity(severity);
@@ -142,8 +143,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/generate/", method = RequestMethod.POST)
   DaemonTask<Halconfig, String> generateConfig(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestParam(required = false) List<String> serviceNames) {
     List<String> finalServiceNames = serviceNames != null ? serviceNames : Collections.emptyList();
     Supplier buildResponse = () -> {
@@ -164,8 +165,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/clean/", method = RequestMethod.POST)
   DaemonTask<Halconfig, Void> clean(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     Supplier buildResponse = () -> {
       deployService.clean(deploymentName);
       return null;
@@ -183,8 +184,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/connect/", method = RequestMethod.POST)
   DaemonTask<Halconfig, RemoteAction> connect(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestParam(required = false) List<String> serviceNames) {
     List<String> finalServiceNames = serviceNames == null ? new ArrayList<>() : serviceNames;
     StaticRequestBuilder<RemoteAction> builder = new StaticRequestBuilder<>(
@@ -201,8 +202,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/rollback/", method = RequestMethod.POST)
   DaemonTask<Halconfig, Void> rollback(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestParam(required = false) List<String> serviceNames,
       @RequestParam(required = false) List<String> excludeServiceNames) {
     List<String> finalServiceNames = serviceNames != null ? serviceNames : Collections.emptyList();
@@ -227,8 +228,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/prep/", method = RequestMethod.POST)
   DaemonTask<Halconfig, RemoteAction> prep(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestParam(required = false) List<String> serviceNames,
       @RequestParam(required = false) List<String> excludeServiceNames) {
     List<String> finalServiceNames = serviceNames != null ? serviceNames : Collections.emptyList();
@@ -248,8 +249,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/deploy/", method = RequestMethod.POST)
   DaemonTask<Halconfig, RemoteAction> deploy(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestParam(required = false) List<DeployOption> deployOptions,
       @RequestParam(required = false) List<String> serviceNames,
       @RequestParam(required = false) List<String> excludeServiceNames) {
@@ -289,8 +290,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/collectLogs/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> collectLogs(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestParam(required = false) List<String> serviceNames,
       @RequestParam(required = false) List<String> excludeServiceNames) {
     List<String> finalServiceNames = serviceNames != null ? serviceNames : Collections.emptyList();
@@ -313,8 +314,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/configDiff/", method = RequestMethod.GET)
   DaemonTask<Halconfig, NodeDiff> configDiff(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<NodeDiff> builder = new StaticRequestBuilder<>(
         () -> deployService.configDiff(deploymentName));
     builder.setSeverity(severity);
@@ -328,8 +329,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/version/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setVersion(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Versions.Version version) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -350,8 +351,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
 
   @RequestMapping(value = "/{deploymentName:.+}/version/", method = RequestMethod.GET)
   DaemonTask<Halconfig, String> getVersion(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<String> builder = new StaticRequestBuilder<>(
         () -> deploymentService.getVersion(deploymentName));
     builder.setSeverity(severity);
@@ -368,8 +369,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase{
   DaemonTask<Halconfig, RunningServiceDetails> getServiceDetails(
       @PathVariable String deploymentName,
       @PathVariable String serviceName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<RunningServiceDetails> builder = new StaticRequestBuilder<>(() -> null);
     builder.setSeverity(severity);
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentEnvironmentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentEnvironmentController.java
@@ -23,20 +23,16 @@ import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.DeploymentEnvironmentService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 
@@ -57,20 +53,14 @@ public class DeploymentEnvironmentController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonTask<Halconfig, DeploymentEnvironment> getDeploymentEnvironment(
-      @PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<DeploymentEnvironment> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> deploymentEnvironmentService.getDeploymentEnvironment(deploymentName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> deploymentEnvironmentService.validateDeploymentEnvironment(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get the deployment environment");
+  DaemonTask<Halconfig, DeploymentEnvironment> getDeploymentEnvironment(@PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<DeploymentEnvironment>builder()
+        .getter(() -> deploymentEnvironmentService.getDeploymentEnvironment(deploymentName))
+        .validator(() -> deploymentEnvironmentService.validateDeploymentEnvironment(deploymentName))
+        .description("Get the deployment environment")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentEnvironmentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentEnvironmentController.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,8 +59,8 @@ public class DeploymentEnvironmentController {
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, DeploymentEnvironment> getDeploymentEnvironment(
       @PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<DeploymentEnvironment> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> deploymentEnvironmentService.getDeploymentEnvironment(deploymentName));
     builder.setSeverity(severity);
@@ -74,8 +75,8 @@ public class DeploymentEnvironmentController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setDeploymentEnvironment(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawDeploymentEnvironment) {
     DeploymentEnvironment deploymentEnvironment = objectMapper
         .convertValue(rawDeploymentEnvironment, DeploymentEnvironment.class);

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
@@ -22,20 +22,16 @@ import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.FeaturesService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.function.Supplier;
@@ -58,12 +54,13 @@ public class FeaturesController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Features> getFeatures(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Features> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> featuresService.getFeatures(deploymentName));
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get features");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Features>builder()
+        .getter(() -> featuresService.getFeatures(deploymentName))
+        .validator(() -> featuresService.validateFeatures(deploymentName))
+        .description("Get features")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/FeaturesController.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -57,8 +58,8 @@ public class FeaturesController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Features> getFeatures(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<Features> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> featuresService.getFeatures(deploymentName));
 
@@ -67,8 +68,8 @@ public class FeaturesController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setFeatures(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawFeatures) {
     Features features = objectMapper.convertValue(rawFeatures, Features.class);
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/HaServiceController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/HaServiceController.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,8 +63,8 @@ public class HaServiceController {
   DaemonTask<Halconfig, HaService> get(
       @PathVariable String deploymentName,
       @PathVariable String serviceName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<HaService> builder = new StaticRequestBuilder<>(
         () -> haServiceService.getHaService(deploymentName, serviceName));
 
@@ -80,8 +81,8 @@ public class HaServiceController {
   DaemonTask<Halconfig, Void> setHaService(
       @PathVariable String deploymentName,
       @PathVariable String serviceName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawHaService) {
     HaService haService = objectMapper.convertValue(
         rawHaService,
@@ -112,8 +113,8 @@ public class HaServiceController {
   DaemonTask<Halconfig, Void> setEnabled(
       @PathVariable String deploymentName,
       @PathVariable String serviceName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -134,8 +135,8 @@ public class HaServiceController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<HaService>> haServices(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<HaService>> builder = new StaticRequestBuilder<>(
         () -> haServiceService.getAllHaServices(deploymentName));
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/HaServiceController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/HaServiceController.java
@@ -25,20 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaServices;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.services.v1.HaServiceService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -60,21 +56,15 @@ public class HaServiceController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/{serviceName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, HaService> get(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, HaService> get(@PathVariable String deploymentName,
       @PathVariable String serviceName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<HaService> builder = new StaticRequestBuilder<>(
-        () -> haServiceService.getHaService(deploymentName, serviceName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> haServiceService.validateHaService(deploymentName, serviceName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get the " + serviceName + " high availability service configuration");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<HaService>builder()
+        .getter(() -> haServiceService.getHaService(deploymentName, serviceName))
+        .validator(() -> haServiceService.validateHaService(deploymentName, serviceName))
+        .description("Get the " + serviceName + " high availability service configuration")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{serviceName:.+}", method = RequestMethod.PUT)
@@ -135,17 +125,12 @@ public class HaServiceController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<HaService>> haServices(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<HaService>> builder = new StaticRequestBuilder<>(
-        () -> haServiceService.getAllHaServices(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> haServiceService.validateAllHaServices(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all high availability service configurations");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<HaService>>builder()
+        .getter( () -> haServiceService.getAllHaServices(deploymentName))
+        .validator(() -> haServiceService.validateAllHaServices(deploymentName))
+        .description("Get all high availability service configurations")
+        .build()
+        .execute(validationSettings);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,8 +62,8 @@ public class MasterController {
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Master>> masters(@PathVariable String deploymentName,
       @PathVariable String ciName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<Master>> builder = new StaticRequestBuilder<>(
         () -> masterService.getAllMasters(deploymentName, ciName));
     builder.setSeverity(severity);
@@ -79,8 +80,8 @@ public class MasterController {
       @PathVariable String deploymentName,
       @PathVariable String ciName,
       @PathVariable String masterName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Master> builder = new StaticRequestBuilder<>(
         () -> masterService.getCiMaster(deploymentName, ciName, masterName));
     builder.setSeverity(severity);
@@ -98,8 +99,8 @@ public class MasterController {
       @PathVariable String deploymentName,
       @PathVariable String ciName,
       @PathVariable String masterName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
     builder.setUpdate(() -> masterService.deleteMaster(deploymentName, ciName, masterName));
@@ -124,8 +125,8 @@ public class MasterController {
       @PathVariable String deploymentName,
       @PathVariable String ciName,
       @PathVariable String masterName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawMaster) {
     Master master = objectMapper.convertValue(
         rawMaster,
@@ -156,8 +157,8 @@ public class MasterController {
   DaemonTask<Halconfig, Void> addMaster(
       @PathVariable String deploymentName,
       @PathVariable String ciName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawMaster) {
     Master master = objectMapper.convertValue(
         rawMaster,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MasterController.java
@@ -24,20 +24,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Cis;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Master;
 import com.netflix.spinnaker.halyard.config.services.v1.MasterService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -62,36 +58,26 @@ public class MasterController {
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Master>> masters(@PathVariable String deploymentName,
       @PathVariable String ciName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<Master>> builder = new StaticRequestBuilder<>(
-        () -> masterService.getAllMasters(deploymentName, ciName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> masterService.validateAllMasters(deploymentName, ciName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all masters for " + ciName);
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Master>>builder()
+        .getter(() -> masterService.getAllMasters(deploymentName, ciName))
+        .validator(() -> masterService.validateAllMasters(deploymentName, ciName))
+        .description("Get all masters for " + ciName)
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{masterName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Master> master(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Master> master(@PathVariable String deploymentName,
       @PathVariable String ciName,
       @PathVariable String masterName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Master> builder = new StaticRequestBuilder<>(
-        () -> masterService.getCiMaster(deploymentName, ciName, masterName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> masterService.validateMaster(deploymentName, ciName, masterName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get the " + masterName + " master");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Master>builder()
+        .getter(() -> masterService.getCiMaster(deploymentName, ciName, masterName))
+        .validator(() -> masterService.validateMaster(deploymentName, ciName, masterName))
+        .description("Get the " + masterName + " master")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{masterName:.+}", method = RequestMethod.DELETE)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MetricStoresController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MetricStoresController.java
@@ -24,20 +24,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.MetricStore;
 import com.netflix.spinnaker.halyard.config.model.v1.node.MetricStores;
 import com.netflix.spinnaker.halyard.config.services.v1.MetricStoresService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 
@@ -59,36 +55,25 @@ public class MetricStoresController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, MetricStores> getMetricStores(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<MetricStores> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> metricStoresService.getMetricStores(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> metricStoresService.validateMetricStores(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all metric stores");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<MetricStores>builder()
+        .getter(() -> metricStoresService.getMetricStores(deploymentName))
+        .validator(() -> metricStoresService.validateMetricStores(deploymentName))
+        .description("Get all metric stores")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{metricStoreType:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, MetricStore> getMetricStore(@PathVariable String deploymentName,
       @PathVariable String metricStoreType,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<MetricStore> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> metricStoresService.getMetricStore(deploymentName, metricStoreType));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> metricStoresService.validateMetricStore(deploymentName, metricStoreType));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + metricStoreType + " metric store");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<MetricStore>builder()
+        .getter(() -> metricStoresService.getMetricStore(deploymentName, metricStoreType))
+        .validator(() -> metricStoresService.validateMetricStore(deploymentName, metricStoreType))
+        .description("Get " + metricStoreType + " metric store")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MetricStoresController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/MetricStoresController.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,8 +59,8 @@ public class MetricStoresController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, MetricStores> getMetricStores(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<MetricStores> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> metricStoresService.getMetricStores(deploymentName));
 
@@ -75,8 +76,8 @@ public class MetricStoresController {
   @RequestMapping(value = "/{metricStoreType:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, MetricStore> getMetricStore(@PathVariable String deploymentName,
       @PathVariable String metricStoreType,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<MetricStore> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> metricStoresService.getMetricStore(deploymentName, metricStoreType));
 
@@ -92,8 +93,8 @@ public class MetricStoresController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setMetricStores(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawMetricStores) {
     MetricStores metricStores = objectMapper.convertValue(rawMetricStores, MetricStores.class);
 
@@ -119,8 +120,8 @@ public class MetricStoresController {
   @RequestMapping(value = "/{metricStoreType:.+}", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setMetricStore(@PathVariable String deploymentName,
       @PathVariable String metricStoreType,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawMetricStore) {
     MetricStore metricStore = objectMapper.convertValue(
         rawMetricStore,
@@ -151,8 +152,8 @@ public class MetricStoresController {
   @RequestMapping(value = "/{metricStoreType:.+}/enabled/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setMethodEnabled(@PathVariable String deploymentName,
       @PathVariable String metricStoreType,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/NotificationController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/NotificationController.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,8 +63,8 @@ public class NotificationController {
   DaemonTask<Halconfig, Notification> notification(
       @PathVariable String deploymentName,
       @PathVariable String notificationName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Notification> builder = new StaticRequestBuilder<>(
         () -> notificationService.getNotification(deploymentName, notificationName));
     builder.setSeverity(severity);
@@ -81,8 +82,8 @@ public class NotificationController {
   DaemonTask<Halconfig, Void> setEnabled(
       @PathVariable String deploymentName,
       @PathVariable String notificationName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -104,8 +105,8 @@ public class NotificationController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Notifications> notifications(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Notifications> builder = new StaticRequestBuilder<>(
         () -> notificationService.getNotifications(deploymentName));
     builder.setSeverity(severity);
@@ -122,8 +123,8 @@ public class NotificationController {
   DaemonTask<Halconfig, Void> setNotification(
       @PathVariable String deploymentName,
       @PathVariable String notificationName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawNotification) {
     Notification notification = objectMapper.convertValue(
         rawNotification,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/NotificationController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/NotificationController.java
@@ -25,20 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Notification;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Notifications;
 import com.netflix.spinnaker.halyard.config.services.v1.NotificationService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.function.Supplier;
@@ -60,22 +56,15 @@ public class NotificationController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/{notificationName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Notification> notification(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Notification> notification(@PathVariable String deploymentName,
       @PathVariable String notificationName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Notification> builder = new StaticRequestBuilder<>(
-        () -> notificationService.getNotification(deploymentName, notificationName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> notificationService.validateNotification(deploymentName, notificationName));
-    }
-
-    return DaemonTaskHandler
-        .submitTask(builder::build, "Get " + notificationName + " notification");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Notification>builder()
+        .getter(() -> notificationService.getNotification(deploymentName, notificationName))
+        .validator(() -> notificationService.validateNotification(deploymentName, notificationName))
+        .description("Get " + notificationName + " notification")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{notificationName:.+}/enabled", method = RequestMethod.PUT)
@@ -105,18 +94,13 @@ public class NotificationController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Notifications> notifications(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Notifications> builder = new StaticRequestBuilder<>(
-        () -> notificationService.getNotifications(deploymentName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder
-          .setValidateResponse(() -> notificationService.validateAllNotifications(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all notification settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Notifications>builder()
+        .getter( () -> notificationService.getNotifications(deploymentName))
+        .validator(() -> notificationService.validateAllNotifications(deploymentName))
+        .description("Get all notification settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{notificationName:.+}", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PersistentStorageController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PersistentStorageController.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -58,8 +59,8 @@ public class PersistentStorageController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, PersistentStorage> getPersistentStorage(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<PersistentStorage> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> persistentStorageService.getPersistentStorage(deploymentName));
 
@@ -75,8 +76,8 @@ public class PersistentStorageController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setPersistentStorage(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawPersistentStorage) {
     PersistentStorage persistentStorage = objectMapper
         .convertValue(rawPersistentStorage, PersistentStorage.class);
@@ -106,8 +107,8 @@ public class PersistentStorageController {
   @RequestMapping(value = "/{persistentStoreType:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, PersistentStore> getPersistentStore(@PathVariable String deploymentName,
       @PathVariable String persistentStoreType,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<PersistentStore> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> persistentStorageService.getPersistentStore(deploymentName, persistentStoreType));
 
@@ -124,8 +125,8 @@ public class PersistentStorageController {
   @RequestMapping(value = "/{persistentStoreType:.+}", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setPersistentStore(@PathVariable String deploymentName,
       @PathVariable String persistentStoreType,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawPersistentStore) {
     PersistentStore persistentStore = objectMapper.convertValue(rawPersistentStore,
         PersistentStorage.translatePersistentStoreType(persistentStoreType));

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -61,8 +62,8 @@ public class ProviderController {
   DaemonTask<Halconfig, Provider> get(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Provider> builder = new StaticRequestBuilder<>(
         () -> providerService.getProvider(deploymentName, providerName));
 
@@ -80,8 +81,8 @@ public class ProviderController {
   DaemonTask<Halconfig, Void> setProvider(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawProvider) {
     Provider provider = objectMapper.convertValue(
         rawProvider,
@@ -112,8 +113,8 @@ public class ProviderController {
   DaemonTask<Halconfig, Void> setEnabled(
       @PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -134,8 +135,8 @@ public class ProviderController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Provider>> providers(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<Provider>> builder = new StaticRequestBuilder<>(
         () -> providerService.getAllProviders(deploymentName));
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ProviderController.java
@@ -23,20 +23,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Providers;
 import com.netflix.spinnaker.halyard.config.services.v1.ProviderService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -59,22 +55,15 @@ public class ProviderController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/{providerName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Provider> get(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Provider> get(@PathVariable String deploymentName,
       @PathVariable String providerName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Provider> builder = new StaticRequestBuilder<>(
-        () -> providerService.getProvider(deploymentName, providerName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> providerService.validateProvider(deploymentName, providerName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get the " + providerName + " provider");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Provider>builder()
+        .getter(() -> providerService.getProvider(deploymentName, providerName))
+        .validator(() -> providerService.validateProvider(deploymentName, providerName))
+        .description("Get the " + providerName + " provider")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{providerName:.+}", method = RequestMethod.PUT)
@@ -135,17 +124,12 @@ public class ProviderController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Provider>> providers(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<Provider>> builder = new StaticRequestBuilder<>(
-        () -> providerService.getAllProviders(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> providerService.validateAllProviders(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all providers");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Provider>>builder()
+        .getter(() -> providerService.getAllProviders(deploymentName))
+        .validator(() -> providerService.validateAllProviders(deploymentName))
+        .description("Get all providers")
+        .build()
+        .execute(validationSettings);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PubsubController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PubsubController.java
@@ -25,20 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsub;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsubs;
 import com.netflix.spinnaker.halyard.config.services.v1.PubsubService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -61,21 +57,15 @@ public class PubsubController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/{pubsubName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Pubsub> get(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Pubsub> get(@PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Pubsub> builder = new StaticRequestBuilder<>(
-        () -> pubsubService.getPubsub(deploymentName, pubsubName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> pubsubService.validatePubsub(deploymentName, pubsubName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get the " + pubsubName + " pubsub");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Pubsub>builder()
+        .getter(() -> pubsubService.getPubsub(deploymentName, pubsubName))
+        .validator(() -> pubsubService.validatePubsub(deploymentName, pubsubName))
+        .description("Get the " + pubsubName + " pubsub")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/{pubsubName:.+}", method = RequestMethod.PUT)
@@ -136,17 +126,12 @@ public class PubsubController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Pubsub>> pubsubs(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<Pubsub>> builder = new StaticRequestBuilder<>(
-        () -> pubsubService.getAllPubsubs(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> pubsubService.validateAllPubsubs(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all pubsubs");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Pubsub>>builder()
+        .getter(() -> pubsubService.getAllPubsubs(deploymentName))
+        .validator(() -> pubsubService.validateAllPubsubs(deploymentName))
+        .description("Get all pubsubs")
+        .build()
+        .execute(validationSettings);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PubsubController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PubsubController.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,8 +64,8 @@ public class PubsubController {
   DaemonTask<Halconfig, Pubsub> get(
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Pubsub> builder = new StaticRequestBuilder<>(
         () -> pubsubService.getPubsub(deploymentName, pubsubName));
 
@@ -81,8 +82,8 @@ public class PubsubController {
   DaemonTask<Halconfig, Void> setPubsub(
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawPubsub) {
     Pubsub pubsub = objectMapper.convertValue(
         rawPubsub,
@@ -113,8 +114,8 @@ public class PubsubController {
   DaemonTask<Halconfig, Void> setEnabled(
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -135,8 +136,8 @@ public class PubsubController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, List<Pubsub>> pubsubs(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<Pubsub>> builder = new StaticRequestBuilder<>(
         () -> pubsubService.getAllPubsubs(deploymentName));
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
@@ -105,7 +105,7 @@ public class SecurityController {
       @ModelAttribute ValidationSettings validationSettings) {
     return GenericGetRequest.<ApacheSsl>builder()
         .getter(() -> securityService.getApacheSsl(deploymentName))
-        .validator(() -> securityService.validateUiSecurity(deploymentName))
+        .validator(() -> securityService.validateApacheSsl(deploymentName))
         .description("Get UI SSL settings")
         .build()
         .execute(validationSettings);
@@ -200,7 +200,7 @@ public class SecurityController {
       @ModelAttribute ValidationSettings validationSettings) {
     return GenericGetRequest.<SpringSsl>builder()
         .getter(() -> securityService.getSpringSsl(deploymentName))
-        .validator(() -> securityService.validateUiSecurity(deploymentName))
+        .validator(() -> securityService.validateSpringSsl(deploymentName))
         .description("Get API SSL settings")
         .build()
         .execute(validationSettings);
@@ -285,7 +285,7 @@ public class SecurityController {
     return GenericGetRequest.<GroupMembership>builder()
         .getter(() -> securityService.getGroupMembership(deploymentName))
         .validator(() -> securityService.validateAuthz(deploymentName))
-        .description("Get API SSL settings")
+        .description("Get group membership settings")
         .build()
         .execute(validationSettings);
   }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
@@ -21,29 +21,18 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
-import com.netflix.spinnaker.halyard.config.model.v1.security.ApacheSsl;
-import com.netflix.spinnaker.halyard.config.model.v1.security.ApiSecurity;
-import com.netflix.spinnaker.halyard.config.model.v1.security.AuthnMethod;
-import com.netflix.spinnaker.halyard.config.model.v1.security.GroupMembership;
-import com.netflix.spinnaker.halyard.config.model.v1.security.RoleProvider;
-import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
-import com.netflix.spinnaker.halyard.config.model.v1.security.SpringSsl;
-import com.netflix.spinnaker.halyard.config.model.v1.security.UiSecurity;
+import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import com.netflix.spinnaker.halyard.config.services.v1.SecurityService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 
@@ -65,34 +54,24 @@ public class SecurityController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Security> getSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Security> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getSecurity(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> securityService.validateSecurity(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all security settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Security>builder()
+        .getter(() -> securityService.getSecurity(deploymentName))
+        .validator(() -> securityService.validateSecurity(deploymentName))
+        .description("Get all security settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/ui/", method = RequestMethod.GET)
   DaemonTask<Halconfig, UiSecurity> getUiSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<UiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getUiSecurity(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> securityService.validateUiSecurity(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get UI security settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<UiSecurity>builder()
+        .getter(() -> securityService.getUiSecurity(deploymentName))
+        .validator(() -> securityService.validateUiSecurity(deploymentName))
+        .description("Get UI security settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/ui/", method = RequestMethod.PUT)
@@ -123,18 +102,13 @@ public class SecurityController {
 
   @RequestMapping(value = "/ui/ssl/", method = RequestMethod.GET)
   DaemonTask<Halconfig, ApacheSsl> getApacheSsl(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<ApacheSsl> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getApacheSsl(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> securityService.validateUiSecurity(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get UI SSL settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<ApacheSsl>builder()
+        .getter(() -> securityService.getApacheSsl(deploymentName))
+        .validator(() -> securityService.validateUiSecurity(deploymentName))
+        .description("Get UI SSL settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/ui/ssl/", method = RequestMethod.PUT)
@@ -186,18 +160,13 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/", method = RequestMethod.GET)
   DaemonTask<Halconfig, ApiSecurity> getApiSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<ApiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getApiSecurity(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> securityService.validateApiSecurity(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get API security settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<ApiSecurity>builder()
+        .getter(() -> securityService.getApiSecurity(deploymentName))
+        .validator(() -> securityService.validateApiSecurity(deploymentName))
+        .description("Get API security settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/api/", method = RequestMethod.PUT)
@@ -228,18 +197,13 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/ssl/", method = RequestMethod.GET)
   DaemonTask<Halconfig, SpringSsl> getSpringSsl(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<SpringSsl> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getSpringSsl(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> securityService.validateUiSecurity(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get API SSL settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<SpringSsl>builder()
+        .getter(() -> securityService.getSpringSsl(deploymentName))
+        .validator(() -> securityService.validateUiSecurity(deploymentName))
+        .description("Get API SSL settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/api/ssl/", method = RequestMethod.PUT)
@@ -317,55 +281,37 @@ public class SecurityController {
 
   @RequestMapping(value = "/authz/groupMembership", method = RequestMethod.GET)
   DaemonTask<Halconfig, GroupMembership> getGroupMembership(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<GroupMembership> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getGroupMembership(deploymentName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> securityService.validateAuthz(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get group membership settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<GroupMembership>builder()
+        .getter(() -> securityService.getGroupMembership(deploymentName))
+        .validator(() -> securityService.validateAuthz(deploymentName))
+        .description("Get API SSL settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/authn/{methodName:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, AuthnMethod> getAuthmethod(@PathVariable String deploymentName,
       @PathVariable String methodName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<AuthnMethod> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getAuthnMethod(deploymentName, methodName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> securityService.validateAuthnMethod(deploymentName, methodName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get authentication settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<AuthnMethod>builder()
+        .getter(() -> securityService.getAuthnMethod(deploymentName, methodName))
+        .validator(() -> securityService.validateAuthnMethod(deploymentName, methodName))
+        .description("Get authentication settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/authz/groupMembership/{roleProviderName:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, RoleProvider> getRoleProvider(@PathVariable String deploymentName,
       @PathVariable String roleProviderName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    DaemonResponse.StaticRequestBuilder<RoleProvider> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> securityService.getRoleProvider(deploymentName, roleProviderName));
-
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> securityService.validateRoleProvider(deploymentName, roleProviderName));
-    }
-
-    return DaemonTaskHandler
-        .submitTask(builder::build, "Get " + roleProviderName + " group membership settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<RoleProvider>builder()
+        .getter(() -> securityService.getRoleProvider(deploymentName, roleProviderName))
+        .validator(() -> securityService.validateRoleProvider(deploymentName, roleProviderName))
+        .description("Get " + roleProviderName + " group membership settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SecurityController.java
@@ -36,6 +36,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -64,8 +65,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Security> getSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<Security> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getSecurity(deploymentName));
 
@@ -80,8 +81,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/ui/", method = RequestMethod.GET)
   DaemonTask<Halconfig, UiSecurity> getUiSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<UiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getUiSecurity(deploymentName));
 
@@ -96,8 +97,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/ui/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setUiSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawUiSecurity) {
     UiSecurity uiSecurity = objectMapper.convertValue(rawUiSecurity, UiSecurity.class);
 
@@ -122,8 +123,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/ui/ssl/", method = RequestMethod.GET)
   DaemonTask<Halconfig, ApacheSsl> getApacheSsl(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<ApacheSsl> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getApacheSsl(deploymentName));
 
@@ -138,8 +139,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/ui/ssl/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setApacheSSl(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawApacheSsl) {
     ApacheSsl apacheSsl = objectMapper.convertValue(rawApacheSsl, ApacheSsl.class);
 
@@ -164,8 +165,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/ui/ssl/enabled/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setApacheSSlEnabled(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -185,8 +186,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/", method = RequestMethod.GET)
   DaemonTask<Halconfig, ApiSecurity> getApiSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<ApiSecurity> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getApiSecurity(deploymentName));
 
@@ -201,8 +202,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setApiSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawApiSecurity) {
     ApiSecurity apiSecurity = objectMapper.convertValue(rawApiSecurity, ApiSecurity.class);
 
@@ -227,8 +228,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/ssl/", method = RequestMethod.GET)
   DaemonTask<Halconfig, SpringSsl> getSpringSsl(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<SpringSsl> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getSpringSsl(deploymentName));
 
@@ -243,8 +244,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/ssl/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setSpringSSl(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawSpringSsl) {
     SpringSsl apacheSsl = objectMapper.convertValue(rawSpringSsl, SpringSsl.class);
 
@@ -269,8 +270,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/api/ssl/enabled/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setSpringSSlEnabled(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -290,8 +291,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/authz/groupMembership", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setGroupMembership(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawMembership) {
     GroupMembership membership = objectMapper.convertValue(rawMembership, GroupMembership.class);
 
@@ -316,8 +317,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/authz/groupMembership", method = RequestMethod.GET)
   DaemonTask<Halconfig, GroupMembership> getGroupMembership(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<GroupMembership> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getGroupMembership(deploymentName));
 
@@ -333,8 +334,8 @@ public class SecurityController {
   @RequestMapping(value = "/authn/{methodName:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, AuthnMethod> getAuthmethod(@PathVariable String deploymentName,
       @PathVariable String methodName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<AuthnMethod> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getAuthnMethod(deploymentName, methodName));
 
@@ -351,8 +352,8 @@ public class SecurityController {
   @RequestMapping(value = "/authz/groupMembership/{roleProviderName:.+}", method = RequestMethod.GET)
   DaemonTask<Halconfig, RoleProvider> getRoleProvider(@PathVariable String deploymentName,
       @PathVariable String roleProviderName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     DaemonResponse.StaticRequestBuilder<RoleProvider> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> securityService.getRoleProvider(deploymentName, roleProviderName));
 
@@ -369,8 +370,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setSecurity(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawSecurity) {
     Security security = objectMapper.convertValue(rawSecurity, Security.class);
 
@@ -396,8 +397,8 @@ public class SecurityController {
   @RequestMapping(value = "/authn/{methodName:.+}", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setAuthnMethod(@PathVariable String deploymentName,
       @PathVariable String methodName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawMethod) {
     AuthnMethod method = objectMapper.convertValue(
         rawMethod,
@@ -427,8 +428,8 @@ public class SecurityController {
   @RequestMapping(value = "/authz/groupMembership/{roleProviderName:.+}", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setRoleProvider(@PathVariable String deploymentName,
       @PathVariable String roleProviderName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawProvider) {
     RoleProvider roleProvider = objectMapper.convertValue(
         rawProvider,
@@ -459,8 +460,8 @@ public class SecurityController {
   @RequestMapping(value = "/authn/{methodName:.+}/enabled/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setMethodEnabled(@PathVariable String deploymentName,
       @PathVariable String methodName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
@@ -482,8 +483,8 @@ public class SecurityController {
 
   @RequestMapping(value = "/authz/enabled/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setMethodEnabled(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody boolean enabled) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SubscriptionController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SubscriptionController.java
@@ -31,6 +31,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,8 +64,8 @@ public class SubscriptionController {
   DaemonTask<Halconfig, List<Subscription>> subscriptions(
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<List<Subscription>> builder = new StaticRequestBuilder<>(
         () -> subscriptionService.getAllSubscriptions(deploymentName, pubsubName));
     builder.setSeverity(severity);
@@ -81,8 +82,8 @@ public class SubscriptionController {
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
       @PathVariable String subscriptionName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     StaticRequestBuilder<Subscription> builder = new StaticRequestBuilder<>(
         () -> subscriptionService
             .getPubsubSubscription(deploymentName, pubsubName, subscriptionName));
@@ -101,8 +102,8 @@ public class SubscriptionController {
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
       @PathVariable String subscriptionName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
     UpdateRequestBuilder builder = new UpdateRequestBuilder();
 
     builder.setUpdate(
@@ -128,8 +129,8 @@ public class SubscriptionController {
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
       @PathVariable String subscriptionName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawSubscription) {
     Subscription subscription = objectMapper.convertValue(
         rawSubscription,
@@ -159,8 +160,8 @@ public class SubscriptionController {
   DaemonTask<Halconfig, Void> addSubscription(
       @PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity,
       @RequestBody Object rawSubscription) {
     Subscription subscription = objectMapper.convertValue(
         rawSubscription,

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SubscriptionController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/SubscriptionController.java
@@ -25,20 +25,16 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsubs;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Subscription;
 import com.netflix.spinnaker.halyard.config.services.v1.SubscriptionService;
-import com.netflix.spinnaker.halyard.core.DaemonResponse.StaticRequestBuilder;
 import com.netflix.spinnaker.halyard.core.DaemonResponse.UpdateRequestBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -61,40 +57,28 @@ public class SubscriptionController {
   ObjectMapper objectMapper;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonTask<Halconfig, List<Subscription>> subscriptions(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, List<Subscription>> subscriptions(@PathVariable String deploymentName,
       @PathVariable String pubsubName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<List<Subscription>> builder = new StaticRequestBuilder<>(
-        () -> subscriptionService.getAllSubscriptions(deploymentName, pubsubName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(() -> subscriptionService.validateAllSubscriptions(deploymentName, pubsubName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get all " + pubsubName + " subscriptions");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Subscription>>builder()
+        .getter(() -> subscriptionService.getAllSubscriptions(deploymentName, pubsubName))
+        .validator(() -> subscriptionService.validateAllSubscriptions(deploymentName, pubsubName))
+        .description("Get all " + pubsubName + " subscriptions")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/subscription/{subscriptionName:.+}", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Subscription> subscription(
-      @PathVariable String deploymentName,
+  DaemonTask<Halconfig, Subscription> subscription(@PathVariable String deploymentName,
       @PathVariable String pubsubName,
       @PathVariable String subscriptionName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Severity severity) {
-    StaticRequestBuilder<Subscription> builder = new StaticRequestBuilder<>(
-        () -> subscriptionService
-            .getPubsubSubscription(deploymentName, pubsubName, subscriptionName));
-    builder.setSeverity(severity);
-
-    if (validate) {
-      builder.setValidateResponse(
-          () -> subscriptionService.validateSubscription(deploymentName, pubsubName, subscriptionName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get " + subscriptionName + " subscription");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Subscription>builder()
+        .getter(() -> subscriptionService.getPubsubSubscription(deploymentName, pubsubName, subscriptionName))
+        .validator(() -> subscriptionService.validateSubscription(deploymentName, pubsubName, subscriptionName))
+        .description("Get " + subscriptionName + " subscription")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/subscription/{subscriptionName:.+}", method = RequestMethod.DELETE)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
@@ -29,6 +29,8 @@ import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
 import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,17 +47,13 @@ public class WebhookController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Webhook> getWebhook(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
-    DaemonResponse.StaticRequestBuilder<Webhook> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> webhookService.getWebhook(deploymentName));
-
-    builder.setSeverity(severity);
-    if (validate) {
-      builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get webhook settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Webhook>builder()
+        .getter(() -> webhookService.getWebhook(deploymentName))
+        .validator(() -> webhookService.validateWebhook(deploymentName))
+        .description("Get webhook settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
@@ -86,17 +84,13 @@ public class WebhookController {
 
   @RequestMapping(value = "/trust/", method = RequestMethod.GET)
   DaemonTask<Halconfig, WebhookTrust> getWebhookTrust(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
-    DaemonResponse.StaticRequestBuilder<WebhookTrust> builder = new DaemonResponse.StaticRequestBuilder<>(
-        () -> webhookService.getWebhookTrust(deploymentName));
-
-    builder.setSeverity(severity);
-    if (validate) {
-      builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName));
-    }
-
-    return DaemonTaskHandler.submitTask(builder::build, "Get webhook trust settings");
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<WebhookTrust>builder()
+        .getter(() -> webhookService.getWebhookTrust(deploymentName))
+        .validator(() -> webhookService.validateWebhookTrust(deploymentName))
+        .description("Get webhook trust settings")
+        .build()
+        .execute(validationSettings);
   }
 
   @RequestMapping(value = "/trust/", method = RequestMethod.PUT)

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
@@ -37,96 +37,90 @@ import java.nio.file.Path;
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/webhook")
 @RequiredArgsConstructor
 public class WebhookController {
-    private final WebhookService webhookService;
-    private final ObjectMapper objectMapper;
-    private final HalconfigDirectoryStructure halconfigDirectoryStructure;
-    private final HalconfigParser halconfigParser;
+  private final WebhookService webhookService;
+  private final ObjectMapper objectMapper;
+  private final HalconfigDirectoryStructure halconfigDirectoryStructure;
+  private final HalconfigParser halconfigParser;
 
-    @RequestMapping(value = "/", method = RequestMethod.GET)
-    DaemonTask<Halconfig, Webhook> getWebhook(
-            @PathVariable String deploymentName,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity
-    ) {
-        DaemonResponse.StaticRequestBuilder<Webhook> builder = new DaemonResponse.StaticRequestBuilder<>(
-                () -> webhookService.getWebhook(deploymentName));
+  @RequestMapping(value = "/", method = RequestMethod.GET)
+  DaemonTask<Halconfig, Webhook> getWebhook(@PathVariable String deploymentName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+    DaemonResponse.StaticRequestBuilder<Webhook> builder = new DaemonResponse.StaticRequestBuilder<>(
+        () -> webhookService.getWebhook(deploymentName));
 
-        builder.setSeverity(severity);
-        if (validate) {
-            builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName));
-        }
-
-        return DaemonTaskHandler.submitTask(builder::build, "Get webhook settings");
+    builder.setSeverity(severity);
+    if (validate) {
+      builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName));
     }
 
-    @RequestMapping(value = "/", method = RequestMethod.PUT)
-    DaemonTask<Halconfig, Void> setWebhook(
-            @PathVariable String deploymentName,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
-            @RequestBody Object rawWebhook) {
-        Webhook webhook = objectMapper.convertValue(rawWebhook, Webhook.class);
+    return DaemonTaskHandler.submitTask(builder::build, "Get webhook settings");
+  }
 
-        DaemonResponse.UpdateRequestBuilder builder = new DaemonResponse.UpdateRequestBuilder();
+  @RequestMapping(value = "/", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setWebhook(@PathVariable String deploymentName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
+      @RequestBody Object rawWebhook) {
+    Webhook webhook = objectMapper.convertValue(rawWebhook, Webhook.class);
 
-        Path configPath = halconfigDirectoryStructure.getConfigPath(deploymentName);
-        builder.setStage(() -> webhook.stageLocalFiles(configPath));
-        builder.setSeverity(severity);
-        builder.setUpdate(() -> webhookService.setWebhook(deploymentName, webhook));
+    DaemonResponse.UpdateRequestBuilder builder = new DaemonResponse.UpdateRequestBuilder();
 
-        builder.setValidate(ProblemSet::new);
-        if (validate) {
-            builder.setValidate(() -> webhookService.validateWebhook(deploymentName));
-        }
+    Path configPath = halconfigDirectoryStructure.getConfigPath(deploymentName);
+    builder.setStage(() -> webhook.stageLocalFiles(configPath));
+    builder.setSeverity(severity);
+    builder.setUpdate(() -> webhookService.setWebhook(deploymentName, webhook));
 
-        builder.setRevert(halconfigParser::undoChanges);
-        builder.setSave(halconfigParser::saveConfig);
-        builder.setClean(() -> halconfigParser.cleanLocalFiles(configPath));
-
-        return DaemonTaskHandler.submitTask(builder::build, "Edit webhook settings");
+    builder.setValidate(ProblemSet::new);
+    if (validate) {
+      builder.setValidate(() -> webhookService.validateWebhook(deploymentName));
     }
 
-    @RequestMapping(value = "/trust/", method = RequestMethod.GET)
-    DaemonTask<Halconfig, WebhookTrust> getWebhookTrust(
-            @PathVariable String deploymentName,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity
-    ) {
-        DaemonResponse.StaticRequestBuilder<WebhookTrust> builder = new DaemonResponse.StaticRequestBuilder<>(
-                () -> webhookService.getWebhookTrust(deploymentName));
+    builder.setRevert(halconfigParser::undoChanges);
+    builder.setSave(halconfigParser::saveConfig);
+    builder.setClean(() -> halconfigParser.cleanLocalFiles(configPath));
 
-        builder.setSeverity(severity);
-        if (validate) {
-            builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName));
-        }
+    return DaemonTaskHandler.submitTask(builder::build, "Edit webhook settings");
+  }
 
-        return DaemonTaskHandler.submitTask(builder::build, "Get webhook trust settings");
+  @RequestMapping(value = "/trust/", method = RequestMethod.GET)
+  DaemonTask<Halconfig, WebhookTrust> getWebhookTrust(@PathVariable String deploymentName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+    DaemonResponse.StaticRequestBuilder<WebhookTrust> builder = new DaemonResponse.StaticRequestBuilder<>(
+        () -> webhookService.getWebhookTrust(deploymentName));
+
+    builder.setSeverity(severity);
+    if (validate) {
+      builder.setValidateResponse(() -> webhookService.validateWebhook(deploymentName));
     }
 
-    @RequestMapping(value = "/trust/", method = RequestMethod.PUT)
-    DaemonTask<Halconfig, Void> setWebhookTrust(
-            @PathVariable String deploymentName,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-            @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
-            @RequestBody Object rawWebhookTrust) {
-        WebhookTrust webhookTrust = objectMapper.convertValue(rawWebhookTrust, WebhookTrust.class);
+    return DaemonTaskHandler.submitTask(builder::build, "Get webhook trust settings");
+  }
 
-        DaemonResponse.UpdateRequestBuilder builder = new DaemonResponse.UpdateRequestBuilder();
+  @RequestMapping(value = "/trust/", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setWebhookTrust(@PathVariable String deploymentName,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
+      @RequestBody Object rawWebhookTrust) {
+    WebhookTrust webhookTrust = objectMapper.convertValue(rawWebhookTrust, WebhookTrust.class);
 
-        Path configPath = halconfigDirectoryStructure.getConfigPath(deploymentName);
-        builder.setStage(() -> webhookTrust.stageLocalFiles(configPath));
-        builder.setSeverity(severity);
-        builder.setUpdate(() -> webhookService.setWebhookTrust(deploymentName, webhookTrust));
+    DaemonResponse.UpdateRequestBuilder builder = new DaemonResponse.UpdateRequestBuilder();
 
-        builder.setValidate(ProblemSet::new);
-        if (validate) {
-            builder.setValidate(() -> webhookService.validateWebhookTrust(deploymentName));
-        }
+    Path configPath = halconfigDirectoryStructure.getConfigPath(deploymentName);
+    builder.setStage(() -> webhookTrust.stageLocalFiles(configPath));
+    builder.setSeverity(severity);
+    builder.setUpdate(() -> webhookService.setWebhookTrust(deploymentName, webhookTrust));
 
-        builder.setRevert(halconfigParser::undoChanges);
-        builder.setSave(halconfigParser::saveConfig);
-        builder.setClean(() -> halconfigParser.cleanLocalFiles(configPath));
-
-        return DaemonTaskHandler.submitTask(builder::build, "Edit webhook trust settings");
+    builder.setValidate(ProblemSet::new);
+    if (validate) {
+      builder.setValidate(() -> webhookService.validateWebhookTrust(deploymentName));
     }
+
+    builder.setRevert(halconfigParser::undoChanges);
+    builder.setSave(halconfigParser::saveConfig);
+    builder.setClean(() -> halconfigParser.cleanLocalFiles(configPath));
+
+    return DaemonTaskHandler.submitTask(builder::build, "Edit webhook trust settings");
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/WebhookController.java
@@ -28,6 +28,7 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.DefaultValidationSettings;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -44,8 +45,8 @@ public class WebhookController {
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, Webhook> getWebhook(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
     DaemonResponse.StaticRequestBuilder<Webhook> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> webhookService.getWebhook(deploymentName));
 
@@ -59,8 +60,8 @@ public class WebhookController {
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setWebhook(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity,
       @RequestBody Object rawWebhook) {
     Webhook webhook = objectMapper.convertValue(rawWebhook, Webhook.class);
 
@@ -85,8 +86,8 @@ public class WebhookController {
 
   @RequestMapping(value = "/trust/", method = RequestMethod.GET)
   DaemonTask<Halconfig, WebhookTrust> getWebhookTrust(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity) {
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity) {
     DaemonResponse.StaticRequestBuilder<WebhookTrust> builder = new DaemonResponse.StaticRequestBuilder<>(
         () -> webhookService.getWebhookTrust(deploymentName));
 
@@ -100,8 +101,8 @@ public class WebhookController {
 
   @RequestMapping(value = "/trust/", method = RequestMethod.PUT)
   DaemonTask<Halconfig, Void> setWebhookTrust(@PathVariable String deploymentName,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity,
       @RequestBody Object rawWebhookTrust) {
     WebhookTrust webhookTrust = objectMapper.convertValue(rawWebhookTrust, WebhookTrust.class);
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/DefaultValidationSettings.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/DefaultValidationSettings.java
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.controllers.v1;
+package com.netflix.spinnaker.halyard.models.v1;
 
-public class DefaultControllerValues {
+public class DefaultValidationSettings {
   public final static String validate = "false";
   public final static String severity = "WARNING";
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/ValidationSettings.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/ValidationSettings.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.models.v1;
+
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import lombok.Data;
+
+@Data
+public class ValidationSettings {
+  private boolean validate = false;
+  private Problem.Severity severity = Problem.Severity.WARNING;
+}

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/ValidationSettingsHandler.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/ValidationSettingsHandler.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.models.v1;
+
+import com.netflix.spinnaker.halyard.controllers.v1.DefaultControllerValues;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@ControllerAdvice
+public class ValidationSettingsHandler {
+  @ModelAttribute
+  public ValidationSettings controllerValues(
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity
+  ) {
+    ValidationSettings values = new ValidationSettings();
+    values.setValidate(validate);
+    values.setSeverity(severity);
+    return values;
+  }
+}

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/ValidationSettingsHandler.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/models/v1/ValidationSettingsHandler.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.halyard.models.v1;
 
-import com.netflix.spinnaker.halyard.controllers.v1.DefaultControllerValues;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -26,8 +25,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 public class ValidationSettingsHandler {
   @ModelAttribute
   public ValidationSettings controllerValues(
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.validate) boolean validate,
-      @RequestParam(required = false, defaultValue = DefaultControllerValues.severity) Problem.Severity severity
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.validate) boolean validate,
+      @RequestParam(required = false, defaultValue = DefaultValidationSettings.severity) Problem.Severity severity
   ) {
     ValidationSettings values = new ValidationSettings();
     values.setValidate(validate);

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/util/v1/GenericGetRequest.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/util/v1/GenericGetRequest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.util.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.core.DaemonResponse;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import lombok.Builder;
+
+import java.util.function.Supplier;
+
+@Builder
+public class GenericGetRequest<T> {
+  private Supplier<T> getter;
+  private Supplier<ProblemSet> validator;
+  private String description;
+
+  public DaemonTask<Halconfig, T> execute(ValidationSettings validationSettings) {
+    DaemonResponse.StaticRequestBuilder<T> builder = new DaemonResponse.StaticRequestBuilder<>(getter);
+    builder.setSeverity(validationSettings.getSeverity());
+    if (validationSettings.isValidate()) {
+      builder.setValidateResponse(validator);
+    }
+    return DaemonTaskHandler.submitTask(builder::build, description);
+  }
+}


### PR DESCRIPTION
There's a lot of duplicated code in the halyard controllers; make it easier to configure new endpoints by factoring duplicated code into a `GenericGetRequest`.  The net number of lines removed is not huge (net negative of ~10 lines per controller) but this should make it conceptually a lot easier to write a new controller.  I plan to do a similar thing for update requests where there is actually a lot more duplicated code.  The goal is to lower the barrier for adding config parameters to halyard.