### PR TITLE
fix(deployment): Only include baseUrl and enabled for each service in spinnaker.yml

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerRuntimeSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/SpinnakerRuntimeSettings.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings.SlimServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService.Type;
 import java.util.Collections;
@@ -62,5 +63,17 @@ public class SpinnakerRuntimeSettings {
 
   public boolean serviceIsEnabled(Type type) {
     return services.containsKey(type) && services.get(type).getEnabled();
+  }
+
+  public SlimRuntimeSettings slim() {
+    SlimRuntimeSettings srs = new SlimRuntimeSettings();
+    services.forEach((t, service) -> srs.services.put(t, service.slim()));
+    return srs;
+  }
+
+  @Data
+  public static class SlimRuntimeSettings {
+    @JsonPropertyOrder(alphabetic = true)
+    private Map<Type, SlimServiceSettings> services = new HashMap<>();
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpinnakerProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpinnakerProfileFactory.java
@@ -25,7 +25,7 @@ import org.springframework.stereotype.Component;
 public class SpinnakerProfileFactory extends StringBackedProfileFactory {
   @Override
   protected void setProfile(Profile profile, DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
-    profile.appendContents(yamlToString(endpoints));
+    profile.appendContents(yamlToString(endpoints.slim()));
     profile.appendContents("global.spinnaker.timezone: " + deploymentConfiguration.getTimezone());
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import lombok.AllArgsConstructor;
 import lombok.Data;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
@@ -165,5 +166,16 @@ public class ServiceSettings {
           .setHost(getAddress()));
     }
     return Optional.empty();
+  }
+
+  public SlimServiceSettings slim() {
+    return new SlimServiceSettings(getBaseUrl(), getEnabled());
+  }
+
+  @Data
+  @AllArgsConstructor
+  public static class SlimServiceSettings {
+    private String baseUrl;
+    private Boolean enabled;
   }
 }


### PR DESCRIPTION
This prevents unnecessary churn in each Kubernetes Deployment object when Spinnaker is deployed. The root cause was:

1. Things like `targetSize` (a field inside `ServiceSettings`) was changed... 
1. which caused the file hash of `spinnaker.yml` to change...
1. which caused the Deployment object to be updated...
1. which invoked a Rollout by Kuberenetes...
1. which rebooted every service.