### PR TITLE
fix(secrets): fix gce credential loading

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/gcs/GcsArtifactAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/gcs/GcsArtifactAccount.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.config.model.v1.artifacts.gcs;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.ArtifactAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -29,5 +30,6 @@ public class GcsArtifactAccount extends ArtifactAccount {
   String name;
 
   @LocalFile
+  @SecretFile
   String jsonPath;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
@@ -30,7 +30,6 @@ import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -47,11 +46,8 @@ public class GoogleCanaryAccount extends AbstractCanaryAccount implements Clonea
   private String rootFolder = "kayenta";
   private SortedSet<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes = new TreeSet<>();
 
-  @Autowired
-  private SecretSessionManager secretSessionManager;
-
   @JsonIgnore
-  public GoogleNamedAccountCredentials getNamedAccountCredentials(String version, ConfigProblemSetBuilder p) {
+  public GoogleNamedAccountCredentials getNamedAccountCredentials(String version, SecretSessionManager secretSessionManager, ConfigProblemSetBuilder p) {
     String jsonKey = null;
     if (!StringUtils.isEmpty(getJsonPath())) {
       jsonKey = secretSessionManager.validatingFileDecrypt(p, getJsonPath());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/GcsPersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/GcsPersistentStore.java
@@ -18,13 +18,14 @@ package com.netflix.spinnaker.halyard.config.model.v1.persistentStorage;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class GcsPersistentStore extends PersistentStore {
-  @LocalFile private String jsonPath;
+  @LocalFile @SecretFile private String jsonPath;
   private String project;
   private String bucket;
   private String rootFolder = "front50";

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
@@ -25,13 +25,13 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.ConsulConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.SupportsConsul;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,14 +47,15 @@ public class GoogleAccount extends CommonGoogleAccount implements Cloneable, Sup
   @LocalFile String userDataFile;
   private List<String> regions;
 
-  @Autowired
-  private SecretSessionManager secretSessionManager;
-
   @JsonIgnore
-  public GoogleNamedAccountCredentials getNamedAccountCredentials(String version, ConfigProblemSetBuilder p) {
+  public GoogleNamedAccountCredentials getNamedAccountCredentials(String version, SecretSessionManager secretSessionManager, ConfigProblemSetBuilder p) {
     String jsonKey = null;
     if (!StringUtils.isEmpty(getJsonPath())) {
-      jsonKey = secretSessionManager.validatingFileDecrypt(p, getJsonPath());
+      if (secretSessionManager != null) {
+        jsonKey = secretSessionManager.validatingFileDecrypt(p, getJsonPath());
+      } else {
+        jsonKey = ValidatingFileReader.contents(p, getJsonPath());
+      }
 
       if (jsonKey == null) {
         return null;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/pubsub/google/GooglePublisher.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/pubsub/google/GooglePublisher.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.config.model.v1.pubsub.google;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Publisher;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -31,6 +32,7 @@ public class GooglePublisher extends Publisher {
   private String project;
   private String topicName;
   @LocalFile
+  @SecretFile
   private String jsonPath;
   private Content content;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/pubsub/google/GoogleSubscription.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/pubsub/google/GoogleSubscription.java
@@ -19,6 +19,7 @@
 package com.netflix.spinnaker.halyard.config.model.v1.pubsub.google;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Subscription;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -30,7 +31,7 @@ import lombok.ToString;
 public class GoogleSubscription extends Subscription {
   private String project;
   private String subscriptionName;
-  @LocalFile private String jsonPath;
+  @LocalFile @SecretFile private String jsonPath;
   @LocalFile private String templatePath;
   private Integer ackDeadlineSeconds;
   private MessageFormat messageFormat;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
@@ -66,7 +66,7 @@ public class GoogleCanaryAccountValidator extends CanaryAccountValidator {
 
     DaemonTaskHandler.message("Validating " + n.getNodeName() + " with " + GoogleCanaryAccountValidator.class.getSimpleName());
 
-    GoogleNamedAccountCredentials credentials = canaryAccount.getNamedAccountCredentials(halyardVersion, p);
+    GoogleNamedAccountCredentials credentials = canaryAccount.getNamedAccountCredentials(halyardVersion, secretSessionManager, p);
 
     if (credentials == null) {
       return;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/google/GoogleAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/google/GoogleAccountValidator.java
@@ -18,13 +18,13 @@ package com.netflix.spinnaker.halyard.config.validate.v1.providers.google;
 
 import com.google.api.services.compute.Compute;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
+import com.netflix.spinnaker.halyard.config.config.v1.secrets.SecretSessionManager;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTaskHandler;
-import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
-
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang.StringUtils;
@@ -39,11 +39,13 @@ public class GoogleAccountValidator extends Validator<GoogleAccount> {
 
   final private String halyardVersion;
 
+  final private SecretSessionManager secretSessionManager;
+
   @Override
   public void validate(ConfigProblemSetBuilder p, GoogleAccount n) {
     DaemonTaskHandler.message("Validating " + n.getNodeName() + " with " + GoogleAccountValidator.class.getSimpleName());
 
-    GoogleNamedAccountCredentials credentials = n.getNamedAccountCredentials(halyardVersion, p);
+    GoogleNamedAccountCredentials credentials = n.getNamedAccountCredentials(halyardVersion, secretSessionManager, p);
     if (credentials == null) {
       return;
     } else {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/google/GoogleProviderValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/google/GoogleProviderValidator.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.config.validate.v1.providers.google;
 
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
+import com.netflix.spinnaker.halyard.config.config.v1.secrets.SecretSessionManager;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleProvider;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
@@ -31,11 +32,14 @@ public class GoogleProviderValidator extends Validator<GoogleProvider> {
   @Autowired
   private String halyardVersion;
 
+  @Autowired
+  private SecretSessionManager secretSessionManager;
+
   @Override
   public void validate(ConfigProblemSetBuilder p, GoogleProvider n) {
     List<GoogleNamedAccountCredentials> credentialsList = new ArrayList<>();
 
-    GoogleAccountValidator googleAccountValidator = new GoogleAccountValidator(credentialsList, halyardVersion);
+    GoogleAccountValidator googleAccountValidator = new GoogleAccountValidator(credentialsList, halyardVersion, secretSessionManager);
 
     n.getAccounts().forEach(googleAccount -> googleAccountValidator.validate(p, googleAccount));
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleProviderUtils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleProviderUtils.java
@@ -19,7 +19,11 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.go
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.compute.Compute;
-import com.google.api.services.compute.model.*;
+import com.google.api.services.compute.model.AccessConfig;
+import com.google.api.services.compute.model.Firewall;
+import com.google.api.services.compute.model.Instance;
+import com.google.api.services.compute.model.Network;
+import com.google.api.services.compute.model.Operation;
 import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCredentials;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
@@ -407,7 +411,7 @@ class GoogleProviderUtils {
 
   static Compute getCompute(AccountDeploymentDetails<GoogleAccount> details) {
     ConfigProblemSetBuilder problemSetBuilder = new ConfigProblemSetBuilder(null);
-    GoogleNamedAccountCredentials credentials = details.getAccount().getNamedAccountCredentials("", problemSetBuilder);
+    GoogleNamedAccountCredentials credentials = details.getAccount().getNamedAccountCredentials("", null, problemSetBuilder);
 
     if (credentials == null) {
       throw new HalException(problemSetBuilder.build().getProblems());


### PR DESCRIPTION
The original change was adding support for storing credentials in an encrypted s3 bucket instead of a plain text file. This is part of the secrets management project here: https://github.com/spinnaker/spinnaker/issues/3649


The problem:
We're seeing an NPE from `GoogleAccount.getNamedAccountCredentials` because we're trying to autowire the `SecretSessionManager` in a class that's not being managed by Spring. The NPE occurs when we try to call `secretSessionManager.validatingFileDecrypt(p, getJsonPath())`.


The fix:
Removing the autowired `SecretSessionManager` in both `GoogleAccount` and `GoogleCanaryAccount` and instead passing it in from the upstream callers where supported. Namely these upstream validators: `GoogleAccountValidator`, `GoogleProviderValidator`,  `GoogleCanaryAccountValidator`.

The flow that isn't supported is the call from `GoogleProviderUtils`. In this case, we're passing in null and the credentials file will be read in the standard way, using `ValidatingFileReader.contents(p, getJsonPath())`.