### PR TITLE
fix(provider/dcos): Fix deserialization error for DCOSAccount.Cluster…

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,3 @@
 lombok.nonNull.exceptionType = IllegalArgumentException
 lombok.accessors.chain = true
+lombok.anyConstructor.addConstructorProperties=true


### PR DESCRIPTION
…Credential

Attempting to add a DC/OS account fails with the error 

```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Cannot construct instance of `com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount$ClusterCredential` (no Creators, like default construct, exist): cannot deserialize from Object value (no delegate- or property-based Creator)
 at [Source: UNKNOWN; line: -1, column: -1] (through reference chain: com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount["clusters"]->java.util.ArrayList[0])
```

This appears to have been introduced with https://github.com/spinnaker/halyard/commit/b5a09b738e1714d6deee651f5f6a6921312abecc.  I think that it may be due to changing the version of lombok and https://github.com/rzwitserloot/lombok/issues/1563.  The change in this PR is the one suggested in that issue as a way to resolve the problem and it seems to work here.

Disclaimer:

I know very little about lombok and don't know if this could break anything else.  I only validated adding a DC/OS account and ran the tests for the project.   I'm also not clear why this causes an issue only for `DCOSAccount.ClusterCredential` when it appears similar to many of the other `@Data` lombok classes in the project that aren't affected by this issue.   