### PR TITLE
switch k8s readiness check from exec to httpGet

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM openjdk:8 as build
 
 LABEL maintainer="delivery-engineering@netflix.com"
 
-ENV KUBECTL_RELEASE=1.10.3
+ENV KUBECTL_RELEASE=1.12.5
 ENV AWS_BINARY_RELEASE_DATE=2018-07-26
 
 COPY . workdir/

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@ FROM openjdk:8
 
 MAINTAINER delivery-engineering@netflix.com
 
-ENV KUBECTL_RELEASE=1.10.3
+ENV KUBECTL_RELEASE=1.12.5
 ENV AWS_BINARY_RELEASE_DATE=2018-07-26
 
 COPY . workdir/

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -88,10 +88,6 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     return true;
   }
 
-  default List<String> getReadinessExecCommand(ServiceSettings settings) {
-    return Arrays.asList("wget", "--no-check-certificate", "--spider", "-q", settings.getScheme() + "://localhost:" + settings.getPort() + settings.getHealthEndpoint());
-  }
-
   default boolean hasPreStopCommand() {
     return false;
   }
@@ -349,8 +345,9 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
 
     TemplatedResource probe;
     if (StringUtils.isNotEmpty(settings.getHealthEndpoint())) {
-      probe = new JinjaJarResource("/kubernetes/manifests/execReadinessProbe.yml");
-      probe.addBinding("command", getReadinessExecCommand(settings));
+      probe = new JinjaJarResource("/kubernetes/manifests/httpReadinessProbe.yml");
+      probe.addBinding("port", settings.getPort());
+      probe.addBinding("path", settings.getHealthEndpoint());
     } else {
       probe = new JinjaJarResource("/kubernetes/manifests/tcpSocketReadinessProbe.yml");
       probe.addBinding("port", settings.getPort());


### PR DESCRIPTION
services that have a healthcheck defined were getting an `exec` check
for the kubernetes readiness check and were running a wget command
against localhost to verify health.  Kubernetes has the httpGet option
for readiness check that does this in a more k8s native way and doesn't
rely on running a command inside the pod.

This is especially important for people that want to put spinnaker
behind an ingress controller or istio as by default many ingress controllers
look for a http or tcp socket readiness check to be used by the cloud
loadbalancer to ensure the service is up.

From Ingress
[documentation](https://kubernetes.io/docs/concepts/services-networking/ingress/#loadbalancing):

```
It’s also worth noting that even though health checks are not exposed directly through the ingress, there exist parallel concepts in Kubernetes such as readiness probes which allow you to achieve the same end result. Please review the controller specific docs to see how they handle health checks ( nginx, GCE).

```

The Google Ingress controller requires a http/tcp based readiness check
and the nginx Ingress controller can utilize them as well.

fixes https://github.com/spinnaker/spinnaker/issues/3864

Signed-off-by: Paul Czarkowski <username.taken@gmail.com>