### PR TITLE
refactor(docs): Refactor descriptions to use static type checking

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/AdminCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/AdminCommand.java
@@ -31,7 +31,7 @@ public class AdminCommand extends NestableCommand {
   private String commandName = "admin";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "This is meant for users building and publishing their own Spinnaker images and config.";
+  private String shortDescription = "This is meant for users building and publishing their own Spinnaker images and config.";
 
   public AdminCommand() {
     registerSubcommand(new DeprecateCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
@@ -43,7 +43,7 @@ public class ConfigCommand extends AbstractConfigCommand {
   private String commandName = "config";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view your halconfig.";
+  private String shortDescription = "Configure, validate, and view your halconfig.";
 
   @Parameter(
       names = "--set-current-deployment",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/DeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/DeployCommand.java
@@ -27,7 +27,7 @@ public class DeployCommand extends NestableCommand {
   private String commandName = "deploy";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Manage the deployment of Spinnaker. This includes where it's deployed,"
+  private String shortDescription = "Manage the deployment of Spinnaker. This includes where it's deployed,"
       + " what the infrastructure footprint looks like, what the currently running deployment looks like, etc...";
 
   public DeployCommand() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
@@ -72,7 +72,7 @@ public class HalCommand extends NestableCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "A tool for configuring, installing, and updating Spinnaker.\n\n"
         + "If this is your first time using Halyard to install Spinnaker we recommend that you skim "
         + "the documentation on www.spinnaker.io/docs for some familiarity with the product. If at any "

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -239,8 +239,7 @@ public abstract class NestableCommand {
     story.addNewline();
 
     paragraph = story.addParagraph().setIndentWidth(indentWidth);
-    String longDescription = getLongDescription() != null ? getLongDescription() : getDescription();
-    paragraph.addSnippet(longDescription);
+    paragraph.addSnippet(getLongDescription());
     story.addNewline();
 
     String usage = fullCommandName;
@@ -328,8 +327,7 @@ public abstract class NestableCommand {
         }
 
         paragraph = story.addParagraph().setIndentWidth(indentWidth * 2);
-        String shortDescription = subcommand.getShortDescription() != null ? subcommand.getShortDescription() : subcommand.getDescription();
-        paragraph.addSnippet(shortDescription);
+        paragraph.addSnippet(subcommand.getShortDescription());
         story.addNewline();
       }
     }
@@ -404,11 +402,10 @@ public abstract class NestableCommand {
       }
     }
 
-    String longDescription = getLongDescription() != null ? getLongDescription() : getDescription();
     result.append("## ")
         .append(fullCommandName)
         .append("\n\n")
-        .append(longDescription)
+        .append(getLongDescription())
         .append("\n\n")
         .append("#### Usage")
         .append("\n```\n")
@@ -481,7 +478,6 @@ public abstract class NestableCommand {
         if (subcommand instanceof DeprecatedCommand) {
           modifiers += " _(Deprecated)_ ";
         }
-        String shortDescription = subcommand.getShortDescription() != null ? subcommand.getShortDescription() : subcommand.getDescription();
 
         result.append(" * ")
             .append("`")
@@ -489,7 +485,7 @@ public abstract class NestableCommand {
             .append("`")
             .append(modifiers)
             .append(": ")
-            .append(shortDescription)
+            .append(subcommand.getShortDescription())
             .append("\n");
       }
     }
@@ -561,19 +557,9 @@ public abstract class NestableCommand {
   abstract public String getCommandName();
   abstract protected void executeThis();
 
-  @Deprecated
-  protected String getDescription() {
-    throw new UnsupportedOperationException("Each command must implement a description. Preferably `get[Long/Short]Description()`. Missing class: " + getClass().getCanonicalName());
-  }
-
-  // TODO(lwander) make abstract once `getDescription` is removed.
-  protected String getShortDescription() {
-    return null;
-  }
-
-  // TODO(lwander) make abstract once `getDescription` is removed.
+  protected abstract String getShortDescription();
   protected String getLongDescription() {
-    return null;
+    return getShortDescription();
   }
 
   @Getter(AccessLevel.PROTECTED)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ShutdownCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ShutdownCommand.java
@@ -34,7 +34,7 @@ public class ShutdownCommand extends NestableCommand {
   private String commandName = "shutdown";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Shutdown the halyard daemon.";
+  private String shortDescription = "Shutdown the halyard daemon.";
 
   @Override
   protected void executeThis() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/SpinCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/SpinCommand.java
@@ -27,7 +27,7 @@ public class SpinCommand extends NestableCommand {
   private String commandName = "spin";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Manage the lifecycle of spin CLI.";
+  private String shortDescription = "Manage the lifecycle of spin CLI.";
 
   public SpinCommand() {
     registerSubcommand(new InstallSpinCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/VersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/VersionCommand.java
@@ -31,9 +31,6 @@ public class VersionCommand extends NestableCommand {
   @Getter(AccessLevel.PUBLIC)
   private String shortDescription = "Get information about the available Spinnaker versions.";
 
-  @Getter(AccessLevel.PUBLIC)
-  private String longDescription = shortDescription;
-
   public VersionCommand() {
     registerSubcommand(new LatestVersionCommand());
     registerSubcommand(new BomVersionCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/DeprecateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/DeprecateCommand.java
@@ -29,7 +29,7 @@ public class DeprecateCommand extends NestableCommand {
   private String commandName = "deprecate";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Deprecate config artifacts in your configured halconfig bucket.";
+  private String shortDescription = "Deprecate config artifacts in your configured halconfig bucket.";
 
   public DeprecateCommand() {
     super();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/DeprecateVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/DeprecateVersionCommand.java
@@ -33,7 +33,7 @@ public class DeprecateVersionCommand extends NestableCommand {
   private String commandName = "version";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Deprecate a version of Spinnaker, removing it from the global versions.yml tracking file.";
+  private String shortDescription = "Deprecate a version of Spinnaker, removing it from the global versions.yml tracking file.";
 
   @Parameter(
       names = "--version",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishBomCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishBomCommand.java
@@ -32,7 +32,7 @@ public class PublishBomCommand extends NestableCommand {
   private String commandName = "bom";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish a Bill of Materials (BOM).";
+  private String shortDescription = "Publish a Bill of Materials (BOM).";
 
   @Parameter(
       names = "--bom-path",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishCommand.java
@@ -28,7 +28,7 @@ public class PublishCommand extends NestableCommand {
   private String commandName = "publish";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish config artifacts to your configured halconfig bucket.";
+  private String shortDescription = "Publish config artifacts to your configured halconfig bucket.";
 
   public PublishCommand() {
     super();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestCommand.java
@@ -35,7 +35,7 @@ public class PublishLatestCommand extends NestableCommand implements DeprecatedC
   private String commandName = "latest";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish the latest version of Spinnaker to the global versions.yml tracking file.";
+  private String shortDescription = "Publish the latest version of Spinnaker to the global versions.yml tracking file.";
 
   @Getter(AccessLevel.PUBLIC)
   private String deprecatedWarning = "Please use `hal admin publish latest-spinnaker` instead.";

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestHalyardCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestHalyardCommand.java
@@ -35,7 +35,7 @@ public class PublishLatestHalyardCommand extends NestableCommand {
   private String commandName = "latest-halyard";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish the latest version of Halyard to the global versions.yml tracking file.";
+  private String shortDescription = "Publish the latest version of Halyard to the global versions.yml tracking file.";
 
   @Override
   public String getMainParameter() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestSpinnakerCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestSpinnakerCommand.java
@@ -35,7 +35,7 @@ public class PublishLatestSpinnakerCommand extends NestableCommand {
   private String commandName = "latest-spinnaker";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish the latest version of Spinnaker to the global versions.yml tracking file.";
+  private String shortDescription = "Publish the latest version of Spinnaker to the global versions.yml tracking file.";
 
   @Override
   public String getMainParameter() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
@@ -35,7 +35,7 @@ public class PublishProfileCommand extends NestableCommand {
   private String commandName = "profile";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish a base halconfig profile for a specific Spinnaker artifact.";
+  private String shortDescription = "Publish a base halconfig profile for a specific Spinnaker artifact.";
 
   @Parameter(
       names = "--bom-path",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishVersionCommand.java
@@ -34,7 +34,7 @@ public class PublishVersionCommand extends NestableCommand {
   private String commandName = "version";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Publish a version of Spinnaker to the global versions.yml tracking file.";
+  private String shortDescription = "Publish a version of Spinnaker to the global versions.yml tracking file.";
 
   @Parameter(
       names = "--version",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/DeploymentEnvironmentCommand.java
@@ -33,7 +33,7 @@ public class DeploymentEnvironmentCommand extends AbstractConfigCommand {
   private String commandName = "deploy";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Display the configured Spinnaker deployment.";
+  private String shortDescription = "Display the configured Spinnaker deployment.";
 
   public DeploymentEnvironmentCommand() {
     registerSubcommand(new EditDeploymentEnvironmentCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -34,7 +34,7 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
   final private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  final private String description = "Edit Spinnaker's deployment footprint and configuration.";
+  final private String shortDescription = "Edit Spinnaker's deployment footprint and configuration.";
 
   @Parameter(
       names = "--account-name",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -31,7 +31,7 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Enable and disable Spinnaker feature flags.";
+  private String shortDescription = "Enable and disable Spinnaker feature flags.";
 
   @Parameter(
       names = "--chaos",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditVersionCommand.java
@@ -30,7 +30,7 @@ public class EditVersionCommand extends AbstractConfigCommand {
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Set the desired Spinnaker version.";
+  private String shortDescription = "Set the desired Spinnaker version.";
 
   @Parameter(
       names = "--version",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/FeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/FeaturesCommand.java
@@ -30,7 +30,7 @@ public class FeaturesCommand extends AbstractConfigCommand {
   private String commandName = "features";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Display the state of Spinnaker's feature flags.";
+  private String shortDescription = "Display the state of Spinnaker's feature flags.";
 
   public FeaturesCommand() {
     registerSubcommand(new EditFeaturesCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/GenerateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/GenerateCommand.java
@@ -29,7 +29,7 @@ public class GenerateCommand extends AbstractConfigCommand {
   private String commandName = "generate";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Generate the full Spinnaker config for your current deployment. "
+  private String shortDescription = "Generate the full Spinnaker config for your current deployment. "
     + "This does _not_ apply that configuration to your running Spinnaker installation. "
     + "That either needs to be done manually, or with `hal deploy apply`.";
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ListCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ListCommand.java
@@ -14,7 +14,7 @@ public class ListCommand extends AbstractConfigCommand {
     private String commandName = "list";
 
     @Getter(AccessLevel.PUBLIC)
-    private String description = "Lists all deployments";
+    private String shortDescription = "Lists all deployments";
 
     @Override
     protected void executeThis() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/MetricStoresCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/MetricStoresCommand.java
@@ -35,7 +35,7 @@ public class MetricStoresCommand extends AbstractConfigCommand {
   private String commandName = "metric-stores";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure Spinnaker's metric stores. Metrics stores are used to store metrics for the various "
+  private String shortDescription = "Configure Spinnaker's metric stores. Metrics stores are used to store metrics for the various "
       + "Spinnaker micro-services. These metrics are not related in any way to canary deployments. The technologies backing both "
       + "are similar, but metrics stores are places to push metrics regarding Spinnaker metrics, whereas canary metrics stores "
       + "are used to pull metrics to analyze deployments. This configuration only affects the publishing of metrics against "

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/NotificationCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/NotificationCommand.java
@@ -35,7 +35,7 @@ public class NotificationCommand extends AbstractConfigCommand {
   private String commandName = "notification";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Display the state of Spinnaker's notification settings.";
+  private String shortDescription = "Display the state of Spinnaker's notification settings.";
 
   public NotificationCommand() {
     registerSubcommand(new PubsubCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/PersistentStorageCommand.java
@@ -35,7 +35,7 @@ public class PersistentStorageCommand extends AbstractConfigCommand {
   private String commandName = "storage";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Show Spinnaker's persistent storage configuration.";
+  private String shortDescription = "Show Spinnaker's persistent storage configuration.";
 
   public PersistentStorageCommand() {
     registerSubcommand(new GcsCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/SecurityCommand.java
@@ -35,7 +35,7 @@ public class SecurityCommand extends AbstractConfigCommand {
   private String commandName = "security";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure Spinnaker's security. This includes external SSL, authentication mechanisms, and authorization policies.";
+  private String shortDescription = "Configure Spinnaker's security. This includes external SSL, authentication mechanisms, and authorization policies.";
 
   public SecurityCommand() {
     registerSubcommand(new ApiSecurityCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/VersionConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/VersionConfigCommand.java
@@ -30,7 +30,7 @@ public class VersionConfigCommand extends AbstractConfigCommand {
   private String commandName = "version";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure & view the current deployment of Spinnaker's version.";
+  private String shortDescription = "Configure & view the current deployment of Spinnaker's version.";
 
   public VersionConfigCommand() {
     registerSubcommand(new EditVersionCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/AbstractArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/AbstractArtifactAccountCommand.java
@@ -32,7 +32,7 @@ public abstract class AbstractArtifactAccountCommand extends AbstractHasArtifact
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getArtifactProviderName() + " artifact provider's account";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/AbstractArtifactProviderEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/AbstractArtifactProviderEnableDisableCommand.java
@@ -47,7 +47,7 @@ public abstract class AbstractArtifactProviderEnableDisableCommand extends Abstr
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set the " + getArtifactProviderName() + " artifact provider as " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/AbstractNamedArtifactProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/AbstractNamedArtifactProviderCommand.java
@@ -37,11 +37,6 @@ public abstract class AbstractNamedArtifactProviderCommand extends AbstractArtif
     return "Manage and view Spinnaker configuration for the " + getArtifactProviderName() + " provider";
   }
 
-  @Override
-  public String getDescription() {
-    return "Manage and view Spinnaker configuration for the " + getArtifactProviderName() + " provider";
-  }
-
   protected AbstractNamedArtifactProviderCommand() {
     registerSubcommand(new ArtifactProviderEnableDisableCommandBuilder()
         .setArtifactProviderName(getArtifactProviderName())

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/ArtifactProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/ArtifactProviderCommand.java
@@ -44,7 +44,7 @@ public class ArtifactProviderCommand extends NestableCommand {
   private String commandName = "artifact";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the specified artifact provider.";
+  private String shortDescription = "Configure, validate, and view the specified artifact provider.";
 
   public ArtifactProviderCommand() {
     registerSubcommand(new BitbucketArtifactProviderCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractAddArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractAddArtifactAccountCommand.java
@@ -41,7 +41,7 @@ public abstract class AbstractAddArtifactAccountCommand extends AbstractHasArtif
 
   protected abstract ArtifactAccount emptyArtifactAccount();
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Add an artifact account to the " + getArtifactProviderName() + " artifact provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractArtifactEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractArtifactEditAccountCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractArtifactEditAccountCommand<T extends ArtifactAccou
 
   protected abstract ArtifactAccount editArtifactAccount(T account);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit an artifact account in the " + getArtifactProviderName() + " artifact provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractDeleteArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractDeleteArtifactAccountCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractDeleteArtifactAccountCommand extends AbstractHasAr
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getArtifactProviderName() + " artifact account by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractGetArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractGetArtifactAccountCommand.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 
 @Parameters(separators = "=")
 abstract class AbstractGetArtifactAccountCommand extends AbstractHasArtifactAccountCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified account details for the " + getArtifactProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractListArtifactAccountsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractListArtifactAccountsCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 @Parameters(separators = "=")
 abstract class AbstractListArtifactAccountsCommand extends AbstractArtifactProviderCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the artifact account names for the " + getArtifactProviderName() + " artifact provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/AddArtifactTemplateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/AddArtifactTemplateCommand.java
@@ -29,7 +29,7 @@ public class AddArtifactTemplateCommand extends AbstractHasArtifactTemplateComma
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "add";
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Add an artifact template";
+  private String shortDescription = "Add an artifact template";
 
   @Parameter(
       names = "--template-path",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/ArtifactTemplateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/ArtifactTemplateCommand.java
@@ -33,7 +33,7 @@ public class ArtifactTemplateCommand extends AbstractConfigCommand {
   private String commandName = "templates";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Show Spinnaker's configured artifact templates.";
+  private String shortDescription = "Show Spinnaker's configured artifact templates.";
 
   public ArtifactTemplateCommand() {
     registerSubcommand(new AddArtifactTemplateCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/DeleteArtifactTemplateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/DeleteArtifactTemplateCommand.java
@@ -27,7 +27,7 @@ public class DeleteArtifactTemplateCommand extends AbstractHasArtifactTemplateCo
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Delete an artifact template";
+  private String shortDescription = "Delete an artifact template";
 
   @Override
   protected void executeThis() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/EditArtifactTemplateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/EditArtifactTemplateCommand.java
@@ -29,7 +29,7 @@ public class EditArtifactTemplateCommand extends AbstractHasArtifactTemplateComm
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "edit";
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Edit an artifact template";
+  private String shortDescription = "Edit an artifact template";
   @Parameter(
       names = "--template-path",
       description = "The path to the Jinja template to use for artifact extraction"

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/ListArtifactTemplatesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/ListArtifactTemplatesCommand.java
@@ -32,7 +32,7 @@ public class ListArtifactTemplatesCommand extends AbstractConfigCommand {
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "list";
   @Getter(AccessLevel.PUBLIC)
-  private String description = "List an artifact templates";
+  private String shortDescription = "List an artifact templates";
 
   private List<ArtifactTemplate> getArtifactTemplates() {
     String currentDeployment = getCurrentDeployment();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/AbstractEditCanaryServiceIntegrationCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/AbstractEditCanaryServiceIntegrationCommand.java
@@ -28,5 +28,5 @@ public abstract class AbstractEditCanaryServiceIntegrationCommand extends Abstra
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Edit Spinnaker's canary analysis " + getServiceIntegration() + " service integration settings.";
+  private String shortDescription = "Edit Spinnaker's canary analysis " + getServiceIntegration() + " service integration settings.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/AbstractEnableDisableCanaryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/AbstractEnableDisableCanaryCommand.java
@@ -53,11 +53,6 @@ public abstract class AbstractEnableDisableCanaryCommand extends AbstractConfigC
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
     boolean enable = isEnable();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/AbstractEnableDisableCanaryServiceIntegrationCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/AbstractEnableDisableCanaryServiceIntegrationCommand.java
@@ -60,11 +60,6 @@ public abstract class AbstractEnableDisableCanaryServiceIntegrationCommand exten
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/CanaryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/CanaryCommand.java
@@ -39,8 +39,6 @@ public class CanaryCommand extends AbstractConfigCommand {
 
   String shortDescription = "Configure your canary analysis settings for Spinnaker.";
 
-  String longDescription = shortDescription;
-
   public CanaryCommand() {
     registerSubcommand(new EnableDisableCanaryCommandBuilder().setEnable(true).build());
     registerSubcommand(new EnableDisableCanaryCommandBuilder().setEnable(false).build());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/EditCanaryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/EditCanaryCommand.java
@@ -32,7 +32,7 @@ public class EditCanaryCommand extends AbstractConfigCommand {
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Edit Spinnaker's canary analysis settings.";
+  private String shortDescription = "Edit Spinnaker's canary analysis settings.";
 
   @Parameter(
       names = "--redux-logger-enabled",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractAddCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractAddCanaryAccountCommand.java
@@ -44,9 +44,6 @@ public abstract class AbstractAddCanaryAccountCommand extends AbstractHasCanaryA
   @Getter(AccessLevel.PUBLIC)
   String shortDescription = "Add a canary account to the " + getServiceIntegration() + " service integration.";
 
-  @Getter(AccessLevel.PUBLIC)
-  String longDescription = shortDescription;
-
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractCanaryAccountCommand.java
@@ -31,11 +31,6 @@ public abstract class AbstractCanaryAccountCommand extends AbstractHasCanaryAcco
     return "Manage and view Spinnaker configuration for the " + getServiceIntegration() + " service integration's canary accounts.";
   }
 
-  @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
   protected AbstractCanaryAccountCommand() {
     registerSubcommand(new GetCanaryAccountCommand(getServiceIntegration()));
     registerSubcommand(new DeleteCanaryAccountCommand(getServiceIntegration()));

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractEditCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractEditCanaryAccountCommand.java
@@ -42,9 +42,6 @@ public abstract class AbstractEditCanaryAccountCommand<T extends AbstractCanaryA
   @Getter(AccessLevel.PUBLIC)
   String shortDescription = "Edit a canary account in the " + getServiceIntegration() + " service integration.";
 
-  @Getter(AccessLevel.PUBLIC)
-  String longDescription = shortDescription;
-
   @Override
   protected void executeThis() {
     String accountName = getAccountName();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/DeleteCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/DeleteCanaryAccountCommand.java
@@ -49,11 +49,6 @@ public class DeleteCanaryAccountCommand extends AbstractHasCanaryAccountCommand 
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected void executeThis() {
     deleteAccount(getAccountName());
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/GetCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/GetCanaryAccountCommand.java
@@ -44,11 +44,6 @@ public class GetCanaryAccountCommand extends AbstractHasCanaryAccountCommand {
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected void executeThis() {
     AnsiUi.success(AnsiFormatUtils.format(getAccount(getAccountName())));
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/ListCanaryAccountsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/ListCanaryAccountsCommand.java
@@ -44,11 +44,6 @@ public class ListCanaryAccountsCommand extends AbstractCanaryServiceIntegrationC
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected void executeThis() {
     AbstractCanaryServiceIntegration serviceIntegration = CanaryUtils.getServiceIntegrationByName(null, getCurrentDeployment(), getServiceIntegration(), noValidate);
     List<AbstractCanaryAccount> accounts = serviceIntegration.getAccounts();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/aws/CanaryAwsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/aws/CanaryAwsCommand.java
@@ -37,8 +37,6 @@ public class CanaryAwsCommand extends AbstractConfigCommand {
 
   String shortDescription = "Configure your canary analysis AWS service integration settings for Spinnaker.";
 
-  String longDescription = shortDescription;
-
   public CanaryAwsCommand() {
     registerSubcommand(new EditCanaryAwsCommand());
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("AWS").setEnable(true).build());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/datadog/CanaryDatadogCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/datadog/CanaryDatadogCommand.java
@@ -37,8 +37,6 @@ public class CanaryDatadogCommand extends AbstractConfigCommand {
 
   String shortDescription = "Configure your canary analysis Datadog service integration settings for Spinnaker.";
 
-  String longDescription = shortDescription;
-
   public CanaryDatadogCommand() {
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("Datadog").setEnable(true).build());
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("Datadog").setEnable(false).build());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/google/CanaryGoogleCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/google/CanaryGoogleCommand.java
@@ -37,8 +37,6 @@ public class CanaryGoogleCommand extends AbstractConfigCommand {
 
   String shortDescription = "Configure your canary analysis Google service integration settings for Spinnaker.";
 
-  String longDescription = shortDescription;
-
   public CanaryGoogleCommand() {
     registerSubcommand(new EditCanaryGoogleCommand());
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("Google").setEnable(true).build());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/prometheus/CanaryPrometheusCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/prometheus/CanaryPrometheusCommand.java
@@ -38,8 +38,6 @@ public class CanaryPrometheusCommand extends AbstractConfigCommand {
 
   String shortDescription = "Configure your canary analysis Prometheus service integration settings for Spinnaker.";
 
-  String longDescription = shortDescription;
-
   public CanaryPrometheusCommand() {
     registerSubcommand(new EditCanaryPrometheusCommand());
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("Prometheus").setEnable(true).build());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/signalfx/CanarySignalfxCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/signalfx/CanarySignalfxCommand.java
@@ -37,8 +37,6 @@ public class CanarySignalfxCommand extends AbstractConfigCommand {
 
   String shortDescription = "Configure your canary analysis SignalFx service integration settings for Spinnaker.";
 
-  String longDescription = shortDescription;
-
   public CanarySignalfxCommand() {
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("Signalfx").setEnable(true).build());
     registerSubcommand(new EnableDisableCanaryServiceIntegrationCommandBuilder().setName("Signalfx").setEnable(false).build());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractCiEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractCiEnableDisableCommand.java
@@ -48,7 +48,7 @@ public abstract class AbstractCiEnableDisableCommand extends AbstractCiCommand {
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set the " + getCiName() + " ci as " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractMasterCommand.java
@@ -31,7 +31,7 @@ public abstract class AbstractMasterCommand extends AbstractHasMasterCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getCiName() + " Continuous Integration services's master";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractNamedCiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractNamedCiCommand.java
@@ -31,7 +31,7 @@ public abstract class AbstractNamedCiCommand extends AbstractCiCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getCiName() + " ci";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/CiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/CiCommand.java
@@ -37,7 +37,7 @@ public class CiCommand extends NestableCommand {
   private String commandName = "ci";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the specified Continuous Integration service.";
+  private String shortDescription = "Configure, validate, and view the specified Continuous Integration service.";
 
   public CiCommand() {
     registerSubcommand(new JenkinsCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractAddMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractAddMasterCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractAddMasterCommand extends AbstractHasMasterCommand 
 
   protected abstract Master buildMaster(String masterName);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Add a master for the " + getCiName() + " Continuous Integration service.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractDeleteMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractDeleteMasterCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractDeleteMasterCommand extends AbstractHasMasterComma
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getCiName() + " master by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractEditMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractEditMasterCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractEditMasterCommand<T extends Master> extends Abstra
 
   protected abstract Master editMaster(T master);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit a master for the " + getCiName() + " Continuous Integration service.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractGetMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractGetMasterCommand.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 
 @Parameters(separators = "=")
 abstract class AbstractGetMasterCommand extends AbstractHasMasterCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified master details for " + getCiName() + ".";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractListMastersCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractListMastersCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 @Parameters(separators = "=")
 abstract class AbstractListMastersCommand extends AbstractCiCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the master names for " + getCiName() + ".";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/ha/AbstractHaServiceEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/ha/AbstractHaServiceEditCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractHaServiceEditCommand<T extends HaService> extends 
 
   protected abstract HaService editHaService(T haService);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit the " + getServiceName() + " high availability service";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/ha/AbstractHaServiceEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/ha/AbstractHaServiceEnableDisableCommand.java
@@ -48,7 +48,7 @@ public abstract class AbstractHaServiceEnableDisableCommand extends AbstractHaSe
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set the " + getServiceName() + " high availability service as " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/ha/HaServiceCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/ha/HaServiceCommand.java
@@ -29,7 +29,7 @@ public class HaServiceCommand extends NestableCommand {
   private String commandName = "ha";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the specified high availability Spinnaker service configuration.";
+  private String shortDescription = "Configure, validate, and view the specified high availability Spinnaker service configuration.";
 
   public HaServiceCommand() {
     registerSubcommand(new ClouddriverHaServiceCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingCommand.java
@@ -35,7 +35,7 @@ public class ComponentSizingCommand extends NestableCommand {
   private String commandName = "component-sizing";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the component sizings for the Spinnaker services.";
+  private String shortDescription = "Configure, validate, and view the component sizings for the Spinnaker services.";
 
   public ComponentSizingCommand() {
     for (SpinnakerService.Type spinnakerService : SpinnakerService.Type.values()) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingDeleteCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingDeleteCommand.java
@@ -42,7 +42,7 @@ public class ComponentSizingDeleteCommand extends AbstractComponentSizingUpdateC
     }
 
     @Override
-    protected String getDescription() {
+    protected String getShortDescription() {
         return "Delete the custom component sizings for service " + spinnakerService.getCanonicalName();
     }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/ComponentSizingEditCommand.java
@@ -77,7 +77,7 @@ public class ComponentSizingEditCommand extends AbstractComponentSizingUpdateCom
     }
 
     @Override
-    protected String getDescription() {
+    protected String getShortDescription() {
         return "Edit the component sizing for service " + spinnakerService.getCanonicalName() +
                 ", such as the number of replicas and the resources limits.";
     }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/deploy/sizing/NamedComponentSizingCommand.java
@@ -54,7 +54,7 @@ public class NamedComponentSizingCommand extends AbstractConfigCommand {
   }
 
   @Override
-  protected String getDescription() {
+  protected String getShortDescription() {
     return "Manage and view Spinnaker component sizing configuration for " + spinnakerService.getCanonicalName();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/AbstractEditMetricStoreCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/AbstractEditMetricStoreCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractEditMetricStoreCommand<T extends MetricStore> exte
 
   protected abstract MetricStore editMetricStore(T metricStore);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit the " + getMetricStoreType().getId() + " authentication method.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/AbstractMetricStoreEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/AbstractMetricStoreEnableDisableCommand.java
@@ -48,7 +48,7 @@ public abstract class AbstractMetricStoreEnableDisableCommand extends AbstractMe
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     String metricStoreType = getMetricStoreType().getId();
     return "Set the " + metricStoreType + " method as " + subjunctivePerfectAction();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/EditMetricStoresCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/EditMetricStoresCommand.java
@@ -33,7 +33,7 @@ public class EditMetricStoresCommand extends AbstractConfigCommand {
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure global metric stores properties.";
+  private String shortDescription = "Configure global metric stores properties.";
 
   @Parameter(
       names = "--period",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/MetricStoreCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/metricStores/MetricStoreCommand.java
@@ -33,7 +33,7 @@ abstract public class MetricStoreCommand extends AbstractConfigCommand {
 
   abstract public MetricStores.MetricStoreType getMetricStoreType();
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Configure your " + getMetricStoreType().getId() + " metric store.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/AbstractEditNotificationCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/AbstractEditNotificationCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractEditNotificationCommand<N extends Notification> ex
 
   protected abstract Notification editNotification(N notification);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit the " + getNotificationName() + " notification type";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/AbstractNamedNotificationCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/AbstractNamedNotificationCommand.java
@@ -32,7 +32,7 @@ public abstract class AbstractNamedNotificationCommand extends AbstractNotificat
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getNotificationName() + " notification";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/AbstractNotificationEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/AbstractNotificationEnableDisableCommand.java
@@ -49,7 +49,7 @@ public abstract class AbstractNotificationEnableDisableCommand extends AbstractN
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set the " + getNotificationName() + " notification as " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractAddPublisherCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractAddPublisherCommand.java
@@ -36,7 +36,7 @@ public abstract class AbstractAddPublisherCommand extends AbstractHasPublisherCo
   private String commandName = "add";
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Add a publisher of type " + getPubsubName();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractDeletePublisherCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractDeletePublisherCommand.java
@@ -39,7 +39,7 @@ public abstract class AbstractDeletePublisherCommand extends AbstractHasPublishe
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getPubsubName() + " publisher by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractEditPublisherCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractEditPublisherCommand.java
@@ -41,7 +41,7 @@ public abstract class AbstractEditPublisherCommand<T extends Publisher> extends
 
   protected abstract Publisher editPublisher(T publisher);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit an publisher in the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractGetPublisherCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractGetPublisherCommand.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 
 public abstract class AbstractGetPublisherCommand extends AbstractHasPublisherCommand {
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified publisher details for the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractListPublishersCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractListPublishersCommand.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 
 public abstract class AbstractListPublishersCommand extends AbstractPubsubCommand {
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the publisher names for the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/PubsubCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/PubsubCommand.java
@@ -31,7 +31,7 @@ public class PubsubCommand extends NestableCommand {
   private String commandName = "pubsub";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the specified pubsub.";
+  private String shortDescription = "Configure, validate, and view the specified pubsub.";
 
   public PubsubCommand() {
     super();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/AbstractNamedPersistentStoreCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/AbstractNamedPersistentStoreCommand.java
@@ -30,7 +30,7 @@ public abstract class AbstractNamedPersistentStoreCommand extends AbstractPersis
   private String commandName = getPersistentStoreType();
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Manage and view Spinnaker configuration for the \"" + getPersistentStoreType() + "\" persistent store.";
+  private String shortDescription = "Manage and view Spinnaker configuration for the \"" + getPersistentStoreType() + "\" persistent store.";
 
   @Override
   protected void executeThis() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/AbstractPersistentStoreEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/AbstractPersistentStoreEditCommand.java
@@ -30,7 +30,7 @@ public abstract class AbstractPersistentStoreEditCommand<T extends PersistentSto
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Edit configuration for the \"" + getPersistentStoreType() + "\" persistent store.";
+  private String shortDescription = "Edit configuration for the \"" + getPersistentStoreType() + "\" persistent store.";
 
   protected abstract PersistentStore editPersistentStore(T persistentStore);
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/EditPersistentStorageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/EditPersistentStorageCommand.java
@@ -34,7 +34,7 @@ public class EditPersistentStorageCommand extends AbstractConfigCommand {
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Edit Spinnaker's persistent storage.";
+  private String shortDescription = "Edit Spinnaker's persistent storage.";
 
   @Parameter(
       names = "--type",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractAccountCommand.java
@@ -31,7 +31,7 @@ public abstract class AbstractAccountCommand extends AbstractHasAccountCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getProviderName() + " provider's account";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractBakeryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractBakeryCommand.java
@@ -27,7 +27,7 @@ public abstract class AbstractBakeryCommand extends AbstractProviderCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getProviderName() + " provider's image bakery configuration.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractNamedProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractNamedProviderCommand.java
@@ -31,12 +31,7 @@ public abstract class AbstractNamedProviderCommand extends AbstractProviderComma
   }
 
   @Override
-  protected String getShortDescription() {
-    return "Manage and view Spinnaker configuration for the " + getProviderName() + " provider";
-  }
-
-  @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getProviderName() + " provider";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractProviderEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/AbstractProviderEnableDisableCommand.java
@@ -47,7 +47,7 @@ public abstract class AbstractProviderEnableDisableCommand extends AbstractProvi
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set the " + getProviderName() + " provider as " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/ProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/ProviderCommand.java
@@ -43,7 +43,7 @@ public class ProviderCommand extends NestableCommand {
   private String commandName = "provider";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the specified provider.";
+  private String shortDescription = "Configure, validate, and view the specified provider.";
 
   public ProviderCommand() {
     registerSubcommand(new AppengineCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
@@ -80,7 +80,7 @@ public abstract class AbstractAddAccountCommand extends AbstractHasAccountComman
 
   protected abstract Account emptyAccount();
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Add an account to the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractDeleteAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractDeleteAccountCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractDeleteAccountCommand extends AbstractHasAccountCom
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getProviderName() + " account by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractEditAccountCommand.java
@@ -118,7 +118,7 @@ public abstract class AbstractEditAccountCommand<T extends Account> extends Abst
 
   protected abstract Account editAccount(T account);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit an account in the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
@@ -27,7 +27,7 @@ import lombok.Getter;
 
 @Parameters(separators = "=")
 abstract class AbstractGetAccountCommand extends AbstractHasAccountCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified account details for the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractListAccountsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractListAccountsCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 @Parameters(separators = "=")
 abstract class AbstractListAccountsCommand extends AbstractProviderCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the account names for the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractAddBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractAddBaseImageCommand.java
@@ -63,7 +63,7 @@ public abstract class AbstractAddBaseImageCommand extends AbstractHasBaseImageCo
   )
   private String templateFile;
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Add a base image for the " + getProviderName() + " provider's bakery.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractBaseImageCommand.java
@@ -28,7 +28,7 @@ public abstract class AbstractBaseImageCommand extends AbstractProviderCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getProviderName() + " provider's base image.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractDeleteBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractDeleteBaseImageCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractDeleteBaseImageCommand extends AbstractHasBaseImag
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getProviderName() + " base image by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractEditBakeryDefaultsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractEditBakeryDefaultsCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractEditBakeryDefaultsCommand<T extends BakeryDefaults
 
   protected abstract BakeryDefaults editBakeryDefaults(T BakeryDefaults);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit the " + getProviderName() + " provider's bakery default options.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractEditBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractEditBaseImageCommand.java
@@ -70,7 +70,7 @@ public abstract class AbstractEditBaseImageCommand<T extends BaseImage> extends 
   )
   private String templateFile;
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit a base image for the " + getProviderName() + " provider's bakery.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractGetBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractGetBaseImageCommand.java
@@ -26,7 +26,7 @@ import lombok.Getter;
 
 @Parameters(separators = "=")
 abstract class AbstractGetBaseImageCommand extends AbstractHasBaseImageCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified base image details for the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractListBaseImagesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractListBaseImagesCommand.java
@@ -30,7 +30,7 @@ import java.util.List;
 
 @Parameters(separators = "=")
 abstract class AbstractListBaseImagesCommand extends AbstractProviderCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the base image names for the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/AbstractClusterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/AbstractClusterCommand.java
@@ -18,7 +18,7 @@ public abstract class AbstractClusterCommand extends AbstractProviderCommand {
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getProviderName() + " provider's cluster";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/DCOSDeleteClusterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/DCOSDeleteClusterCommand.java
@@ -20,7 +20,7 @@ public class DCOSDeleteClusterCommand extends AbstractClusterCommand {
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getProviderName() + " cluster by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/DCOSGetClusterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/DCOSGetClusterCommand.java
@@ -13,7 +13,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSCluster;
 
 @Parameters(separators = "=")
 public class DCOSGetClusterCommand extends AbstractClusterCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified cluster details for the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/DCOSListClusterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/DCOSListClusterCommand.java
@@ -17,7 +17,7 @@ import java.util.List;
  */
 @Parameters(separators = "=")
 public class DCOSListClusterCommand extends AbstractClusterCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the cluster names for the " + getProviderName() + " provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/AbstractNamedPubsubCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/AbstractNamedPubsubCommand.java
@@ -33,12 +33,7 @@ public abstract class AbstractNamedPubsubCommand extends AbstractPubsubCommand {
   }
 
   @Override
-  protected String getShortDescription() {
-    return "Manage and view Spinnaker configuration for the " + getPubsubName() + " pubsub";
-  }
-
-  @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getPubsubName() + " pubsub";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/AbstractPubsubEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/AbstractPubsubEnableDisableCommand.java
@@ -50,7 +50,7 @@ public abstract class AbstractPubsubEnableDisableCommand extends AbstractPubsubC
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set the " + getPubsubName() + " pubsub as " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/AbstractSubscriptionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/AbstractSubscriptionCommand.java
@@ -32,7 +32,7 @@ public abstract class AbstractSubscriptionCommand extends AbstractHasSubscriptio
   }
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Manage and view Spinnaker configuration for the " + getPubsubName() + " pubsub's subscription";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/PubsubCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/PubsubCommand.java
@@ -35,7 +35,7 @@ public class PubsubCommand extends NestableCommand {
   private String commandName = "pubsub";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Configure, validate, and view the specified pubsub.";
+  private String shortDescription = "Configure, validate, and view the specified pubsub.";
 
   public PubsubCommand() {
     registerSubcommand(new GooglePubsubCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractAddSubscriptionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractAddSubscriptionCommand.java
@@ -42,7 +42,7 @@ public abstract class AbstractAddSubscriptionCommand extends AbstractHasSubscrip
 
   protected abstract Subscription emptySubscription();
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Add an subscription to the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractDeleteSubscriptionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractDeleteSubscriptionCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractDeleteSubscriptionCommand extends AbstractHasSubsc
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "delete";
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Delete a specific " + getPubsubName() + " subscription by name.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractEditSubscriptionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractEditSubscriptionCommand.java
@@ -40,7 +40,7 @@ public abstract class AbstractEditSubscriptionCommand<T extends Subscription> ex
 
   protected abstract Subscription editSubscription(T subscription);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit an subscription in the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractGetSubscriptionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractGetSubscriptionCommand.java
@@ -29,7 +29,7 @@ import lombok.Getter;
 
 @Parameters(separators = "=")
 abstract class AbstractGetSubscriptionCommand extends AbstractHasSubscriptionCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "Get the specified subscription details for the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractListSubscriptionsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractListSubscriptionsCommand.java
@@ -31,7 +31,7 @@ import java.util.List;
 
 @Parameters(separators = "=")
 abstract class AbstractListSubscriptionsCommand extends AbstractPubsubCommand {
-  public String getDescription() {
+  public String getShortDescription() {
     return "List the subscription names for the " + getPubsubName() + " pubsub.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/AbstractEnableDisableSslCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/AbstractEnableDisableSslCommand.java
@@ -38,11 +38,6 @@ abstract public class AbstractEnableDisableSslCommand extends AbstractEnableDisa
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected Supplier<Void> getOperationSupplier() {
     String deploymentName = getCurrentDeployment();
     return Daemon.setSpringSslEnabled(deploymentName, !noValidate, isEnable());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/ApiSecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/api/ApiSecurityCommand.java
@@ -34,8 +34,6 @@ public class ApiSecurityCommand extends AbstractConfigCommand {
 
   private String shortDescription = "Configure and view the API server's addressable URL and CORS policies.";
 
-  private String longDescription = shortDescription;
-
   public ApiSecurityCommand() {
     registerSubcommand(new ApiSecurityEditCommand());
     registerSubcommand(new SpringSslCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractAuthnMethodEnableDisableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractAuthnMethodEnableDisableCommand.java
@@ -48,7 +48,7 @@ public abstract class AbstractAuthnMethodEnableDisableCommand extends AbstractAu
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     String methodName = getMethod().id;
     return "Set the " + methodName + " method as " + subjunctivePerfectAction();
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractEditAuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AbstractEditAuthnMethodCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractEditAuthnMethodCommand<T extends AuthnMethod> exte
 
   protected abstract AuthnMethod editAuthnMethod(T authnMethod);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit the " + getMethod().id + " authentication method.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/AuthnMethodCommand.java
@@ -32,7 +32,7 @@ abstract public class AuthnMethodCommand extends AbstractConfigCommand {
 
   abstract public AuthnMethod.Method getMethod();
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Configure the " + getMethod().id + " method for authenticating.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEditRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEditRoleProviderCommand.java
@@ -38,7 +38,7 @@ public abstract class AbstractEditRoleProviderCommand<T extends RoleProvider> ex
 
   protected abstract RoleProvider editRoleProvider(T roleProvider);
 
-  public String getDescription() {
+  public String getShortDescription() {
     return "Edit the " + getRoleProviderType() + " role provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEnableDisableAuthzCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractEnableDisableAuthzCommand.java
@@ -49,7 +49,7 @@ public abstract class AbstractEnableDisableAuthzCommand extends AbstractConfigCo
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Set Spinnaker's role-based authorization to " + subjunctivePerfectAction();
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractRoleProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AbstractRoleProviderCommand.java
@@ -30,7 +30,7 @@ abstract public class AbstractRoleProviderCommand extends AbstractConfigCommand 
   abstract public GroupMembership.RoleProviderType getRoleProviderType();
 
   @Override
-  public String getDescription() {
+  public String getShortDescription() {
     return "Configure the " + getRoleProviderType() + " role provider.";
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AuthzEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authz/AuthzEditCommand.java
@@ -32,7 +32,7 @@ import lombok.EqualsAndHashCode;
 @Parameters(separators = "=")
 public class AuthzEditCommand extends AbstractConfigCommand {
   private String commandName = "edit";
-  private String description = "Edit your roles provider settings.";
+  private String shortDescription = "Edit your roles provider settings.";
 
   @Parameter(
       names = "--type",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/ui/AbstractEnableDisableSslCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/ui/AbstractEnableDisableSslCommand.java
@@ -38,11 +38,6 @@ abstract public class AbstractEnableDisableSslCommand extends AbstractEnableDisa
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected Supplier<Void> getOperationSupplier() {
     String deploymentName = getCurrentDeployment();
     return Daemon.setApacheSslEnabled(deploymentName, !noValidate, isEnable());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/ui/UiSecurityCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/ui/UiSecurityCommand.java
@@ -34,8 +34,6 @@ public class UiSecurityCommand extends AbstractConfigCommand {
 
   private String shortDescription = "Configure and view the UI server's addressable URL.";
 
-  private String longDescription = shortDescription;
-
   public UiSecurityCommand() {
     registerSubcommand(new UiSecurityEditCommand());
     registerSubcommand(new ApacheSslCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/AbstractEnableDisableWebhookTrustCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/AbstractEnableDisableWebhookTrustCommand.java
@@ -55,11 +55,6 @@ public abstract class AbstractEnableDisableWebhookTrustCommand extends AbstractC
   }
 
   @Override
-  public String getLongDescription() {
-    return getShortDescription();
-  }
-
-  @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
     boolean enable = isEnable();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/WebhookCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/WebhookCommand.java
@@ -31,7 +31,7 @@ public class WebhookCommand extends AbstractConfigCommand {
     private String commandName = "webhook";
 
     @Getter(AccessLevel.PUBLIC)
-    private String description = "Show Spinnaker's webhook configuration.";
+    private String shortDescription = "Show Spinnaker's webhook configuration.";
 
     public WebhookCommand() {
         registerSubcommand(new WebhookTrustCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/WebhookTrustCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/WebhookTrustCommand.java
@@ -31,7 +31,7 @@ public class WebhookTrustCommand extends AbstractConfigCommand {
     private String commandName = "trust";
 
     @Getter(AccessLevel.PUBLIC)
-    private String description = "Show Spinnaker's webhook trust configuration.";
+    private String shortDescription = "Show Spinnaker's webhook trust configuration.";
 
     public WebhookTrustCommand() {
         registerSubcommand(new WebhookTrustEditCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/WebhookTrustEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/webhook/WebhookTrustEditCommand.java
@@ -33,7 +33,7 @@ public class WebhookTrustEditCommand extends AbstractConfigCommand {
     private String commandName = "edit";
 
     @Getter(AccessLevel.PUBLIC)
-    private String description = "Edit Spinnaker's webhook trust configuration.";
+    private String shortDescription = "Edit Spinnaker's webhook trust configuration.";
 
     @Parameter(
             names = "--trustStore",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DetailsDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DetailsDeployCommand.java
@@ -33,7 +33,7 @@ public class DetailsDeployCommand extends AbstractConfigCommand {
   private String commandName = "details";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Get details about your currently deployed Spinnaker installation.";
+  private String shortDescription = "Get details about your currently deployed Spinnaker installation.";
 
   @Parameter(
       names = "--service-name",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DiffDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/DiffDeployCommand.java
@@ -33,7 +33,7 @@ public class DiffDeployCommand extends AbstractConfigCommand {
   private String commandName = "diff";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "This shows what changes you have made since Spinnaker was last deployed.";
+  private String shortDescription = "This shows what changes you have made since Spinnaker was last deployed.";
 
   @Override
   protected void executeThis() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/task/InterruptTaskCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/task/InterruptTaskCommand.java
@@ -33,7 +33,7 @@ public class InterruptTaskCommand extends NestableCommand {
   private String commandName = "interrupt";
 
   @Getter(AccessLevel.PUBLIC)
-  private String description = "Interrupt (attempt to kill) a given task.";
+  private String shortDescription = "Interrupt (attempt to kill) a given task.";
 
   @Override
   public String getMainParameter() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/task/ListTaskCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/task/ListTaskCommand.java
@@ -33,9 +33,6 @@ public class ListTaskCommand extends NestableCommand {
   @Getter(AccessLevel.PUBLIC)
   private String shortDescription = "List the currently running Tasks.";
 
-  @Getter(AccessLevel.PUBLIC)
-  private String longDescription = shortDescription;
-
   @Override
   protected void executeThis() {
     AnsiPrinter.out.println(AnsiFormatUtils.format(AnsiFormatUtils.Format.YAML, Daemon.getTasks()));

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/LatestVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/LatestVersionCommand.java
@@ -33,9 +33,6 @@ public class LatestVersionCommand extends NestableCommand {
   @Getter(AccessLevel.PUBLIC)
   private String shortDescription = "Get the latest released, validated version number of Spinnaker.";
 
-  @Getter(AccessLevel.PUBLIC)
-  private String longDescription = shortDescription;
-
   @Override
   protected void executeThis() {
     new OperationHandler<String>()


### PR DESCRIPTION
The docs generation currently has description, shortDescription, and longDescription, and commands must implement a subset of these that is checked at runtime.  Simplify this by just using shortDescription (required) and longDescription (optional), and enforcing this using static type checking.