### PR TITLE
feat(provider/kubernetes): Pods security context in service-settings

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSecurityContext.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSecurityContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Target, Inc.
+ * Copyright 2019 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -12,29 +12,16 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service;
 
 import lombok.Data;
-import lombok.EqualsAndHashCode;
-
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 
 @Data
-@EqualsAndHashCode(callSuper = false)
-public class KubernetesSettings {
-  List<String> imagePullSecrets = new ArrayList<>();
-  Map<String, String> nodeSelector = new HashMap<>();
-  Map<String, String> podAnnotations = new HashMap<>();
-  List<ConfigSource> volumes = new ArrayList<>();
-  String serviceAccountName = null;
-  String serviceType = "ClusterIP";
-  String nodePort = null;
-  Boolean useExecHealthCheck = true;
-  KubernetesSecurityContext securityContext = null;
+public class KubernetesSecurityContext {
+  Integer runAsUser;
+  Integer fsGroup;
 }
+

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -228,6 +228,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
               .addBinding("terminationGracePeriodSeconds", terminationGracePeriodSeconds())
               .addBinding("nodeSelector", settings.getKubernetes().getNodeSelector())
               .addBinding("volumes", combineVolumes(configSources, settings.getKubernetes(), sidecarConfigs))
+              .addBinding("securityContext", settings.getKubernetes().getSecurityContext())
               .toString();
   }
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/podSpec.yml
@@ -43,6 +43,17 @@
     },
   {% endif %}
 
+  {% if securityContext != null %}
+  "securityContext": {
+    {% if securityContext.runAsUser != null %}
+    "runAsUser": {{ securityContext.runAsUser }} {% if securityContext.fsGroup != null %} , {% endif %}
+    {% endif %}
+    {% if securityContext.fsGroup != null %}
+    "fsGroup": {{ securityContext.fsGroup }}
+    {% endif %}
+  },
+  {% endif %}
+
   "volumes": [
     {% for volume in volumes %}
     {{ volume }} {% if not loop.last %} , {% endif %}


### PR DESCRIPTION
This is for being able to specify the `securityContext` under which spinnaker's pods will run. Example `service-settings/clouddriver.yml`:
```
kubernetes:
  securityContext:
    runAsUser: 99
    fsGroup: 99
```
Results in:
```
bash-4.4$ whoami
whoami: unknown uid 99
bash-4.4$
bash-4.4$ ls -la /opt/spinnaker/
total 0
drwxr-xr-x    3 root     root            20 Mar 19 17:21 .
drwxr-xr-x    1 root     root            23 Mar 19 17:21 ..
drwxrwsrwt    3 root     99             120 Mar 19 17:20 config
bash-4.4$
```

