### PR TITLE
feat(provider/azure): Add SSH public key support to provision linux vm

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6413,7 +6413,7 @@ hal config provider azure account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--app-key`: (*Required*) (*Sensitive data* - user will be prompted on standard input) The appKey (password) of your service principal.
  * `--client-id`: (*Required*) The clientId (also called appId) of your service principal.
- * `--default-key-vault`: (*Required*) The name of a KeyVault that contains the default user name and password used to create VMs
+ * `--default-key-vault`: (*Required*) The name of a KeyVault that contains the user name, password, and ssh public key used to create VMs
  * `--default-resource-group`: (*Required*) The default resource group to contain any non-application specific resources.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
@@ -6464,7 +6464,7 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--app-key`: (*Sensitive data* - user will be prompted on standard input) The appKey (password) of your service principal.
  * `--client-id`: The clientId (also called appId) of your service principal.
- * `--default-key-vault`: The name of a KeyVault that contains the default user name and password used to create VMs
+ * `--default-key-vault`: The name of a KeyVault that contains the user name, password, and ssh public key used to create VMs
  * `--default-resource-group`: The default resource group to contain any non-application specific resources.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6427,6 +6427,7 @@ hal config provider azure account add ACCOUNT [parameters]
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--subscription-id`: (*Required*) The subscriptionId that your service principal is assigned to.
  * `--tenant-id`: (*Required*) The tenantId that your service principal is assigned to.
+ * `--useSshPublicKey`: (*Default*: `true`) Whether to use SSH public key to provision the linux vm. The default value is true which means using the ssh public key. Setting it to false means using the password instead.
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
 
 
@@ -6480,6 +6481,7 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--subscription-id`: The subscriptionId that your service principal is assigned to.
  * `--tenant-id`: The tenantId that your service principal is assigned to.
+ * `--useSshPublicKey`: Whether to use SSH public key to provision the linux vm. The default value is true which means using the ssh public key. Setting it to false means using the password instead.
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.
 
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureAddAccountCommand.java
@@ -101,6 +101,12 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
   )
   private List<String> regions = new ArrayList<String>(Arrays.asList("westus", "eastus"));
 
+  @Parameter(
+      names = "--useSshPublicKey",
+      description = AzureCommandProperties.USE_SSH_PUBLIC_KEY_DESCRIPTION
+  )
+  private String useSshPublicKey = "true";
+
   @Override
   protected Account buildAccount(String accountName) {
     return ((AzureAccount) new AzureAccount().setName(accountName))
@@ -113,7 +119,8 @@ class AzureAddAccountCommand extends AbstractAddAccountCommand {
         .setDefaultKeyVault(defaultKeyVault)
         .setPackerResourceGroup(packerResourceGroup)
         .setPackerStorageAccount(packerStorageAccount)
-        .setRegions(regions);
+        .setRegions(regions)
+        .setUseSshPublicKey(useSshPublicKey);
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
@@ -29,7 +29,7 @@ class AzureCommandProperties {
 
   static final String DEFAULT_RESOURCE_GROUP_DESCRIPTION = "The default resource group to contain any non-application specific resources.";
 
-  static final String DEFAULT_KEY_VAULT_DESCRIPTION = "The name of a KeyVault that contains the default user name and password used to create VMs";
+  static final String DEFAULT_KEY_VAULT_DESCRIPTION = "The name of a KeyVault that contains the user name, password, and ssh public key used to create VMs";
 
   static final String PACKER_RESOURCE_GROUP_DESCRIPTION = "The resource group to use if baking images with Packer.";
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureCommandProperties.java
@@ -44,4 +44,6 @@ class AzureCommandProperties {
   static final String IMAGE_VERSION_DESCRIPTION = "The version of your base image. This defaults to 'latest' if not specified.";
 
   static final String REGIONS_DESCRIPTION = "The Azure regions this Spinnaker account will manage.";
+
+  static final String USE_SSH_PUBLIC_KEY_DESCRIPTION = "Whether to use SSH public key to provision the linux vm. The default value is true which means using the ssh public key. Setting it to false means using the password instead.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/azure/AzureEditAccountCommand.java
@@ -94,6 +94,12 @@ public class AzureEditAccountCommand extends AbstractEditAccountCommand<AzureAcc
   )
   private List<String> regions;
 
+  @Parameter(
+      names = "--useSshPublicKey",
+      description = AzureCommandProperties.USE_SSH_PUBLIC_KEY_DESCRIPTION
+  )
+  private String useSshPublicKey;
+
   @Override
   protected Account editAccount(AzureAccount account) {
     account.setClientId(isSet(clientId) ? clientId : account.getClientId());
@@ -105,6 +111,7 @@ public class AzureEditAccountCommand extends AbstractEditAccountCommand<AzureAcc
     account.setDefaultKeyVault(isSet(defaultKeyVault) ? defaultKeyVault : account.getDefaultKeyVault());
     account.setPackerResourceGroup(isSet(packerResourceGroup) ? packerResourceGroup : account.getPackerResourceGroup());
     account.setPackerStorageAccount(isSet(packerStorageAccount) ? packerStorageAccount : account.getPackerStorageAccount());
+    account.setUseSshPublicKey(isSet(useSshPublicKey) ? useSshPublicKey : account.getUseSshPublicKey());
 
     try {
       account.setRegions(regions);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureAccount.java
@@ -37,4 +37,5 @@ public class AzureAccount extends Account {
   private String packerResourceGroup;
   private String packerStorageAccount;
   private List<String> regions = new ArrayList<>();
+  private String useSshPublicKey;
 }


### PR DESCRIPTION
Provide users with the option of using SSH public key or password to provision linux vm during hal setup. The backend function is in the clouddriver [PR](https://github.com/spinnaker/clouddriver/pull/3468)