### PR TITLE
fix(secrets): fix saml secret decryption

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SecretFile.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SecretFile.java
@@ -11,4 +11,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface SecretFile {
+  String prefix() default "";
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SamlConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SamlConfig.java
@@ -16,6 +16,9 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Saml;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import lombok.Data;
@@ -33,7 +36,10 @@ public class SamlConfig {
   String issuerId;
   String metadataUrl;
 
+  @LocalFile
+  @SecretFile(prefix="file:")
   String keyStore;
+  @Secret
   String keyStorePassword;
   String keyStoreAliasName;
 
@@ -56,8 +62,7 @@ public class SamlConfig {
     if (StringUtils.isNotEmpty(saml.getMetadataRemote())) {
       this.metadataUrl = saml.getMetadataRemote();
     }
-
-    this.keyStore = "file:" + saml.getKeyStore();
+    this.keyStore = saml.getKeyStore();
     this.keyStoreAliasName = saml.getKeyStoreAliasName();
     this.keyStorePassword = saml.getKeyStorePassword();
 


### PR DESCRIPTION
Normally, secret annotations are placed on secret fields in the config classes so that the `DecryptingObjectMapper` knows which fields to decrypt when serializing. In the case of `Saml`, the `GateProfileFactory` creates a new `SamlConfig` object instead of passing the `Saml` object itself to the `DecryptingObjectMapper`. Therefore, the `SamlConfig` class needs annotations on secret fields in order to decrypt when printing the service profiles.
