### PR TITLE
fix(kayenta/setorder): Make Kayenta canary account supported types ordered.

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/aws/AwsCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/aws/AwsCanaryAccount.java
@@ -24,8 +24,8 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -39,5 +39,5 @@ public class AwsCanaryAccount extends AbstractCanaryAccount implements Cloneable
   private String endpoint;
   private String accessKeyId;
   @Secret private String secretAccessKey;
-  private Set<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes = new HashSet<>();
+  private SortedSet<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes = new TreeSet<>();
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
@@ -31,8 +31,8 @@ import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -44,7 +44,7 @@ public class GoogleCanaryAccount extends AbstractCanaryAccount implements Clonea
   private String bucket;
   private String bucketLocation;
   private String rootFolder = "kayenta";
-  private Set<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes = new HashSet<>();
+  private SortedSet<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes = new TreeSet<>();
 
   @JsonIgnore
   public GoogleNamedAccountCredentials getNamedAccountCredentials(String version, ConfigProblemSetBuilder p) {


### PR DESCRIPTION
This ensures that the generated kayenta.yaml keeps the same order for
supported types.