### PR TITLE
feat(authn/saml): Add userAttributeMapping to saml configuration

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/saml/EditSamlCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/saml/EditSamlCommand.java
@@ -86,6 +86,36 @@ public class EditSamlCommand extends AbstractEditAuthnMethodCommand<Saml> {
   )
   private URL serviceAddress;
 
+  @Parameter(
+    names = "--user-attribute-mapping-first-name",
+    description = "The first name field returned from your SAML provider."
+  )
+  private String userInfoMappingFirstName;
+
+  @Parameter(
+    names = "--user-attribute-mapping-last-name",
+    description = "The last name field returned from your SAML provider."
+  )
+  private String userAttributeMappingLastName;
+
+  @Parameter(
+    names = "--user-attribute-mapping-username",
+    description = "The username field returned from your SAML provider."
+  )
+  private String userAttributeMappingUsername;
+
+  @Parameter(
+    names = "--user-attribute-mapping-roles",
+    description = "The roles field returned from your SAML provider."
+  )
+  private String userAttributeMappingRoles;
+
+  @Parameter(
+    names = "--user-attribute-mapping-roles-delimiter",
+    description = "The roles delimiter field returned from your SAML provider."
+  )
+  private String userAttributeMappingRolesDelimiter;
+
   @Override
   protected AuthnMethod editAuthnMethod(Saml s) {
     s.setIssuerId(isSet(issuerId) ? issuerId : s.getIssuerId());
@@ -103,6 +133,13 @@ public class EditSamlCommand extends AbstractEditAuthnMethodCommand<Saml> {
         s.setMetadataRemote(null);
       }
     }
+
+    Saml.UserAttributeMapping userAttributeMapping = s.getUserAttributeMapping();
+    userAttributeMapping.setFirstName(isSet(userInfoMappingFirstName) ? userInfoMappingFirstName : userAttributeMapping.getFirstName());
+    userAttributeMapping.setLastName(isSet(userAttributeMappingLastName) ? userAttributeMappingLastName : userAttributeMapping.getLastName());
+    userAttributeMapping.setRoles(isSet(userAttributeMappingRoles) ? userAttributeMappingRoles : userAttributeMapping.getRoles());
+    userAttributeMapping.setRolesDelimiter(isSet(userAttributeMappingRolesDelimiter) ? userAttributeMappingRolesDelimiter : userAttributeMapping.getRolesDelimiter());
+    userAttributeMapping.setUsername(isSet(userAttributeMappingUsername) ? userAttributeMappingUsername : userAttributeMapping.getUsername());
 
     return s;
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Saml.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Saml.java
@@ -44,4 +44,15 @@ public class Saml extends AuthnMethod {
   private String keyStoreAliasName;
 
   private URL serviceAddress;
+
+  private UserAttributeMapping userAttributeMapping = new UserAttributeMapping();
+
+  @Data
+  public static class UserAttributeMapping {
+    private String firstName;
+    private String lastName;
+    private String roles;
+    private String rolesDelimiter;
+    private String username;
+  }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SamlConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SamlConfig.java
@@ -41,6 +41,8 @@ public class SamlConfig {
   String redirectHostname;
   String redirectBasePath;
 
+  Saml.UserAttributeMapping userAttributeMapping;
+
   public SamlConfig(Security security) {
     if (!security.getAuthn().getSaml().isEnabled()) {
       return;
@@ -68,5 +70,7 @@ public class SamlConfig {
     if (StringUtils.isNotEmpty(u.getPath())) {
       this.redirectBasePath = u.getPath();
     }
+
+    this.userAttributeMapping = saml.getUserAttributeMapping();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/spinnaker/spinnaker/issues/3987

Expose the configuration for userAttributeMapping when using SAML as Identity provider.

New parameters added for saml

```
 ./hal config security authn saml edit --help
...

  --user-attribute-mapping-first-name
    The first name field returned from your SAML provider.

  --user-attribute-mapping-last-name
    The last name field returned from your SAML provider.

  --user-attribute-mapping-roles
    The roles field returned from your SAML provider.

  --user-attribute-mapping-roles-delimiter
    The roles delimiter field returned from your SAML provider.

  --user-attribute-mapping-username
    The username field returned from your SAML provider.
```

Using the new `userAttributeMapping` parameters:
```
./hal config security authn saml edit --keystore=/path/to/keystore.jks \
   --keystore-alias=spinnaker  --keystore-password=pass \                                                              
   --metadata=/path/to/metadata.xml \
   --issuer-id=ISSUER_ID \
   --user-attribute-mapping-roles=Group \
   --user-attribute-mapping-first-name=FirstName \
   --user-attribute-mapping-last-name=LastName \
   --user-attribute-mapping-roles-delimiter=,
```

Generated config:
```
$ cat ~/.hal/config
...
    saml:
        enabled: true
        ...
        userAttributeMapping:
          firstName: FirstName
          lastName: LastName
          roles: Group
          rolesDelimiter: ','
```