### PR TITLE
fix(config/orca): set global.spinnaker.timezone for orca

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpinnakerProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpinnakerProfileFactory.java
@@ -26,6 +26,7 @@ public class SpinnakerProfileFactory extends StringBackedProfileFactory {
   @Override
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
     profile.appendContents(yamlToString(endpoints));
+    profile.appendContents("global.spinnaker.timezone: " + deploymentConfiguration.getTimezone());
   }
 
   @Override


### PR DESCRIPTION
- Fixes bug where Restrict Execution During Time Window stages always calculate whether the current time is within range using PST rather than a user's configured timezone