### PR TITLE
feat(kubernetes): add live-manifest-calls flag to cli

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7962,6 +7962,8 @@ When no context is configured for an account the 'current-context' in your kubec
  * `--kinds`: (*Default*: `[]`) (V2 Only) A list of resource kinds this Spinnaker account can deploy to and will cache.
 When no kinds are configured, this defaults to 'all kinds described here https://spinnaker.io/reference/providers/kubernetes-v2'.
  * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
+ * `--live-manifest-calls`: When true, clouddriver will query manifest status during pipeline executions using live data rather than the cache.
+This eliminates all time spent in the "force cache refresh" task in pipelines, greatly reducing execution time.
  * `--namespaces`: (*Default*: `[]`) A list of namespaces this Spinnaker account can deploy to and will cache.
 When no namespaces are configured, this defaults to 'all namespaces'.
  * `--no-validate`: (*Default*: `false`) Skip validation.
@@ -8028,6 +8030,8 @@ When no context is configured for an account the 'current-context' in your kubec
  * `--kinds`: (*Default*: `[]`) (V2 Only) A list of resource kinds this Spinnaker account can deploy to and will cache.
 When no kinds are configured, this defaults to 'all kinds described here https://spinnaker.io/reference/providers/kubernetes-v2'.
  * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
+ * `--live-manifest-calls`: When true, clouddriver will query manifest status during pipeline executions using live data rather than the cache.
+This eliminates all time spent in the "force cache refresh" task in pipelines, greatly reducing execution time.
  * `--namespaces`: (*Default*: `[]`) A list of namespaces this Spinnaker account can deploy to and will cache.
 When no namespaces are configured, this defaults to 'all namespaces'.
  * `--no-validate`: (*Default*: `false`) Skip validation.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -134,6 +134,13 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
   )
   public Boolean checkPermissionsOnStartup;
 
+  @Parameter(
+      names = "--live-manifest-calls",
+      arity = 1,
+      description = KubernetesCommandProperties.LIVE_MANIFEST_CALLS
+  )
+  public Boolean liveManifestCalls;
+
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -152,6 +159,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setSkin(skin);
     account.setOnlySpinnakerManaged(onlySpinnakerManaged);
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
+    account.setLiveManifestCalls(liveManifestCalls);
     return account;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -50,4 +50,7 @@ public class KubernetesCommandProperties {
 
   static final String CHECK_PERMISSIONS_ON_STARTUP = "When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time\n"
       + "during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.";
+
+  static final String LIVE_MANIFEST_CALLS = "When true, clouddriver will query manifest status during pipeline executions using live data rather than the cache.\n"
+      + "This eliminates all time spent in the \"force cache refresh\" task in pipelines, greatly reducing execution time.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -227,6 +227,13 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
   )
   public Boolean checkPermissionsOnStartup;
 
+  @Parameter(
+      names = "--live-manifest-calls",
+      arity = 1,
+      description = KubernetesCommandProperties.LIVE_MANIFEST_CALLS
+  )
+  public Boolean liveManifestCalls;
+
   @Override
   protected Account editAccount(KubernetesAccount account) {
     boolean contextSet = context != null && !context.isEmpty();
@@ -295,7 +302,8 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
     account.setNamingStrategy(isSet(namingStrategy) ? namingStrategy : account.getNamingStrategy());
     account.setSkin(isSet(skin) ? skin : account.getSkin());
     account.setOnlySpinnakerManaged(isSet(onlySpinnakerManaged) ? onlySpinnakerManaged : account.getOnlySpinnakerManaged());
-    account.setCheckPermissionsOnStartup(isSet(checkPermissionsOnStartup) ? checkPermissionsOnStartup : Boolean.TRUE);
+    account.setCheckPermissionsOnStartup(isSet(checkPermissionsOnStartup) ? checkPermissionsOnStartup : account.getCheckPermissionsOnStartup());
+    account.setLiveManifestCalls(isSet(liveManifestCalls) ? liveManifestCalls : account.getLiveManifestCalls());
     return account;
   }
 


### PR DESCRIPTION
There's been some discussion in Slack that the `liveManifestCalls` feature works wonderfully, but should not have to be manually added to one's halconfig.