### PR TITLE
fix(deploy): use curl instead of netcat on deck-start.sh

### DIFF
--- a/halyard-deploy/src/main/resources/git/deck-start.sh
+++ b/halyard-deploy/src/main/resources/git/deck-start.sh
@@ -21,7 +21,7 @@ function start() {
     2> ${LOG_DIR}/${ARTIFACT}.err \
     > ${LOG_DIR}/${ARTIFACT}.log &
 
-  while ! nc -z localhost 9000; do sleep 1; done;
+  while ! curl localhost:9000 > /dev/null 2>&1; do sleep 1; done;
   ps -aef | grep [n]ode.*/deck/.*/webpack-dev-server | awk '{print $2}' > $PID_FILE
   popd
 }


### PR DESCRIPTION
Occasionally, MacOSX hangs indefenitely when using `nc` command to
check wether deck is already alive (always fail). This prevents the rest of
services to start normally.
This patch replaces `nc` by `curl` removing one dependency and works
reliably on both linux/mac platforms.

Signed-off-by: Xavi León <xavi.leon@schibsted.com>