### PR TITLE
feat(core): Use gradle to generate docs

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -1,3 +1,5 @@
+import org.gradle.api.tasks.Exec
+
 dependencies {
   compile spinnaker.dependency('lombok')
 
@@ -11,3 +13,28 @@ apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'com.netflix.spinnaker.halyard.cli.Main'
+
+task generateDocs(type: Exec, dependsOn: installDist) {
+  workingDir "$projectDir"
+  commandLine './hal', '--docs'
+  standardOutput new ByteArrayOutputStream()
+  doLast {
+    ext.output = standardOutput.toString()
+  }
+}
+
+task checkDocs(dependsOn: generateDocs) << {
+  def newDocs = tasks.generateDocs.output
+  def currentDocs = new File("$projectDir/../docs/commands.md").text
+  if (newDocs != currentDocs) {
+    throw new GradleException('The docs for halyard-cli are out of date. Regenerate them by running the :halyard-cli:updateDocs gradle task.')
+  }
+}
+
+task updateDocs(dependsOn: generateDocs) << {
+  new File("$projectDir/../docs/commands.md").withWriter { writer ->
+    writer.write(tasks.generateDocs.output)
+  }  
+}
+
+tasks.check.dependsOn(checkDocs)


### PR DESCRIPTION
The Halyard docs are currently generated via a makefile. Move this to gradle so that it can be incorporated into the build process rather than a separate shell command.

In particular, the check task should fail if the docs do not generate properly or if the docs committed to git do not match what are generated from source. This will cause our Travis build to fail and block merging when a PR either forgets to update the docs or breaks doc generation.