### PR TITLE
fix(update-halyard): restart daemon on upgrade

### DIFF
--- a/startup/debian/update-halyard
+++ b/startup/debian/update-halyard
@@ -69,6 +69,10 @@ function configure_bash_completion() {
   fi
 }
 
+function kill_daemon() {
+    pkill -f '/opt/halyard/lib/halyard-web' || true
+}
+
 function install_halyard() {
   TEMPDIR=$(mktemp -d installhalyard.XXXX)
   pushd $TEMPDIR
@@ -92,6 +96,9 @@ process_args $@
 configure_defaults
 
 install_halyard
+
+echo "Install completed... restarting Halyard"
+kill_daemon
 
 su -l -c "hal -v" -s /bin/bash $HAL_USER
 


### PR DESCRIPTION
Not using `hal shutdown`, since old version may not support the command.