### PR TITLE
feat(deploy/kubernetes) - add ability for sidecars to be applied by canonical name

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/SpinnakerService.java
@@ -75,6 +75,10 @@ abstract public class SpinnakerService<T> implements HasServiceSettings<T> {
     return getType().getCanonicalName();
   }
 
+  public String getBaseCanonicalName() {
+    return getType().getBaseType().getCanonicalName();
+  }
+
   public String getSpinnakerStagingPath(String deploymentName) {
     return halconfigDirectoryStructure.getStagingPath(deploymentName).toString();
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -155,44 +155,8 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
 
     List<ConfigSource> configSources = stageConfig(details, resolvedConfiguration);
 
-    List<SidecarConfig> sidecarConfigs = details.getDeploymentConfiguration()
-        .getDeploymentEnvironment()
-        .getSidecars()
-        .getOrDefault(getService().getServiceName(), new ArrayList<>());
-
-    List<String> initContainers = details.getDeploymentConfiguration()
-        .getDeploymentEnvironment()
-        .getInitContainers()
-        .getOrDefault(getService().getServiceName(), new ArrayList<>())
-        .stream()
-        .map(o -> {
-          try {
-            return getObjectMapper().writeValueAsString(o);
-          } catch (JsonProcessingException e) {
-            throw new HalException(Problem.Severity.FATAL, "Invalid init container format: " + e.getMessage(), e);
-          }
-        }).collect(Collectors.toList());
-
-    if (initContainers.isEmpty()) {
-      initContainers = null;
-    }
-
-    List<String> hostAliases = details.getDeploymentConfiguration()
-        .getDeploymentEnvironment()
-        .getHostAliases()
-        .getOrDefault(getService().getServiceName(), new ArrayList<>())
-        .stream()
-        .map(o -> {
-          try {
-            return getObjectMapper().writeValueAsString(o);
-          } catch (JsonProcessingException e) {
-            throw new HalException(Problem.Severity.FATAL, "Invalid host alias format: " + e.getMessage(), e);
-          }
-        }).collect(Collectors.toList());
-
-    if (hostAliases.isEmpty()) {
-      hostAliases = null;
-    }
+    //attempt to get the service name specific sidecars first
+    List<SidecarConfig> sidecarConfigs = getSidecarConfigs(details);
 
     configSources.addAll(sidecarConfigs.stream()
         .filter(c -> StringUtils.isNotEmpty(c.getMountPath()))
@@ -260,8 +224,8 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
 
     TemplatedResource podSpec = new JinjaJarResource("/kubernetes/manifests/podSpec.yml")
         .addBinding("containers", containers)
-        .addBinding("initContainers", initContainers)
-        .addBinding("hostAliases", hostAliases)
+        .addBinding("initContainers", getInitContainers(details))
+        .addBinding("hostAliases", getHostAliases(details))
         .addBinding("imagePullSecrets", settings.getKubernetes().getImagePullSecrets())
         .addBinding("serviceAccountName", settings.getKubernetes().getServiceAccountName())
         .addBinding("terminationGracePeriodSeconds", terminationGracePeriodSeconds())
@@ -481,6 +445,83 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     }
 
     return configSources;
+  }
+
+  default List<SidecarConfig> getSidecarConfigs(AccountDeploymentDetails<KubernetesAccount> details) {
+    //attempt to get the service name specific sidecars first
+    List<SidecarConfig> sidecarConfigs = details.getDeploymentConfiguration()
+            .getDeploymentEnvironment()
+            .getSidecars()
+            .getOrDefault(getService().getServiceName(), new ArrayList<>());
+
+    if(sidecarConfigs.isEmpty()) {
+      sidecarConfigs = details.getDeploymentConfiguration()
+              .getDeploymentEnvironment()
+              .getSidecars()
+              .getOrDefault(getService().getBaseCanonicalName(), new ArrayList<>());
+    }
+
+    return sidecarConfigs;
+  }
+
+  default List<String> getHostAliases(AccountDeploymentDetails<KubernetesAccount> details) {
+    //attempt to get the service name specific sidecars first
+    List<Map> hostAliasesConfig = details.getDeploymentConfiguration()
+            .getDeploymentEnvironment()
+            .getHostAliases()
+            .getOrDefault(getService().getServiceName(), new ArrayList<>());
+
+    if(hostAliasesConfig.isEmpty()) {
+      hostAliasesConfig = details.getDeploymentConfiguration()
+              .getDeploymentEnvironment()
+              .getHostAliases()
+              .getOrDefault(getService().getBaseCanonicalName(), new ArrayList<>());
+    }
+
+    List<String> hostAliases = hostAliasesConfig
+            .stream()
+            .map(o -> {
+              try {
+                return getObjectMapper().writeValueAsString(o);
+              } catch (JsonProcessingException e) {
+                throw new HalException(Problem.Severity.FATAL, "Invalid host alias format: " + e.getMessage(), e);
+              }
+            }).collect(Collectors.toList());
+
+    if (hostAliases.isEmpty()) {
+      hostAliases = null;
+    }
+    return hostAliases;
+  }
+
+  default List<String> getInitContainers(AccountDeploymentDetails<KubernetesAccount> details) {
+    List<Map> initContainersConfig = details.getDeploymentConfiguration()
+            .getDeploymentEnvironment()
+            .getInitContainers()
+            .getOrDefault(getService().getServiceName(), new ArrayList<>());
+
+    if(initContainersConfig.isEmpty()) {
+      initContainersConfig = details.getDeploymentConfiguration()
+              .getDeploymentEnvironment()
+              .getInitContainers()
+              .getOrDefault(getService().getBaseCanonicalName(), new ArrayList<>());
+    }
+
+    List<String> initContainers = initContainersConfig
+            .stream()
+            .map(o -> {
+              try {
+                return getObjectMapper().writeValueAsString(o);
+              } catch (JsonProcessingException e) {
+                throw new HalException(Problem.Severity.FATAL, "Invalid init container format: " + e.getMessage(), e);
+              }
+            }).collect(Collectors.toList());
+
+    if (initContainers.isEmpty()) {
+      initContainers = null;
+    }
+
+    return initContainers;
   }
 
   default List<SidecarService> getSidecars(SpinnakerRuntimeSettings runtimeSettings) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -154,8 +154,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     String namespace = getNamespace(settings);
 
     List<ConfigSource> configSources = stageConfig(details, resolvedConfiguration);
-
-    //attempt to get the service name specific sidecars first
+    
     List<SidecarConfig> sidecarConfigs = getSidecarConfigs(details);
 
     configSources.addAll(sidecarConfigs.stream()

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -488,9 +488,6 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
               }
             }).collect(Collectors.toList());
 
-    if (hostAliases.isEmpty()) {
-      hostAliases = null;
-    }
     return hostAliases;
   }
 
@@ -516,10 +513,6 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
                 throw new HalException(Problem.Severity.FATAL, "Invalid init container format: " + e.getMessage(), e);
               }
             }).collect(Collectors.toList());
-
-    if (initContainers.isEmpty()) {
-      initContainers = null;
-    }
 
     return initContainers;
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -453,7 +453,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
             .getSidecars()
             .getOrDefault(getService().getServiceName(), new ArrayList<>());
 
-    if(sidecarConfigs.isEmpty()) {
+    if (sidecarConfigs.isEmpty()) {
       sidecarConfigs = details.getDeploymentConfiguration()
               .getDeploymentEnvironment()
               .getSidecars()
@@ -470,7 +470,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
             .getHostAliases()
             .getOrDefault(getService().getServiceName(), new ArrayList<>());
 
-    if(hostAliasesConfig.isEmpty()) {
+    if (hostAliasesConfig.isEmpty()) {
       hostAliasesConfig = details.getDeploymentConfiguration()
               .getDeploymentEnvironment()
               .getHostAliases()
@@ -496,7 +496,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
             .getInitContainers()
             .getOrDefault(getService().getServiceName(), new ArrayList<>());
 
-    if(initContainersConfig.isEmpty()) {
+    if (initContainersConfig.isEmpty()) {
       initContainersConfig = details.getDeploymentConfiguration()
               .getDeploymentEnvironment()
               .getInitContainers()

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
@@ -13,7 +13,7 @@
   ],
   {% endif %}
 
-  {% if initContainers != null %}
+  {% if initContainers %}
   "initContainers": [
     {% for c in initContainers %}
     {{ c }} {% if not loop.last %} , {% endif %}
@@ -21,7 +21,7 @@
   ],
   {% endif %}
 
-  {% if hostAliases != null %}
+  {% if hostAliases %}
   "hostAliases": [
     {% for h in hostAliases %}
     {{ h }} {% if not loop.last %} , {% endif %}


### PR DESCRIPTION
Background
When using HA mode the sidecar support is hard to configure due to the differing service names. Since the configuration is done per deployment this makes managing multiple sidecars unwieldy. 

Change
Add a check for canonical name of the base service if a service specific config is not supplied.
The configuration works as follows:
Check for Service Name configs (spin-clouddriver) 
-> if not set check the canonical name (clouddriver)
-> done 

Test
Compiled and ran tests, there are no tests for this particular module, cut a custom build and applied changes via service name and canonical name