### PR TITLE
feat(secrets): add support for decrypting kube configs

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubectlServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubectlServiceProvider.java
@@ -95,12 +95,15 @@ public class KubectlServiceProvider extends SpinnakerServiceProvider<AccountDepl
   @Autowired
   KubernetesV2RoscoService roscoService;
 
+  @Autowired
+  KubernetesV2Utils kubernetesV2Utils;
+
   @Override
   public RemoteAction clean(AccountDeploymentDetails<KubernetesAccount> details, SpinnakerRuntimeSettings runtimeSettings) {
     DaemonTaskHandler.newStage("Invoking kubectl");
     DaemonTaskHandler.message("Deleting all 'svc,deploy,secret' resources with label 'app=spin'...");
     KubernetesSharedServiceSettings kubernetesSharedServiceSettings = new KubernetesSharedServiceSettings(details.getDeploymentConfiguration());
-    new KubernetesV2Executor(DaemonTaskHandler.getJobExecutor(), details.getAccount()).deleteSpinnaker(kubernetesSharedServiceSettings.getDeployLocation());
+    new KubernetesV2Executor(DaemonTaskHandler.getJobExecutor(), details.getAccount(), kubernetesV2Utils).deleteSpinnaker(kubernetesSharedServiceSettings.getDeployLocation());
     return new RemoteAction();
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -476,7 +476,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
               Entry::getValue
           ));
 
-      KubernetesV2Utils.SecretSpec spec = KubernetesV2Utils.createSecretSpec(namespace, getService().getCanonicalName(), secretNamePrefix, files);
+      KubernetesV2Utils.SecretSpec spec = executor.getKubernetesV2Utils().createSecretSpec(namespace, getService().getCanonicalName(), secretNamePrefix, files);
       executor.apply(spec.resource.toString());
       configSources.add(new ConfigSource()
           .setId(spec.name)
@@ -496,7 +496,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
               .map(k -> new SecretMountPair(k, requiredEncryptedFiles.get(k)))
               .forEach(s -> files.add(s));
 
-      KubernetesV2Utils.SecretSpec spec = KubernetesV2Utils.createSecretSpec(namespace, getService().getCanonicalName(), secretNamePrefix, files);
+      KubernetesV2Utils.SecretSpec spec = executor.getKubernetesV2Utils().createSecretSpec(namespace, getService().getCanonicalName(), secretNamePrefix, files);
       executor.apply(spec.resource.toString());
       configSources.add(new ConfigSource()
           .setId(spec.name)
@@ -626,18 +626,18 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
   }
 
   default String connectCommand(AccountDeploymentDetails<KubernetesAccount> details,
-      SpinnakerRuntimeSettings runtimeSettings) {
+      SpinnakerRuntimeSettings runtimeSettings, KubernetesV2Utils kubernetesV2Utils) {
     ServiceSettings settings = runtimeSettings.getServiceSettings(getService());
     KubernetesAccount account = details.getAccount();
     String namespace = settings.getLocation();
     String name = getServiceName();
     int port = settings.getPort();
 
-    String podNameCommand = String.join(" ", KubernetesV2Utils.kubectlPodServiceCommand(account,
+    String podNameCommand = String.join(" ", kubernetesV2Utils.kubectlPodServiceCommand(account,
         namespace,
         name));
 
-    return String.join(" ", KubernetesV2Utils.kubectlConnectPodCommand(account,
+    return String.join(" ", kubernetesV2Utils.kubectlConnectPodCommand(account,
         namespace,
         "$(" + podNameCommand + ")",
         port));

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Utils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Utils.java
@@ -24,23 +24,18 @@ import com.netflix.spinnaker.config.secrets.EncryptedSecret;
 import com.netflix.spinnaker.halyard.config.config.v1.secrets.SecretSessionManager;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
-import com.netflix.spinnaker.halyard.core.job.v1.JobRequest;
-import com.netflix.spinnaker.halyard.core.job.v1.JobStatus;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.resource.v1.JinjaJarResource;
 import com.netflix.spinnaker.halyard.core.resource.v1.TemplatedResource;
-import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskInterrupted;
-import java.util.Arrays;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.SafeConstructor;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -51,13 +46,14 @@ import java.util.List;
 import java.util.Map;
 
 @Slf4j
+@Component
 public class KubernetesV2Utils {
-  static private ObjectMapper mapper = new ObjectMapper();
+  private ObjectMapper mapper = new ObjectMapper();
 
   @Autowired
-  private static SecretSessionManager secretSessionManager;
+  private SecretSessionManager secretSessionManager;
 
-  public static List<String> kubectlPrefix(KubernetesAccount account) {
+  public List<String> kubectlPrefix(KubernetesAccount account) {
     List<String> command = new ArrayList<>();
     command.add("kubectl");
 
@@ -85,7 +81,7 @@ public class KubernetesV2Utils {
     return command;
   }
 
-  static List<String> kubectlPodServiceCommand(KubernetesAccount account, String namespace, String service) {
+  List<String> kubectlPodServiceCommand(KubernetesAccount account, String namespace, String service) {
     List<String> command = kubectlPrefix(account);
 
     if (StringUtils.isNotEmpty(namespace)) {
@@ -101,7 +97,7 @@ public class KubernetesV2Utils {
     return command;
   }
 
-  static List<String> kubectlConnectPodCommand(KubernetesAccount account, String namespace, String name, int port) {
+  List<String> kubectlConnectPodCommand(KubernetesAccount account, String namespace, String name, int port) {
     List<String> command = kubectlPrefix(account);
 
     if (StringUtils.isNotEmpty(namespace)) {
@@ -115,7 +111,7 @@ public class KubernetesV2Utils {
     return command;
   }
 
-  public static SecretSpec createSecretSpec(String namespace, String clusterName, String name, List<SecretMountPair> files) {
+  public SecretSpec createSecretSpec(String namespace, String clusterName, String name, List<SecretMountPair> files) {
     Map<String, String> contentMap = new HashMap<>();
     for (SecretMountPair pair: files) {
       String contents;
@@ -148,12 +144,12 @@ public class KubernetesV2Utils {
     return spec;
   }
 
-  static public String prettify(String input) {
+  public String prettify(String input) {
     Yaml yaml = new Yaml(new SafeConstructor());
     return yaml.dump(yaml.load(input));
   }
 
-  static public Map<String, Object> parseManifest(String input) {
+  public Map<String, Object> parseManifest(String input) {
     Yaml yaml = new Yaml(new SafeConstructor());
     return mapper.convertValue(yaml.load(input), new TypeReference<Map<String, Object>>() {});
   }


### PR DESCRIPTION
Part of secrets management project: [spinnaker/spinnaker#3649](https://github.com/spinnaker/spinnaker/issues/3649)

So far, we've been adding an autowired SecretSessionManager to deal with decryption, but kube configs are handled in static methods in KubernetesV2Utils. Since you can't static autowire, it seems the cleanest solution is to make those methods non-static and make adjustments in the couple classes that call them.

We also have to remove the static autowire in Kubernetesv1Utils, so secrets in v1 kubernetes is unsupported for now.