### PR TITLE
fix(rosco): Fix backup of service account key

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RoscoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/RoscoProfileFactory.java
@@ -105,6 +105,8 @@ public class RoscoProfileFactory extends SpringProfileFactory {
 
     augmentProvidersBaseImages(providers, otherProviders);
 
+    List<String> files = backupRequiredFiles(providers, deploymentConfiguration.getName());
+
     Map imageProviders = new TreeMap();
 
     NodeIterator iterator = providers.getChildren();
@@ -121,7 +123,6 @@ public class RoscoProfileFactory extends SpringProfileFactory {
       profile.appendContents(yamlParser.dump(imageProviders));
     }
 
-    List<String> files = backupRequiredFiles(providers, deploymentConfiguration.getName());
     profile.appendContents(profile.getBaseContents())
         .setRequiredFiles(files);
   }


### PR DESCRIPTION
The rosco profile factory is currently writing out the account configuration before local files are backed up to the halyard staging directory. This means the rosco profile contains a reference to the key at the raw file location, which may not be readable by Spinnaker.

Fixes a bug introduced in #1183, which was caught by our integration tests.