### PR TITLE
feat(kubernetes): add livenessProbe

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/ResourceBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/ResourceBuilder.java
@@ -93,6 +93,7 @@ class ResourceBuilder {
         .withVolumeMounts(volumeMounts)
         .withEnv(envVars)
         .withReadinessProbe(probeBuilder.build())
+        .withLivenessProbe(probeBuilder.build())
         .withResources(buildResourceRequirements(name, deploymentEnvironment));
 
     return containerBuilder.build();

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
@@ -21,7 +21,9 @@
   ],
   {% endif %}
 
-  "readinessProbe": {{ probe }},
+  "readinessProbe": {{ readinessProbe }},
+
+  "livenessProbe": {{ livenessProbe }},
 
   "securityContext": {{ securityContext }},
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketLivenessProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketLivenessProbe.yml
@@ -1,0 +1,5 @@
+{
+  "tcpSocket": {
+    "port": {{ port }}
+  }
+}


### PR DESCRIPTION
Per discussion on https://github.com/spinnaker/spinnaker/issues/4023, reuses `readinessProbe` as a `livenessProbe` so that containers that fail health checks are not only removed from the load balancer, but also restarted automatically.