### PR TITLE
feat(artifacts): Allow config of artifact templates

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/ArtifactTemplate.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/ArtifactTemplate.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.artifacts;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class ArtifactTemplate extends Node {
+  private String name;
+  @LocalFile
+  private String templatePath;
+
+  @Override
+  public String getNodeName() {
+    return name;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Artifacts.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Artifacts.java
@@ -18,6 +18,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.model.v1.artifacts.ArtifactTemplate;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.bitbucket.BitbucketArtifactProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.gcs.GcsArtifactProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.github.GitHubArtifactProvider;
@@ -30,7 +31,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 import java.lang.reflect.Field;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 @EqualsAndHashCode(callSuper = true)
@@ -44,6 +47,7 @@ public class Artifacts extends Node {
   HttpArtifactProvider http = new HttpArtifactProvider();
   HelmArtifactProvider helm = new HelmArtifactProvider();
   S3ArtifactProvider s3 = new S3ArtifactProvider();
+  List<ArtifactTemplate> templates = new ArrayList<>();
 
   @Override
   public String getNodeName() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.Artifacts;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Notifications;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsubs;
@@ -56,6 +57,12 @@ public class EchoProfileFactory extends SpringProfileFactory {
       profile.appendContents(yamlToString(new PubsubWrapper(pubsubs)));
     }
 
+    Artifacts artifacts = deploymentConfiguration.getArtifacts();
+    if (artifacts != null) {
+      files.addAll(backupRequiredFiles(artifacts, deploymentConfiguration.getName()));
+      profile.appendContents(yamlToString(new ArtifactWrapper(artifacts)));
+    }
+
     profile.appendContents(profile.getBaseContents())
         .setRequiredFiles(files);
   }
@@ -66,6 +73,15 @@ public class EchoProfileFactory extends SpringProfileFactory {
 
     PubsubWrapper(Pubsubs pubsub) {
       this.pubsub = pubsub;
+    }
+  }
+
+  @Data
+  private static class ArtifactWrapper {
+    private Artifacts artifacts;
+
+    ArtifactWrapper(Artifacts artifacts) {
+      this.artifacts = artifacts;
     }
   }
 }


### PR DESCRIPTION
Add the ability for Halyard to parse the configuration of artifact templates and write them to echo.yml; the commands to write the config using hal commands will be in a separate change.