### PR TITLE
feat(appengine): add flag to configure caching agent interval

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5962,6 +5962,7 @@ hal config provider appengine account add ACCOUNT [parameters]
 
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
+ * `--caching-interval-seconds`: The interval in seconds at which Spinnaker will poll for updates in your AppEngine clusters.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--gcloud-release-track`: The gcloud release track (ALPHA, BETA, or STABLE) that Spinnaker will use when deploying to App Engine.
@@ -6017,6 +6018,7 @@ hal config provider appengine account edit ACCOUNT [parameters]
  * `--add-read-permission`: Add this permission to the list of read permissions.
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
  * `--add-write-permission`: Add this permission to the list of write permissions.
+ * `--caching-interval-seconds`: The interval in seconds at which Spinnaker will poll for updates in your AppEngine clusters.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--gcloud-release-track`: The gcloud release track (ALPHA, BETA, or STABLE) that Spinnaker will use when deploying to App Engine.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineAddAccountCommand.java
@@ -136,6 +136,12 @@ public class AppengineAddAccountCommand extends AbstractAddAccountCommand {
   )
   private List<String> omitVersions;
 
+  @Parameter(
+      names = "--caching-interval-seconds",
+      description = AppengineCommandProperties.CACHING_INTERVAL_SECONDS
+  )
+  private Long cachingIntervalSeconds;
+
   @Override
   protected Account buildAccount(String accountName) {
     AppengineAccount account = (AppengineAccount) new AppengineAccount().setName(accountName);
@@ -149,7 +155,8 @@ public class AppengineAddAccountCommand extends AbstractAddAccountCommand {
             .setServices(services)
             .setVersions(versions)
             .setOmitServices(omitServices)
-            .setOmitVersions(omitVersions);
+            .setOmitVersions(omitVersions)
+            .setCachingIntervalSeconds(cachingIntervalSeconds);
 
     return account;
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineCommandProperties.java
@@ -45,4 +45,6 @@ public class AppengineCommandProperties {
             "will be ignored by Spinnaker.";
     static final String OMIT_VERSIONS = "A list of regular expressions. Any version matching one of these regexes " +
             "will be ignored by Spinnaker.";
+    static final String CACHING_INTERVAL_SECONDS = "The interval in seconds at which Spinnaker will poll for updates " +
+            "in your AppEngine clusters.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineEditAccountCommand.java
@@ -136,6 +136,12 @@ public class AppengineEditAccountCommand extends AbstractEditAccountCommand<Appe
   )
   private List<String> omitVersions;
 
+  @Parameter(
+          names = "--caching-interval-seconds",
+          description = AppengineCommandProperties.CACHING_INTERVAL_SECONDS
+  )
+  private Long cachingIntervalSeconds;
+
   @Override
   protected Account editAccount(AppengineAccount account) {
     account.setJsonPath(isSet(jsonPath) ? jsonPath : account.getJsonPath());
@@ -153,6 +159,7 @@ public class AppengineEditAccountCommand extends AbstractEditAccountCommand<Appe
     account.setVersions(versions != null ? versions : account.getVersions());
     account.setOmitServices(omitServices != null ? omitServices : account.getOmitServices());
     account.setOmitVersions(omitVersions != null ? omitVersions : account.getOmitVersions());
+    account.setCachingIntervalSeconds(cachingIntervalSeconds != null ? cachingIntervalSeconds : account.getCachingIntervalSeconds());
     
     return account;
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/appengine/AppengineAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/appengine/AppengineAccount.java
@@ -70,6 +70,11 @@ public class AppengineAccount extends CommonGoogleAccount {
           tooLowMessage = "The set of versions that Spinnaker will ignore is not configurable prior to this release."
   )
   private List<String> omitVersions;
+  @ValidForSpinnakerVersion(
+          lowerBound = "1.13.0",
+          tooLowMessage = "The AppEngine provider's caching interval is not configurable prior to this release."
+  )
+  private Long cachingIntervalSeconds;
 
   public enum GcloudReleaseTrack {
     ALPHA,


### PR DESCRIPTION
Allows a user to configure Spinnaker to hit the AppEngine Admin API less often, thereby reducing the risk of hitting quotas.