### PR TITLE
feat(deployments): add command for component sizing on kubernetes distributed deployments

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.HaServiceCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing.ComponentSizingCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
@@ -37,6 +38,7 @@ public class DeploymentEnvironmentCommand extends AbstractConfigCommand {
   public DeploymentEnvironmentCommand() {
     registerSubcommand(new EditDeploymentEnvironmentCommand());
     registerSubcommand(new HaServiceCommand());
+    registerSubcommand(new ComponentSizingCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/AbstractComponentSizingUpdateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/AbstractComponentSizingUpdateCommand.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters(separators = "=")
+public abstract class AbstractComponentSizingUpdateCommand extends AbstractConfigCommand {
+    @Getter(AccessLevel.PROTECTED)
+    private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+    @Getter(AccessLevel.PUBLIC)
+    private String commandName;
+
+    @Getter(AccessLevel.PUBLIC)
+    protected SpinnakerService.Type spinnakerService;
+
+    public AbstractComponentSizingUpdateCommand(SpinnakerService.Type spinnakerService, String commandName) {
+        this.spinnakerService = spinnakerService;
+        this.commandName = commandName;
+    }
+
+    @Override
+    protected void executeThis() {
+        String serviceName = spinnakerService.getCanonicalName();
+        String currentDeployment = getCurrentDeployment();
+        DeploymentEnvironment deploymentEnvironment = new OperationHandler<DeploymentEnvironment>()
+                .setFailureMesssage("Failed to get component sizing for service " + serviceName + ".")
+                .setOperation(Daemon.getDeploymentEnvironment(currentDeployment, false))
+                .get();
+
+        CustomSizing customSizing = deploymentEnvironment.getCustomSizing();
+        int originalHash = customSizing.hashCode();
+
+        update(customSizing);
+
+        if (originalHash == customSizing.hashCode()) {
+            AnsiUi.failure("Nothing to do.");
+            return;
+        }
+
+        new OperationHandler<Void>()
+                .setFailureMesssage("Failed to " + commandName + " custom component sizings for " + serviceName + ".")
+                .setSuccessMessage("Successfully managed to " + commandName + " component sizings for service " + serviceName + ".")
+                .setOperation(Daemon.setDeploymentEnvironment(currentDeployment, !noValidate, deploymentEnvironment))
+                .get();
+    }
+
+    protected abstract CustomSizing update(CustomSizing customSizing);
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/AbstractComponentSizingUpdateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/AbstractComponentSizingUpdateCommand.java
@@ -70,7 +70,7 @@ public abstract class AbstractComponentSizingUpdateCommand extends AbstractConfi
 
         new OperationHandler<Void>()
                 .setFailureMesssage("Failed to " + commandName + " custom component sizings for " + serviceName + ".")
-                .setSuccessMessage("Successfully managed to " + commandName + " component sizings for service " + serviceName + ".")
+                .setSuccessMessage("Successfully managed to " + commandName + " the custom component sizings for service " + serviceName + ".")
                 .setOperation(Daemon.setDeploymentEnvironment(currentDeployment, !noValidate, deploymentEnvironment))
                 .get();
     }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingCommand.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.ClouddriverHaServiceCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.EchoHaServiceCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class ComponentSizingCommand extends NestableCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "component-sizing";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String description = "Configure, validate, and view the component sizings for the Spinnaker services.";
+
+  public ComponentSizingCommand() {
+    registerSubcommand(new NamedComponentSizingCommand("clouddriver"));
+    registerSubcommand(new NamedComponentSizingCommand("deck"));
+    registerSubcommand(new NamedComponentSizingCommand("echo"));
+    registerSubcommand(new NamedComponentSizingCommand("front50"));
+    registerSubcommand(new NamedComponentSizingCommand("gate"));
+    registerSubcommand(new NamedComponentSizingCommand("igor"));
+    registerSubcommand(new NamedComponentSizingCommand("orca"));
+    registerSubcommand(new NamedComponentSizingCommand("rosco"));
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingCommand.java
@@ -18,12 +18,16 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing;
 
+import com.amazonaws.services.dynamodbv2.xspec.S;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.ClouddriverHaServiceCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.EchoHaServiceCommand;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import lombok.AccessLevel;
 import lombok.Getter;
+
+import static com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService.Type.*;
 
 @Parameters(separators = "=")
 public class ComponentSizingCommand extends NestableCommand {
@@ -34,14 +38,9 @@ public class ComponentSizingCommand extends NestableCommand {
   private String description = "Configure, validate, and view the component sizings for the Spinnaker services.";
 
   public ComponentSizingCommand() {
-    registerSubcommand(new NamedComponentSizingCommand("clouddriver"));
-    registerSubcommand(new NamedComponentSizingCommand("deck"));
-    registerSubcommand(new NamedComponentSizingCommand("echo"));
-    registerSubcommand(new NamedComponentSizingCommand("front50"));
-    registerSubcommand(new NamedComponentSizingCommand("gate"));
-    registerSubcommand(new NamedComponentSizingCommand("igor"));
-    registerSubcommand(new NamedComponentSizingCommand("orca"));
-    registerSubcommand(new NamedComponentSizingCommand("rosco"));
+    for (SpinnakerService.Type spinnakerService : SpinnakerService.Type.values()) {
+      registerSubcommand(new NamedComponentSizingCommand(spinnakerService));
+    }
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingDeleteCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingDeleteCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters(separators = "=")
+public class ComponentSizingDeleteCommand extends AbstractComponentSizingUpdateCommand {
+
+    public ComponentSizingDeleteCommand(SpinnakerService.Type spinnakerService) {
+        super(spinnakerService, "delete");
+    }
+
+    @Override
+    protected String getShortDescription() {
+        return "Delete the custom component sizings for service " + spinnakerService.getCanonicalName();
+    }
+
+    @Override
+    protected CustomSizing update(CustomSizing customSizing) {
+        return delete(customSizing);
+    }
+
+    private CustomSizing delete(CustomSizing customSizing) {
+        customSizing.put(spinnakerService.getServiceName(), null);
+        return customSizing;
+    }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingEditCommand.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters(separators = "=")
+public class ComponentSizingEditCommand extends AbstractConfigCommand {
+    @Getter(AccessLevel.PROTECTED)
+    private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+    @Getter(AccessLevel.PUBLIC)
+    private String commandName = "edit";
+
+    @Getter(AccessLevel.PUBLIC)
+    private String serviceName;
+
+    @Parameter(
+            names = "--replicas",
+            description = "Set the number of replicas (pods) to be created for this service."
+    )
+    private Integer replicas;
+
+    @Parameter(
+            names = "--pod-requests-cpu",
+            description = "Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m."
+    )
+    private String requestsCpu;
+
+    @Parameter(
+            names = "--pod-requests-memory",
+            description = "Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi."
+    )
+    private String requestsMemory;
+
+    @Parameter(
+            names = "--pod-limits-cpu",
+            description = "Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1."
+    )
+    private String limitsCpu;
+
+    @Parameter(
+            names = "--pod-limits-memory",
+            description = "Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi."
+    )
+    private String limitsMemory;
+
+    public ComponentSizingEditCommand(String serviceName) {
+        this.serviceName = serviceName;
+    }
+
+    @Override
+    protected String getShortDescription() {
+        return "Edit the component sizing for service " + getServiceName();
+    }
+
+    @Override
+    protected void executeThis() {
+        String currentDeployment = getCurrentDeployment();
+        String serviceName = getServiceName();
+        DeploymentEnvironment deploymentEnvironment = new OperationHandler<DeploymentEnvironment>()
+                .setFailureMesssage("Failed to get component sizing for service " + serviceName + ".")
+                .setOperation(Daemon.getDeploymentEnvironment(currentDeployment, false))
+                .get();
+
+        CustomSizing customSizing = deploymentEnvironment.getCustomSizing();
+        int originalHash = customSizing.hashCode();
+
+        customSizing = edit(customSizing);
+
+        if (originalHash == customSizing.hashCode()) {
+            AnsiUi.failure("No changes supplied.");
+            return;
+        }
+
+        new OperationHandler<Void>()
+                .setFailureMesssage("Failed to edit component sizing for " + serviceName + ".")
+                .setSuccessMessage("Successfully edited component sizing for service " + serviceName + ".")
+                .setOperation(Daemon.setDeploymentEnvironment(currentDeployment, !noValidate, deploymentEnvironment))
+                .get();
+    }
+
+    private CustomSizing edit(CustomSizing customSizing) {
+        Map serviceSizing = customSizing.computeIfAbsent(spinService(), (k) -> new HashMap<>());
+        edit(serviceSizing);
+        return customSizing;
+    }
+
+    private void edit(Map serviceSizing) {
+        putIfNotNull(serviceSizing, "replicas", replicas);
+
+        Map limits = (Map) serviceSizing.computeIfAbsent("limits", (k) -> new HashMap<>());
+        putIfNotNull(limits, "cpu", limitsCpu);
+        putIfNotNull(limits, "memory", limitsMemory);
+
+        Map requests = (Map) serviceSizing.computeIfAbsent("requests", (k) -> new HashMap<>());
+        putIfNotNull(requests, "cpu", requestsCpu);
+        putIfNotNull(requests, "memory", requestsMemory);
+    }
+
+    private void putIfNotNull(Map map, String key, Object value) {
+        if (value != null) {
+            map.put(key, value);
+        }
+    }
+
+    private String spinService() {
+        return "spin-" + serviceName;
+    }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.sizing;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.AbstractHaServiceCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.ClouddriverHaServiceEditCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.deploy.ha.HaServiceEnableDisableCommandBuilder;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.Map;
+import java.util.function.Supplier;
+
+import static com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format.STRING;
+
+@Parameters(separators = "=")
+public class NamedComponentSizingCommand extends AbstractConfigCommand {
+
+  @Getter(AccessLevel.PUBLIC)
+  private String serviceName;
+
+  public NamedComponentSizingCommand(String serviceName) {
+    this.serviceName = serviceName;
+    registerSubcommand(new ComponentSizingEditCommand(serviceName));
+  }
+
+  @Override
+  public String getCommandName() {
+    return serviceName;
+  }
+
+  @Override
+  protected String getShortDescription() {
+    return "Manage and view Spinnaker component sizing configuration for " + getServiceName();
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    String serviceName = getServiceName();
+    new OperationHandler<Map>()
+        .setFailureMesssage("Failed to get component sizing for service " + serviceName + ".")
+        .setSuccessMessage("Successfully got component sizing for service " + serviceName + ".")
+        .setFormat(STRING)
+        .setUserFormatted(true)
+        .setOperation(() -> Daemon.getDeploymentEnvironment(currentDeployment, !noValidate).get().getCustomSizing().get("spin-" + serviceName))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
 import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -39,33 +40,33 @@ import static com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format.STR
 public class NamedComponentSizingCommand extends AbstractConfigCommand {
 
   @Getter(AccessLevel.PUBLIC)
-  private String serviceName;
+  private SpinnakerService.Type spinnakerService;
 
-  public NamedComponentSizingCommand(String serviceName) {
-    this.serviceName = serviceName;
-    registerSubcommand(new ComponentSizingEditCommand(serviceName));
+  public NamedComponentSizingCommand(SpinnakerService.Type spinnakerService) {
+    this.spinnakerService = spinnakerService;
+    registerSubcommand(new ComponentSizingEditCommand(spinnakerService));
+    registerSubcommand(new ComponentSizingDeleteCommand(spinnakerService));
   }
 
   @Override
   public String getCommandName() {
-    return serviceName;
+    return spinnakerService.getCanonicalName();
   }
 
   @Override
   protected String getShortDescription() {
-    return "Manage and view Spinnaker component sizing configuration for " + getServiceName();
+    return "Manage and view Spinnaker component sizing configuration for " + spinnakerService.getCanonicalName();
   }
 
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
-    String serviceName = getServiceName();
     new OperationHandler<Map>()
-        .setFailureMesssage("Failed to get component sizing for service " + serviceName + ".")
-        .setSuccessMessage("Successfully got component sizing for service " + serviceName + ".")
+        .setFailureMesssage("Failed to get component sizing for service " + spinnakerService + ".")
+        .setSuccessMessage("Successfully got component sizing for service " + spinnakerService + ".")
         .setFormat(STRING)
         .setUserFormatted(true)
-        .setOperation(() -> Daemon.getDeploymentEnvironment(currentDeployment, !noValidate).get().getCustomSizing().get("spin-" + serviceName))
+        .setOperation(() -> Daemon.getDeploymentEnvironment(currentDeployment, !noValidate).get().getCustomSizing().get(spinnakerService.getServiceName()))
         .get();
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/CustomSizing.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/CustomSizing.java
@@ -95,4 +95,8 @@ public class CustomSizing implements Map<String, Map> {
   public Set<Entry<String, Map>> entrySet() {
     return componentSizings.entrySet();
   }
+
+  public boolean hasCustomSizing(String service) {
+    return get(service) != null;
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentEnvironmentValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentEnvironmentValidator.java
@@ -29,11 +29,13 @@ import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.config.validate.v1.providers.kubernetes.KubernetesAccountValidator;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+@Slf4j
 public class DeploymentEnvironmentValidator extends Validator<DeploymentEnvironment> {
   @Autowired
   AccountService accountService;
@@ -43,6 +45,10 @@ public class DeploymentEnvironmentValidator extends Validator<DeploymentEnvironm
 
   @Override
   public void validate(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
+
+    log.info("[VALIDATE-COSTI] DeploymentEnvironmentValidator");
+
+
     DeploymentType type = n.getType();
     switch (type) {
       case LocalDebian:

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HaClouddriverValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HaClouddriverValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.validate.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ha.HaServices;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HaClouddriverValidator extends Validator<DeploymentEnvironment>  {
+
+  @Override
+  public void validate(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
+    CustomSizing customSizing = n.getCustomSizing();
+    HaServices haServices = n.getHaServices();
+
+    boolean haCloudDriverEnabled = haServices.getClouddriver().isEnabled();
+    if (haCloudDriverEnabled && customSizing.hasCustomSizing("spin-clouddriver")) {
+      p.addProblem(Problem.Severity.WARNING, "High Availability (HA) is enabled for clouddriver, but found custom sizing for the main service (this setting will be ignored). " +
+              "With HA enabled, the service is split into multiple sub-services (eg. clouddriver-caching, clouddriver-rw). You need to update the component sizing for each sub-service, individually.");
+    }
+
+    if (!haCloudDriverEnabled &&
+            (customSizing.hasCustomSizing("spin-clouddriver-rw") ||
+                    customSizing.hasCustomSizing("spin-clouddriver-ro") ||
+                    customSizing.hasCustomSizing("spin-clouddriver-ro-deck") ||
+                    customSizing.hasCustomSizing("spin-clouddriver-caching")
+            )) {
+      p.addProblem(Problem.Severity.WARNING, "Discovered custom sizing for HA clouddriver subcomponent, but High Availability (HA) is not enabled. Please enable HA or edit the clouddriver main service directly.");
+    }
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HaEchoValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HaEchoValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.config.validate.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ha.HaServices;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CustomSizing;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+public class HaEchoValidator extends Validator<DeploymentEnvironment>  {
+
+  @Override
+  public void validate(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
+    CustomSizing customSizing = n.getCustomSizing();
+    HaServices haServices = n.getHaServices();
+
+    boolean haEchoEnabled = haServices.getEcho().isEnabled();
+    if (haEchoEnabled && customSizing.hasCustomSizing("spin-echo")) {
+      p.addProblem(Problem.Severity.WARNING, "High Availability (HA) is enabled for echo, but found custom sizing for the main service (this setting will be ignored). " +
+              "With HA enabled, the service is split into multiple sub-services (echo-scheduler, echo-scheduler). You need to update the component sizing for each sub-service, individually.");
+    }
+
+    if (!haEchoEnabled &&
+            (customSizing.hasCustomSizing("spin-echo-worker") ||
+             customSizing.hasCustomSizing("spin-echo-scheduler")
+            )) {
+      p.addProblem(Problem.Severity.WARNING, "Discovered custom sizing for HA echo subcomponent, but High Availability (HA) is not enabled. Please enable HA or edit the echo main service directly.");
+    }
+  }
+}


### PR DESCRIPTION
fixes https://github.com/spinnaker/spinnaker/issues/3981

```
spinnaker@halyard:$ hal config deploy component-sizing orca edit --replicas 3
+ Get current deployment
  Success
+ Get the deployment environment
  Success
+ Edit the deployment environment
  Success
+ Successfully edited component sizing for service orca.

spinnaker@halyard:$ hal config deploy component-sizing orca
+ Get current deployment
  Success
+ Get the deployment environment
  Success
+ Successfully got component sizing for service orca.
{replicas=3}
```

`$ cat ~/.hal/config`
```yaml
currentDeployment: default
deploymentConfigurations:
  deploymentEnvironment:
    size: SMALL
    type: Distributed
    ....
    customSizing:
      spin-orca:
        replicas: 3
```


```sh
$HAL_COMMAND config deploy component-sizing clouddriver edit --pod-requests-cpu 250m --pod-requests-memory 512Mi

$HAL_COMMAND config deploy component-sizing clouddriver edit --pod-limits-cpu 1 --pod-limits-memory 1Gi
```

```yaml
    customSizing:
      spin-clouddriver:
        replicas: 2
        requests:
          cpu: 250m
          memory: 512Mi
        limits:
          cpu: 1
          memory: 1Gi
```


