### PR TITLE
fix(deployments): Fix docs generation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -186,6 +186,82 @@
  * [**hal config ci wercker master get**](#hal-config-ci-wercker-master-get)
  * [**hal config ci wercker master list**](#hal-config-ci-wercker-master-list)
  * [**hal config deploy**](#hal-config-deploy)
+ * [**hal config deploy component-sizing**](#hal-config-deploy-component-sizing)
+ * [**hal config deploy component-sizing clouddriver**](#hal-config-deploy-component-sizing-clouddriver)
+ * [**hal config deploy component-sizing clouddriver delete**](#hal-config-deploy-component-sizing-clouddriver-delete)
+ * [**hal config deploy component-sizing clouddriver edit**](#hal-config-deploy-component-sizing-clouddriver-edit)
+ * [**hal config deploy component-sizing clouddriver-bootstrap**](#hal-config-deploy-component-sizing-clouddriver-bootstrap)
+ * [**hal config deploy component-sizing clouddriver-bootstrap delete**](#hal-config-deploy-component-sizing-clouddriver-bootstrap-delete)
+ * [**hal config deploy component-sizing clouddriver-bootstrap edit**](#hal-config-deploy-component-sizing-clouddriver-bootstrap-edit)
+ * [**hal config deploy component-sizing clouddriver-caching**](#hal-config-deploy-component-sizing-clouddriver-caching)
+ * [**hal config deploy component-sizing clouddriver-caching delete**](#hal-config-deploy-component-sizing-clouddriver-caching-delete)
+ * [**hal config deploy component-sizing clouddriver-caching edit**](#hal-config-deploy-component-sizing-clouddriver-caching-edit)
+ * [**hal config deploy component-sizing clouddriver-ro**](#hal-config-deploy-component-sizing-clouddriver-ro)
+ * [**hal config deploy component-sizing clouddriver-ro delete**](#hal-config-deploy-component-sizing-clouddriver-ro-delete)
+ * [**hal config deploy component-sizing clouddriver-ro edit**](#hal-config-deploy-component-sizing-clouddriver-ro-edit)
+ * [**hal config deploy component-sizing clouddriver-ro-deck**](#hal-config-deploy-component-sizing-clouddriver-ro-deck)
+ * [**hal config deploy component-sizing clouddriver-ro-deck delete**](#hal-config-deploy-component-sizing-clouddriver-ro-deck-delete)
+ * [**hal config deploy component-sizing clouddriver-ro-deck edit**](#hal-config-deploy-component-sizing-clouddriver-ro-deck-edit)
+ * [**hal config deploy component-sizing clouddriver-rw**](#hal-config-deploy-component-sizing-clouddriver-rw)
+ * [**hal config deploy component-sizing clouddriver-rw delete**](#hal-config-deploy-component-sizing-clouddriver-rw-delete)
+ * [**hal config deploy component-sizing clouddriver-rw edit**](#hal-config-deploy-component-sizing-clouddriver-rw-edit)
+ * [**hal config deploy component-sizing consul-client**](#hal-config-deploy-component-sizing-consul-client)
+ * [**hal config deploy component-sizing consul-client delete**](#hal-config-deploy-component-sizing-consul-client-delete)
+ * [**hal config deploy component-sizing consul-client edit**](#hal-config-deploy-component-sizing-consul-client-edit)
+ * [**hal config deploy component-sizing consul-server**](#hal-config-deploy-component-sizing-consul-server)
+ * [**hal config deploy component-sizing consul-server delete**](#hal-config-deploy-component-sizing-consul-server-delete)
+ * [**hal config deploy component-sizing consul-server edit**](#hal-config-deploy-component-sizing-consul-server-edit)
+ * [**hal config deploy component-sizing deck**](#hal-config-deploy-component-sizing-deck)
+ * [**hal config deploy component-sizing deck delete**](#hal-config-deploy-component-sizing-deck-delete)
+ * [**hal config deploy component-sizing deck edit**](#hal-config-deploy-component-sizing-deck-edit)
+ * [**hal config deploy component-sizing echo**](#hal-config-deploy-component-sizing-echo)
+ * [**hal config deploy component-sizing echo delete**](#hal-config-deploy-component-sizing-echo-delete)
+ * [**hal config deploy component-sizing echo edit**](#hal-config-deploy-component-sizing-echo-edit)
+ * [**hal config deploy component-sizing echo-scheduler**](#hal-config-deploy-component-sizing-echo-scheduler)
+ * [**hal config deploy component-sizing echo-scheduler delete**](#hal-config-deploy-component-sizing-echo-scheduler-delete)
+ * [**hal config deploy component-sizing echo-scheduler edit**](#hal-config-deploy-component-sizing-echo-scheduler-edit)
+ * [**hal config deploy component-sizing echo-worker**](#hal-config-deploy-component-sizing-echo-worker)
+ * [**hal config deploy component-sizing echo-worker delete**](#hal-config-deploy-component-sizing-echo-worker-delete)
+ * [**hal config deploy component-sizing echo-worker edit**](#hal-config-deploy-component-sizing-echo-worker-edit)
+ * [**hal config deploy component-sizing fiat**](#hal-config-deploy-component-sizing-fiat)
+ * [**hal config deploy component-sizing fiat delete**](#hal-config-deploy-component-sizing-fiat-delete)
+ * [**hal config deploy component-sizing fiat edit**](#hal-config-deploy-component-sizing-fiat-edit)
+ * [**hal config deploy component-sizing front50**](#hal-config-deploy-component-sizing-front50)
+ * [**hal config deploy component-sizing front50 delete**](#hal-config-deploy-component-sizing-front50-delete)
+ * [**hal config deploy component-sizing front50 edit**](#hal-config-deploy-component-sizing-front50-edit)
+ * [**hal config deploy component-sizing gate**](#hal-config-deploy-component-sizing-gate)
+ * [**hal config deploy component-sizing gate delete**](#hal-config-deploy-component-sizing-gate-delete)
+ * [**hal config deploy component-sizing gate edit**](#hal-config-deploy-component-sizing-gate-edit)
+ * [**hal config deploy component-sizing igor**](#hal-config-deploy-component-sizing-igor)
+ * [**hal config deploy component-sizing igor delete**](#hal-config-deploy-component-sizing-igor-delete)
+ * [**hal config deploy component-sizing igor edit**](#hal-config-deploy-component-sizing-igor-edit)
+ * [**hal config deploy component-sizing kayenta**](#hal-config-deploy-component-sizing-kayenta)
+ * [**hal config deploy component-sizing kayenta delete**](#hal-config-deploy-component-sizing-kayenta-delete)
+ * [**hal config deploy component-sizing kayenta edit**](#hal-config-deploy-component-sizing-kayenta-edit)
+ * [**hal config deploy component-sizing monitoring-daemon**](#hal-config-deploy-component-sizing-monitoring-daemon)
+ * [**hal config deploy component-sizing monitoring-daemon delete**](#hal-config-deploy-component-sizing-monitoring-daemon-delete)
+ * [**hal config deploy component-sizing monitoring-daemon edit**](#hal-config-deploy-component-sizing-monitoring-daemon-edit)
+ * [**hal config deploy component-sizing orca**](#hal-config-deploy-component-sizing-orca)
+ * [**hal config deploy component-sizing orca delete**](#hal-config-deploy-component-sizing-orca-delete)
+ * [**hal config deploy component-sizing orca edit**](#hal-config-deploy-component-sizing-orca-edit)
+ * [**hal config deploy component-sizing orca-bootstrap**](#hal-config-deploy-component-sizing-orca-bootstrap)
+ * [**hal config deploy component-sizing orca-bootstrap delete**](#hal-config-deploy-component-sizing-orca-bootstrap-delete)
+ * [**hal config deploy component-sizing orca-bootstrap edit**](#hal-config-deploy-component-sizing-orca-bootstrap-edit)
+ * [**hal config deploy component-sizing redis**](#hal-config-deploy-component-sizing-redis)
+ * [**hal config deploy component-sizing redis delete**](#hal-config-deploy-component-sizing-redis-delete)
+ * [**hal config deploy component-sizing redis edit**](#hal-config-deploy-component-sizing-redis-edit)
+ * [**hal config deploy component-sizing redis-bootstrap**](#hal-config-deploy-component-sizing-redis-bootstrap)
+ * [**hal config deploy component-sizing redis-bootstrap delete**](#hal-config-deploy-component-sizing-redis-bootstrap-delete)
+ * [**hal config deploy component-sizing redis-bootstrap edit**](#hal-config-deploy-component-sizing-redis-bootstrap-edit)
+ * [**hal config deploy component-sizing rosco**](#hal-config-deploy-component-sizing-rosco)
+ * [**hal config deploy component-sizing rosco delete**](#hal-config-deploy-component-sizing-rosco-delete)
+ * [**hal config deploy component-sizing rosco edit**](#hal-config-deploy-component-sizing-rosco-edit)
+ * [**hal config deploy component-sizing vault-client**](#hal-config-deploy-component-sizing-vault-client)
+ * [**hal config deploy component-sizing vault-client delete**](#hal-config-deploy-component-sizing-vault-client-delete)
+ * [**hal config deploy component-sizing vault-client edit**](#hal-config-deploy-component-sizing-vault-client-edit)
+ * [**hal config deploy component-sizing vault-server**](#hal-config-deploy-component-sizing-vault-server)
+ * [**hal config deploy component-sizing vault-server delete**](#hal-config-deploy-component-sizing-vault-server-delete)
+ * [**hal config deploy component-sizing vault-server edit**](#hal-config-deploy-component-sizing-vault-server-edit)
  * [**hal config deploy edit**](#hal-config-deploy-edit)
  * [**hal config deploy ha**](#hal-config-deploy-ha)
  * [**hal config deploy ha clouddriver**](#hal-config-deploy-ha-clouddriver)
@@ -3658,8 +3734,1371 @@ hal config deploy [parameters] [subcommands]
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 #### Subcommands
+ * `component-sizing`: Configure, validate, and view the component sizings for the Spinnaker services.
  * `edit`: Edit Spinnaker's deployment footprint and configuration.
  * `ha`: Configure, validate, and view the specified high availability Spinnaker service configuration.
+
+---
+## hal config deploy component-sizing
+
+Configure, validate, and view the component sizings for the Spinnaker services.
+
+#### Usage
+```
+hal config deploy component-sizing [subcommands]
+```
+
+#### Subcommands
+ * `clouddriver`: Manage and view Spinnaker component sizing configuration for clouddriver
+ * `clouddriver-bootstrap`: Manage and view Spinnaker component sizing configuration for clouddriver-bootstrap
+ * `clouddriver-caching`: Manage and view Spinnaker component sizing configuration for clouddriver-caching
+ * `clouddriver-ro`: Manage and view Spinnaker component sizing configuration for clouddriver-ro
+ * `clouddriver-ro-deck`: Manage and view Spinnaker component sizing configuration for clouddriver-ro-deck
+ * `clouddriver-rw`: Manage and view Spinnaker component sizing configuration for clouddriver-rw
+ * `consul-client`: Manage and view Spinnaker component sizing configuration for consul-client
+ * `consul-server`: Manage and view Spinnaker component sizing configuration for consul-server
+ * `deck`: Manage and view Spinnaker component sizing configuration for deck
+ * `echo`: Manage and view Spinnaker component sizing configuration for echo
+ * `echo-scheduler`: Manage and view Spinnaker component sizing configuration for echo-scheduler
+ * `echo-worker`: Manage and view Spinnaker component sizing configuration for echo-worker
+ * `fiat`: Manage and view Spinnaker component sizing configuration for fiat
+ * `front50`: Manage and view Spinnaker component sizing configuration for front50
+ * `gate`: Manage and view Spinnaker component sizing configuration for gate
+ * `igor`: Manage and view Spinnaker component sizing configuration for igor
+ * `kayenta`: Manage and view Spinnaker component sizing configuration for kayenta
+ * `monitoring-daemon`: Manage and view Spinnaker component sizing configuration for monitoring-daemon
+ * `orca`: Manage and view Spinnaker component sizing configuration for orca
+ * `orca-bootstrap`: Manage and view Spinnaker component sizing configuration for orca-bootstrap
+ * `redis`: Manage and view Spinnaker component sizing configuration for redis
+ * `redis-bootstrap`: Manage and view Spinnaker component sizing configuration for redis-bootstrap
+ * `rosco`: Manage and view Spinnaker component sizing configuration for rosco
+ * `vault-client`: Manage and view Spinnaker component sizing configuration for vault-client
+ * `vault-server`: Manage and view Spinnaker component sizing configuration for vault-server
+
+---
+## hal config deploy component-sizing clouddriver
+
+Manage and view Spinnaker component sizing configuration for clouddriver
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service clouddriver
+ * `edit`: Edit the component sizing for service clouddriver, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing clouddriver delete
+
+Delete the custom component sizings for service clouddriver
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing clouddriver edit
+
+Edit the component sizing for service clouddriver, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing clouddriver-bootstrap
+
+Manage and view Spinnaker component sizing configuration for clouddriver-bootstrap
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-bootstrap [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service clouddriver-bootstrap
+ * `edit`: Edit the component sizing for service clouddriver-bootstrap, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing clouddriver-bootstrap delete
+
+Delete the custom component sizings for service clouddriver-bootstrap
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-bootstrap delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing clouddriver-bootstrap edit
+
+Edit the component sizing for service clouddriver-bootstrap, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-bootstrap edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing clouddriver-caching
+
+Manage and view Spinnaker component sizing configuration for clouddriver-caching
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-caching [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service clouddriver-caching
+ * `edit`: Edit the component sizing for service clouddriver-caching, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing clouddriver-caching delete
+
+Delete the custom component sizings for service clouddriver-caching
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-caching delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing clouddriver-caching edit
+
+Edit the component sizing for service clouddriver-caching, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-caching edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing clouddriver-ro
+
+Manage and view Spinnaker component sizing configuration for clouddriver-ro
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-ro [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service clouddriver-ro
+ * `edit`: Edit the component sizing for service clouddriver-ro, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing clouddriver-ro delete
+
+Delete the custom component sizings for service clouddriver-ro
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-ro delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing clouddriver-ro edit
+
+Edit the component sizing for service clouddriver-ro, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-ro edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing clouddriver-ro-deck
+
+Manage and view Spinnaker component sizing configuration for clouddriver-ro-deck
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-ro-deck [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service clouddriver-ro-deck
+ * `edit`: Edit the component sizing for service clouddriver-ro-deck, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing clouddriver-ro-deck delete
+
+Delete the custom component sizings for service clouddriver-ro-deck
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-ro-deck delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing clouddriver-ro-deck edit
+
+Edit the component sizing for service clouddriver-ro-deck, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-ro-deck edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing clouddriver-rw
+
+Manage and view Spinnaker component sizing configuration for clouddriver-rw
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-rw [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service clouddriver-rw
+ * `edit`: Edit the component sizing for service clouddriver-rw, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing clouddriver-rw delete
+
+Delete the custom component sizings for service clouddriver-rw
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-rw delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing clouddriver-rw edit
+
+Edit the component sizing for service clouddriver-rw, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing clouddriver-rw edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing consul-client
+
+Manage and view Spinnaker component sizing configuration for consul-client
+
+#### Usage
+```
+hal config deploy component-sizing consul-client [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service consul-client
+ * `edit`: Edit the component sizing for service consul-client, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing consul-client delete
+
+Delete the custom component sizings for service consul-client
+
+#### Usage
+```
+hal config deploy component-sizing consul-client delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing consul-client edit
+
+Edit the component sizing for service consul-client, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing consul-client edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing consul-server
+
+Manage and view Spinnaker component sizing configuration for consul-server
+
+#### Usage
+```
+hal config deploy component-sizing consul-server [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service consul-server
+ * `edit`: Edit the component sizing for service consul-server, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing consul-server delete
+
+Delete the custom component sizings for service consul-server
+
+#### Usage
+```
+hal config deploy component-sizing consul-server delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing consul-server edit
+
+Edit the component sizing for service consul-server, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing consul-server edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing deck
+
+Manage and view Spinnaker component sizing configuration for deck
+
+#### Usage
+```
+hal config deploy component-sizing deck [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service deck
+ * `edit`: Edit the component sizing for service deck, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing deck delete
+
+Delete the custom component sizings for service deck
+
+#### Usage
+```
+hal config deploy component-sizing deck delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing deck edit
+
+Edit the component sizing for service deck, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing deck edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing echo
+
+Manage and view Spinnaker component sizing configuration for echo
+
+#### Usage
+```
+hal config deploy component-sizing echo [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service echo
+ * `edit`: Edit the component sizing for service echo, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing echo delete
+
+Delete the custom component sizings for service echo
+
+#### Usage
+```
+hal config deploy component-sizing echo delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing echo edit
+
+Edit the component sizing for service echo, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing echo edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing echo-scheduler
+
+Manage and view Spinnaker component sizing configuration for echo-scheduler
+
+#### Usage
+```
+hal config deploy component-sizing echo-scheduler [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service echo-scheduler
+ * `edit`: Edit the component sizing for service echo-scheduler, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing echo-scheduler delete
+
+Delete the custom component sizings for service echo-scheduler
+
+#### Usage
+```
+hal config deploy component-sizing echo-scheduler delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing echo-scheduler edit
+
+Edit the component sizing for service echo-scheduler, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing echo-scheduler edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing echo-worker
+
+Manage and view Spinnaker component sizing configuration for echo-worker
+
+#### Usage
+```
+hal config deploy component-sizing echo-worker [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service echo-worker
+ * `edit`: Edit the component sizing for service echo-worker, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing echo-worker delete
+
+Delete the custom component sizings for service echo-worker
+
+#### Usage
+```
+hal config deploy component-sizing echo-worker delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing echo-worker edit
+
+Edit the component sizing for service echo-worker, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing echo-worker edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing fiat
+
+Manage and view Spinnaker component sizing configuration for fiat
+
+#### Usage
+```
+hal config deploy component-sizing fiat [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service fiat
+ * `edit`: Edit the component sizing for service fiat, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing fiat delete
+
+Delete the custom component sizings for service fiat
+
+#### Usage
+```
+hal config deploy component-sizing fiat delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing fiat edit
+
+Edit the component sizing for service fiat, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing fiat edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing front50
+
+Manage and view Spinnaker component sizing configuration for front50
+
+#### Usage
+```
+hal config deploy component-sizing front50 [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service front50
+ * `edit`: Edit the component sizing for service front50, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing front50 delete
+
+Delete the custom component sizings for service front50
+
+#### Usage
+```
+hal config deploy component-sizing front50 delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing front50 edit
+
+Edit the component sizing for service front50, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing front50 edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing gate
+
+Manage and view Spinnaker component sizing configuration for gate
+
+#### Usage
+```
+hal config deploy component-sizing gate [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service gate
+ * `edit`: Edit the component sizing for service gate, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing gate delete
+
+Delete the custom component sizings for service gate
+
+#### Usage
+```
+hal config deploy component-sizing gate delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing gate edit
+
+Edit the component sizing for service gate, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing gate edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing igor
+
+Manage and view Spinnaker component sizing configuration for igor
+
+#### Usage
+```
+hal config deploy component-sizing igor [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service igor
+ * `edit`: Edit the component sizing for service igor, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing igor delete
+
+Delete the custom component sizings for service igor
+
+#### Usage
+```
+hal config deploy component-sizing igor delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing igor edit
+
+Edit the component sizing for service igor, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing igor edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing kayenta
+
+Manage and view Spinnaker component sizing configuration for kayenta
+
+#### Usage
+```
+hal config deploy component-sizing kayenta [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service kayenta
+ * `edit`: Edit the component sizing for service kayenta, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing kayenta delete
+
+Delete the custom component sizings for service kayenta
+
+#### Usage
+```
+hal config deploy component-sizing kayenta delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing kayenta edit
+
+Edit the component sizing for service kayenta, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing kayenta edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing monitoring-daemon
+
+Manage and view Spinnaker component sizing configuration for monitoring-daemon
+
+#### Usage
+```
+hal config deploy component-sizing monitoring-daemon [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service monitoring-daemon
+ * `edit`: Edit the component sizing for service monitoring-daemon, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing monitoring-daemon delete
+
+Delete the custom component sizings for service monitoring-daemon
+
+#### Usage
+```
+hal config deploy component-sizing monitoring-daemon delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing monitoring-daemon edit
+
+Edit the component sizing for service monitoring-daemon, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing monitoring-daemon edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing orca
+
+Manage and view Spinnaker component sizing configuration for orca
+
+#### Usage
+```
+hal config deploy component-sizing orca [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service orca
+ * `edit`: Edit the component sizing for service orca, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing orca delete
+
+Delete the custom component sizings for service orca
+
+#### Usage
+```
+hal config deploy component-sizing orca delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing orca edit
+
+Edit the component sizing for service orca, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing orca edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing orca-bootstrap
+
+Manage and view Spinnaker component sizing configuration for orca-bootstrap
+
+#### Usage
+```
+hal config deploy component-sizing orca-bootstrap [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service orca-bootstrap
+ * `edit`: Edit the component sizing for service orca-bootstrap, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing orca-bootstrap delete
+
+Delete the custom component sizings for service orca-bootstrap
+
+#### Usage
+```
+hal config deploy component-sizing orca-bootstrap delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing orca-bootstrap edit
+
+Edit the component sizing for service orca-bootstrap, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing orca-bootstrap edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing redis
+
+Manage and view Spinnaker component sizing configuration for redis
+
+#### Usage
+```
+hal config deploy component-sizing redis [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service redis
+ * `edit`: Edit the component sizing for service redis, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing redis delete
+
+Delete the custom component sizings for service redis
+
+#### Usage
+```
+hal config deploy component-sizing redis delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing redis edit
+
+Edit the component sizing for service redis, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing redis edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing redis-bootstrap
+
+Manage and view Spinnaker component sizing configuration for redis-bootstrap
+
+#### Usage
+```
+hal config deploy component-sizing redis-bootstrap [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service redis-bootstrap
+ * `edit`: Edit the component sizing for service redis-bootstrap, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing redis-bootstrap delete
+
+Delete the custom component sizings for service redis-bootstrap
+
+#### Usage
+```
+hal config deploy component-sizing redis-bootstrap delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing redis-bootstrap edit
+
+Edit the component sizing for service redis-bootstrap, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing redis-bootstrap edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing rosco
+
+Manage and view Spinnaker component sizing configuration for rosco
+
+#### Usage
+```
+hal config deploy component-sizing rosco [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service rosco
+ * `edit`: Edit the component sizing for service rosco, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing rosco delete
+
+Delete the custom component sizings for service rosco
+
+#### Usage
+```
+hal config deploy component-sizing rosco delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing rosco edit
+
+Edit the component sizing for service rosco, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing rosco edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing vault-client
+
+Manage and view Spinnaker component sizing configuration for vault-client
+
+#### Usage
+```
+hal config deploy component-sizing vault-client [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service vault-client
+ * `edit`: Edit the component sizing for service vault-client, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing vault-client delete
+
+Delete the custom component sizings for service vault-client
+
+#### Usage
+```
+hal config deploy component-sizing vault-client delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing vault-client edit
+
+Edit the component sizing for service vault-client, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing vault-client edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
+
+---
+## hal config deploy component-sizing vault-server
+
+Manage and view Spinnaker component sizing configuration for vault-server
+
+#### Usage
+```
+hal config deploy component-sizing vault-server [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `delete`: Delete the custom component sizings for service vault-server
+ * `edit`: Edit the component sizing for service vault-server, such as the number of replicas and the resources limits.
+
+---
+## hal config deploy component-sizing vault-server delete
+
+Delete the custom component sizings for service vault-server
+
+#### Usage
+```
+hal config deploy component-sizing vault-server delete [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config deploy component-sizing vault-server edit
+
+Edit the component sizing for service vault-server, such as the number of replicas and the resources limits.
+
+#### Usage
+```
+hal config deploy component-sizing vault-server edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--pod-limits-cpu`: Sets the cpu limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1.
+ * `--pod-limits-memory`: Sets the memory limit for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 1Gi.
+ * `--pod-requests-cpu`: Sets the cpu request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 250m.
+ * `--pod-requests-memory`: Sets the memory request for the container running the spinnaker service, as well as any sidecar containers (e.g. the monitoring daemon). Example: 512Mi.
+ * `--replicas`: (*Default*: `1`) Set the number of replicas (pods) to be created for this service.
+
 
 ---
 ## hal config deploy edit
@@ -7967,6 +9406,11 @@ hal config security authn saml edit [parameters]
  * `--metadata`: The address to your identity provider's metadata XML file. This can be a URL or the path of a local file.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--service-address-url`: The address of the Gate server that will be accesible by the SAML identity provider. This should be the full URL, including port, e.g. https://gate.org.com:8084/. If deployed behind a load balancer, this would be the laod balancer's address.
+ * `--user-attribute-mapping-first-name`: The first name field returned from your SAML provider.
+ * `--user-attribute-mapping-last-name`: The last name field returned from your SAML provider.
+ * `--user-attribute-mapping-roles`: The roles field returned from your SAML provider.
+ * `--user-attribute-mapping-roles-delimiter`: The roles delimiter field returned from your SAML provider.
+ * `--user-attribute-mapping-username`: The username field returned from your SAML provider.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingDeleteCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingDeleteCommand.java
@@ -42,7 +42,7 @@ public class ComponentSizingDeleteCommand extends AbstractComponentSizingUpdateC
     }
 
     @Override
-    protected String getShortDescription() {
+    protected String getDescription() {
         return "Delete the custom component sizings for service " + spinnakerService.getCanonicalName();
     }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingEditCommand.java
@@ -77,7 +77,7 @@ public class ComponentSizingEditCommand extends AbstractComponentSizingUpdateCom
     }
 
     @Override
-    protected String getShortDescription() {
+    protected String getDescription() {
         return "Edit the component sizing for service " + spinnakerService.getCanonicalName() +
                 ", such as the number of replicas and the resources limits.";
     }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
@@ -54,7 +54,7 @@ public class NamedComponentSizingCommand extends AbstractConfigCommand {
   }
 
   @Override
-  protected String getShortDescription() {
+  protected String getDescription() {
     return "Manage and view Spinnaker component sizing configuration for " + spinnakerService.getCanonicalName();
   }
 


### PR DESCRIPTION
The prior commit implemented getShortDescription for new commands, but not either getLongDescription or getDescription. As a quick fix, just rename the getShortDescription to getDescription which fixes docs generation.