### PR TITLE
fix(cli): add password flag to password fields

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/azs/AzsEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/azs/AzsEditCommand.java
@@ -36,6 +36,7 @@ public class AzsEditCommand extends AbstractPersistentStoreEditCommand<AzsPersis
 
   @Parameter(
       names = "--storage-account-key",
+      password = true,
       description = "The key to access the Azure Storage Account used for Spinnaker's persistent data."
   )
   private String storageAccountKey;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackAddAccountCommand.java
@@ -40,6 +40,7 @@ public class OpenstackAddAccountCommand extends AbstractAddAccountCommand {
   @Parameter(
       names = "--password",
       required = true,
+      password = true,
       description = OpenstackCommandProperties.PASSWORD_DESCRIPTION
   )
   private String password;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/openstack/OpenstackEditAccountCommand.java
@@ -36,6 +36,7 @@ public class OpenstackEditAccountCommand extends AbstractEditAccountCommand<Open
 
   @Parameter(
       names = "--password",
+      password = true,
       description = OpenstackCommandProperties.PASSWORD_DESCRIPTION
   )
   private String password;


### PR DESCRIPTION
A few fields in the CLI seem to be missing the "password = true" flag.