### PR TITLE
feat(provider/azure): Add regions support for Azure provider

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4648,11 +4648,11 @@ hal config provider azure account add ACCOUNT [parameters]
  * `--packer-storage-account`: The storage account to use if baking images with Packer.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
+ * `--regions`: (*Default*: `[westus, eastus]`) The Azure regions this Spinnaker account will manage.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--subscription-id`: (*Required*) The subscriptionId that your service principal is assigned to.
  * `--tenant-id`: (*Required*) The tenantId that your service principal is assigned to.
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
- * `--regions`: (*Default*: `['westus', 'eastus']`) The Azure regions this Spinnaker account will manage.
 
 
 ---
@@ -4698,6 +4698,7 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--packer-storage-account`: The storage account to use if baking images with Packer.
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
+ * `--regions`: The Azure regions this Spinnaker account will manage.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
  * `--remove-write-permission`: Remove this permission to from list of write permissions.
@@ -4705,7 +4706,6 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--subscription-id`: The subscriptionId that your service principal is assigned to.
  * `--tenant-id`: The tenantId that your service principal is assigned to.
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.
- * `--regions`: The Azure regions this Spinnaker account will manage.
 
 
 ---

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -4652,6 +4652,7 @@ hal config provider azure account add ACCOUNT [parameters]
  * `--subscription-id`: (*Required*) The subscriptionId that your service principal is assigned to.
  * `--tenant-id`: (*Required*) The tenantId that your service principal is assigned to.
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
+ * `--regions`: (*Default*: `['westus', 'eastus']`) The Azure regions this Spinnaker account will manage.
 
 
 ---
@@ -4704,6 +4705,7 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--subscription-id`: The subscriptionId that your service principal is assigned to.
  * `--tenant-id`: The tenantId that your service principal is assigned to.
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.
+ * `--regions`: The Azure regions this Spinnaker account will manage.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
@@ -105,7 +105,7 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
   @Override
   protected Account buildAccount(String accountName) {
     // Add default regions if user not specified
-    if(regions.size() == 0) {
+    if (regions.size() == 0) {
       regions.add("westus");
       regions.add("eastus");
     }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
@@ -21,6 +21,11 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Parameters(separators = "=")
 class AzureAddAccountCommand extends AbstractAddAccountCommand {
@@ -89,8 +94,22 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
   )
   private String packerStorageAccount;
 
+  @Parameter(
+      names = "--regions",
+      variableArity = true,
+      description = AzureCommandProperties.REGIONS_DESCRIPTION
+  )
+  private List<String> regions = new ArrayList<>();
+
+
   @Override
   protected Account buildAccount(String accountName) {
+    // Add default regions if user not specified
+    if(regions.size() == 0) {
+      regions.add("westus");
+      regions.add("eastus");
+    }
+
     return ((AzureAccount) new AzureAccount().setName(accountName))
         .setClientId(clientId)
         .setAppKey(appKey)
@@ -100,7 +119,8 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
         .setDefaultResourceGroup(defaultResourceGroup)
         .setDefaultKeyVault(defaultKeyVault)
         .setPackerResourceGroup(packerResourceGroup)
-        .setPackerStorageAccount(packerStorageAccount);
+        .setPackerStorageAccount(packerStorageAccount)
+        .setRegions(regions);
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureAccoun
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -99,16 +100,11 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
       variableArity = true,
       description = AzureCommandProperties.REGIONS_DESCRIPTION
   )
-  private List<String> regions = new ArrayList<>();
+  private List<String> regions = Arrays.asList("westus", "eastus");
 
 
   @Override
   protected Account buildAccount(String accountName) {
-    // Add default regions if user not specified
-    if (regions.size() == 0) {
-      regions.add("westus");
-      regions.add("eastus");
-    }
 
     return ((AzureAccount) new AzureAccount().setName(accountName))
         .setClientId(clientId)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
@@ -100,7 +100,7 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
       variableArity = true,
       description = AzureCommandProperties.REGIONS_DESCRIPTION
   )
-  private List<String> regions = Arrays.asList("westus", "eastus");
+  private List<String> regions = new ArrayList<String>(Arrays.asList("westus", "eastus"));
 
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
@@ -43,5 +43,5 @@ class AzureCommandProperties {
 
   static final String IMAGE_VERSION_DESCRIPTION = "The version of your base image. This defaults to 'latest' if not specified.";
 
-  static final String REGIONS_DESCRIPTION = "The Azure regions this Spinnaker account will manage. If not specified, the default value is 'eastus,westus'";
+  static final String REGIONS_DESCRIPTION = "The Azure regions this Spinnaker account will manage.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
@@ -43,5 +43,5 @@ class AzureCommandProperties {
 
   static final String IMAGE_VERSION_DESCRIPTION = "The version of your base image. This defaults to 'latest' if not specified.";
 
-  static final String REGIONS_DESCRIPTION = "The Azure regions this Spinnaker account will manage.";
+  static final String REGIONS_DESCRIPTION = "The Azure regions this Spinnaker account will manage. If not specified, the default value is 'eastus,westus'";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
@@ -42,4 +42,6 @@ class AzureCommandProperties {
   static final String IMAGE_SKU_DESCRIPTION = "The SKU for your base image. See https://aka.ms/azspinimage to get a list of images.";
 
   static final String IMAGE_VERSION_DESCRIPTION = "The version of your base image. This defaults to 'latest' if not specified.";
+
+  static final String REGIONS_DESCRIPTION = "The Azure regions this Spinnaker account will manage.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureEditAccountCommand.java
@@ -21,6 +21,10 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Parameters(separators = "=")
 public class AzureEditAccountCommand extends AbstractEditAccountCommand<AzureAccount> {
@@ -83,6 +87,13 @@ public class AzureEditAccountCommand extends AbstractEditAccountCommand<AzureAcc
   )
   private String packerStorageAccount;
 
+  @Parameter(
+      names = "--regions",
+      variableArity = true,
+      description = AzureCommandProperties.REGIONS_DESCRIPTION
+  )
+  private List<String> regions;
+
   @Override
   protected Account editAccount(AzureAccount account) {
     account.setClientId(isSet(clientId) ? clientId : account.getClientId());
@@ -94,6 +105,12 @@ public class AzureEditAccountCommand extends AbstractEditAccountCommand<AzureAcc
     account.setDefaultKeyVault(isSet(defaultKeyVault) ? defaultKeyVault : account.getDefaultKeyVault());
     account.setPackerResourceGroup(isSet(packerResourceGroup) ? packerResourceGroup : account.getPackerResourceGroup());
     account.setPackerStorageAccount(isSet(packerStorageAccount) ? packerStorageAccount : account.getPackerStorageAccount());
+
+    try {
+      account.setRegions(regions);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Set either --regions or --[add/remove]-region");
+    }
     
     return account;
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureEditAccountCommand.java
@@ -109,7 +109,7 @@ public class AzureEditAccountCommand extends AbstractEditAccountCommand<AzureAcc
     try {
       account.setRegions(regions);
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Set either --regions or --[add/remove]-region");
+      throw new IllegalArgumentException("Set --regions");
     }
     
     return account;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureAccount.java
@@ -21,6 +21,9 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class AzureAccount extends Account {
@@ -33,4 +36,5 @@ public class AzureAccount extends Account {
   private String defaultKeyVault;
   private String packerResourceGroup;
   private String packerStorageAccount;
+  private List<String> regions = new ArrayList<>();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureProvider.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.azure;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.HasImageProvider;
-import lombok.Data;
 
 public class AzureProvider extends HasImageProvider<AzureAccount, AzureBakeryDefaults> {
   @Override

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureProvider.java
@@ -20,11 +20,6 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.HasImageProvider;
 import lombok.Data;
 
 public class AzureProvider extends HasImageProvider<AzureAccount, AzureBakeryDefaults> {
-//  @Data
-//  public static class AzureRegion {
-//    String name;
-//  }
-
   @Override
   public ProviderType providerType() {
     return ProviderType.AZURE;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureProvider.java
@@ -17,8 +17,14 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.azure;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.HasImageProvider;
+import lombok.Data;
 
 public class AzureProvider extends HasImageProvider<AzureAccount, AzureBakeryDefaults> {
+//  @Data
+//  public static class AzureRegion {
+//    String name;
+//  }
+
   @Override
   public ProviderType providerType() {
     return ProviderType.AZURE;


### PR DESCRIPTION
Currently halyard doesn't have command to configure regions for Azure provider.
Add regions property in hal-config and default value "eastus","westus"

Command | result
-- | --
Hal config provider azure account add/edit --help | --regions       The Azure regions this Spinnaker   account will manage.
hal config provider azure account add/edit   my-azure-account --regions a,b | regions:           - a           - b
Hal config provider azure account add (without setting regions) | regions:           - westus           - eastus

