### PR TITLE
chore(dockerfile): decreased docker image size

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+Dockerfile*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM openjdk:8
+FROM openjdk:8 as build
 
-MAINTAINER delivery-engineering@netflix.com
+LABEL maintainer="delivery-engineering@netflix.com"
 
 ENV KUBECTL_RELEASE=1.10.3
 ENV AWS_BINARY_RELEASE_DATE=2018-07-26
@@ -9,13 +9,14 @@ COPY . workdir/
 
 WORKDIR workdir
 
-RUN GRADLE_USER_HOME=cache ./gradlew installDist -x test -Prelease.useLastTag=true && \
-  cp -r ./halyard-web/build/install/halyard /opt && \
-  cd .. && \
-  rm -rf workdir
+RUN GRADLE_USER_HOME=cache ./gradlew installDist -x test -Prelease.useLastTag=true
+
+FROM openjdk:8
+
+COPY --from=build /workdir/halyard-web/build/install/halyard /opt/halyard
 
 RUN echo '#!/usr/bin/env bash' | tee /usr/local/bin/hal > /dev/null && \
-  echo '/opt/halyard/bin/hal "$@"' | tee /usr/local/bin/hal > /dev/null
+    echo '/opt/halyard/bin/hal "$@"' | tee /usr/local/bin/hal > /dev/null
 
 RUN chmod +x /usr/local/bin/hal
 
@@ -24,8 +25,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECT
     mv ./kubectl /usr/local/bin/kubectl
 
 RUN curl -o aws-iam-authenticator https://amazon-eks.s3-us-west-2.amazonaws.com/${KUBECTL_RELEASE}/${AWS_BINARY_RELEASE_DATE}/bin/linux/amd64/aws-iam-authenticator && \
-  chmod +x ./aws-iam-authenticator && \
-  mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
+    chmod +x ./aws-iam-authenticator && \
+    mv ./aws-iam-authenticator /usr/local/bin/aws-iam-authenticator
 
 ENV PATH "$PATH:/usr/local/bin/aws-iam-authenticator"
 


### PR DESCRIPTION
Removed depricated mantainer instruction, replaced with `LABEL maintainer=`

Changed to multi-stage dockerfile as the rm -rf workdir doesn’t delete the workdir from the prior layer. This cuts down the final docker image size by 700Mb.
https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds