### PR TITLE
fix(kubernetes): move kube specific setting to kubernetes config

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
@@ -124,7 +124,6 @@ abstract public class ClouddriverService extends SpringService<ClouddriverServic
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulClientService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulClientService.java
@@ -110,7 +110,6 @@ abstract public class ConsulClientService extends SpinnakerService<ConsulApi> im
     // Host is what's bound to by the service.
     String host = "0.0.0.0";
     String scheme = "http";
-    Boolean useExecHealthCheck = true;
     String healthEndpoint = null;
     Boolean enabled = true;
     Boolean safeToUpdate = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulServerService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConsulServerService.java
@@ -65,7 +65,6 @@ abstract public class ConsulServerService extends SpinnakerService<ConsulApi> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = false;
     Boolean monitored = false;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/DeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/DeckService.java
@@ -114,7 +114,6 @@ abstract public class DeckService extends SpinnakerService<DeckService.Deck> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = null;
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = false;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/EchoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/EchoService.java
@@ -86,7 +86,6 @@ abstract public class EchoService extends SpringService<EchoService.Echo> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/FiatService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/FiatService.java
@@ -86,7 +86,6 @@ abstract public class FiatService extends SpringService<FiatService.Fiat> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
@@ -113,7 +113,6 @@ abstract public class Front50Service extends SpringService<Front50Service.Front5
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/GateService.java
@@ -111,7 +111,6 @@ abstract public class GateService extends SpringService<GateService.Gate> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/IgorService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/IgorService.java
@@ -86,7 +86,6 @@ abstract public class IgorService extends SpringService<IgorService.Igor> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KayentaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KayentaService.java
@@ -132,7 +132,6 @@ abstract public class KayentaService extends SpringService<KayentaService.Kayent
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -35,4 +35,5 @@ public class KubernetesSettings {
   String serviceAccountName = null;
   String serviceType = "ClusterIP";
   String nodePort = null;
+  Boolean useExecHealthCheck = true;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -114,7 +114,6 @@ abstract public class OrcaService extends SpringService<OrcaService.Orca> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RedisService.java
@@ -63,7 +63,6 @@ abstract public class RedisService extends SpinnakerService<Jedis> {
     String host = "0.0.0.0";
     String scheme = "redis";
     String healthEndpoint = null;
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = false;
     Boolean monitored = false;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RoscoService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/RoscoService.java
@@ -133,7 +133,6 @@ abstract public class RoscoService extends SpringService<RoscoService.Rosco> {
     String host = "0.0.0.0";
     String scheme = "http";
     String healthEndpoint = "/health";
-    Boolean useExecHealthCheck = true;
     Boolean enabled = true;
     Boolean safeToUpdate = true;
     Boolean monitored = true;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ServiceSettings.java
@@ -57,7 +57,6 @@ public class ServiceSettings {
   String overrideBaseUrl;
   String location;
   KubernetesSettings kubernetes = new KubernetesSettings();
-  Boolean useExecHealthCheck;
   Boolean enabled;
   Boolean basicAuthEnabled;
   Boolean monitored;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -324,7 +324,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
 
     TemplatedResource probe;
     if (StringUtils.isNotEmpty(settings.getHealthEndpoint())) {
-      if (settings.getUseExecHealthCheck()) {
+      if (settings.getKubernetes().getUseExecHealthCheck()) {
         probe = new JinjaJarResource("/kubernetes/manifests/execReadinessProbe.yml");
         probe.addBinding("command", getReadinessExecCommand(settings));
       } else {


### PR DESCRIPTION
When updating the docs for #1171 I realized that there's a kubernetes specific config, so this moves the `useExecHealthCheck` setting to `kubernetes.useExecHealthCheck`.


Signed-off-by: Paul Czarkowski <username.taken@gmail.com>