### PR TITLE
fix debian noninteractive install

### DIFF
--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -264,13 +264,13 @@ function install_java() {
     # This causes the /etc/ssl/certs/java/cacerts file to never be generated, causing a startup
     # failure in Clouddriver.
     dpkg --purge --force-depends ca-certificates-java
-    apt-get install ca-certificates-java
+    apt-get install -y ca-certificates-java
   elif [ "$ID" = "debian" ] && [ "$VERSION_ID" = "8" ]; then
     echo "Running debian 8 (jessie)"
-    apt install -t jessie-backports openjdk-8-jre-headless ca-certificates-java
+    apt install -yt jessie-backports openjdk-8-jre-headless ca-certificates-java
   elif [ "$ID" = "debian" ] && [ "$VERSION_ID" = "9" ]; then
     echo "Running debian 9 (stretch)"
-    apt install -t stretch-backports openjdk-8-jre-headless ca-certificates-java
+    apt install -yt stretch-backports openjdk-8-jre-headless ca-certificates-java
   else
     >&2 echo "Distribution $PRETTY_NAME is not supported yet - please file an issue"
     >&2 echo "  https://github.com/spinnaker/halyard/issues"


### PR DESCRIPTION
I ran into this installing Halyard from a debian 9 dockerfile.

All of the other `apt install` commands run non-interactively other than installing Java. Maybe adding ca-certificates is something you want someone to acknowledge, but if that's the case, then when someone does

```
InstallHalyard.sh -y
```

*everything* should be non-interactive.

I also had to have my dockerfile manually add `stretch-backports` to `/etc/apt/sources.list.d/stretch-backports.list`

Edit: fixes https://github.com/spinnaker/spinnaker/issues/4045