### PR TITLE
Allow specifying of serviceAccountName

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -31,4 +31,5 @@ public class KubernetesSettings {
   List<String> imagePullSecrets = new ArrayList<>();
   Map<String, String> podAnnotations = new HashMap<>();
   List<ConfigSource> volumes = new ArrayList<>();
+  String serviceAccountName = null;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -263,6 +263,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         .addBinding("initContainers", initContainers)
         .addBinding("hostAliases", hostAliases)
         .addBinding("imagePullSecrets", settings.getKubernetes().getImagePullSecrets())
+        .addBinding("serviceAccountName", settings.getKubernetes().getServiceAccountName())
         .addBinding("terminationGracePeriodSeconds", terminationGracePeriodSeconds())
         .addBinding("volumes", volumes);
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
@@ -29,6 +29,10 @@
   ],
   {% endif %}
 
+  {% if serviceAccountName != null %}
+  "serviceAccountName": {{ serviceAccountName }},
+  {% endif %}
+
   "terminationGracePeriodSeconds": {{ terminationGracePeriodSeconds }},
 
   "volumes": [


### PR DESCRIPTION
At least in OpenShift, we need to run certain Services under a
serviceAccountName, in order to be able to run containers under
anyuid.