### PR TITLE
feat(deploy/kubernetes): add readinessCommandExtras to kubernetes service settings

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -32,4 +32,5 @@ public class KubernetesSettings {
   Map<String, String> podAnnotations = new HashMap<>();
   List<ConfigSource> volumes = new ArrayList<>();
   String serviceAccountName = null;
+  String readinessCommandExtras = null;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -64,7 +64,6 @@ public class ServiceSettings {
   Integer targetSize;
   Boolean skipLifeCycleManagement;
   String baseUrl;
-  String readinessCommandExtras;
 
   public ServiceSettings() {}
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -64,6 +64,7 @@ public class ServiceSettings {
   Integer targetSize;
   Boolean skipLifeCycleManagement;
   String baseUrl;
+  String readinessCommandExtras;
 
   public ServiceSettings() {}
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -89,7 +89,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default List<String> getReadinessExecCommand(ServiceSettings settings) {
-    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint());
+    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint(), settings.getReadinessCommandExtras);
   }
 
   default boolean hasPreStopCommand() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -89,7 +89,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default List<String> getReadinessExecCommand(ServiceSettings settings) {
-    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint(), settings.getReadinessCommandExtras);
+    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint(), settings.getReadinessCommandExtras());
   }
 
   default boolean hasPreStopCommand() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -89,7 +89,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default List<String> getReadinessExecCommand(ServiceSettings settings) {
-    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint(), settings.getReadinessCommandExtras());
+    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint(), settings.getKubernetes().getReadinessCommandExtras());
   }
 
   default boolean hasPreStopCommand() {


### PR DESCRIPTION
allow adding `readinessCommandExtras: --no-check-certificate` when
the schema is https to prevent healthcheck failing with

  ssl_client: localhost: certificate verification failed: unable to get local issuer certificate
  wget: error getting response: Connection reset by peer