### PR TITLE
Revert "feat(kubernetes): add livenessProbe"

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -386,7 +386,7 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
   default KubernetesContainerDescription buildContainer(String name, ServiceSettings settings, List<ConfigSource> configSources, DeploymentEnvironment deploymentEnvironment, DeployKubernetesAtomicOperationDescription description) {
     KubernetesContainerDescription container = new KubernetesContainerDescription();
     KubernetesProbe readinessProbe = new KubernetesProbe();
-    KubernetesHandler readinessHandler = new KubernetesHandler();
+    KubernetesHandler handler = new KubernetesHandler();
     int port = settings.getPort();
     String scheme = settings.getScheme();
     if (StringUtils.isNotEmpty(scheme)) {
@@ -397,30 +397,21 @@ public interface KubernetesV1DistributedService<T> extends DistributedService<T,
 
     String healthEndpoint = settings.getHealthEndpoint();
     if (healthEndpoint != null) {
-      readinessHandler.setType(KubernetesHandlerType.HTTP);
+      handler.setType(KubernetesHandlerType.HTTP);
       KubernetesHttpGetAction action = new KubernetesHttpGetAction();
       action.setPath(healthEndpoint);
       action.setPort(port);
       action.setUriScheme(scheme);
-      readinessHandler.setHttpGetAction(action);
+      handler.setHttpGetAction(action);
     } else {
-      readinessHandler.setType(KubernetesHandlerType.TCP);
+      handler.setType(KubernetesHandlerType.TCP);
       KubernetesTcpSocketAction action = new KubernetesTcpSocketAction();
       action.setPort(port);
-      readinessHandler.setTcpSocketAction(action);
+      handler.setTcpSocketAction(action);
     }
 
-    readinessProbe.setHandler(readinessHandler);
+    readinessProbe.setHandler(handler);
     container.setReadinessProbe(readinessProbe);
-
-    KubernetesProbe livenessProbe = new KubernetesProbe();
-    KubernetesHandler livenessHandler = new KubernetesHandler();
-    livenessHandler.setType(KubernetesHandlerType.TCP);
-    KubernetesTcpSocketAction livenessHandlerAction = new KubernetesTcpSocketAction();
-    livenessHandlerAction.setPort(port);
-    livenessHandler.setTcpSocketAction(livenessHandlerAction);
-    livenessProbe.setHandler(livenessHandler);
-    container.setLivenessProbe(livenessProbe);
 
     applyCustomSize(container, deploymentEnvironment, name, description);
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/ResourceBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/ResourceBuilder.java
@@ -93,7 +93,6 @@ class ResourceBuilder {
         .withVolumeMounts(volumeMounts)
         .withEnv(envVars)
         .withReadinessProbe(probeBuilder.build())
-        .withLivenessProbe(probeBuilder.build())
         .withResources(buildResourceRequirements(name, deploymentEnvironment));
 
     return containerBuilder.build();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -298,8 +298,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     container.addBinding("command", config.getCommand());
     container.addBinding("args", config.getArgs());
     container.addBinding("volumeMounts", volumeMounts);
-    container.addBinding("readinessProbe", null);
-    container.addBinding("livenessProbe", null);
+    container.addBinding("probe", null);
     container.addBinding("lifecycle", null);
     container.addBinding("env", config.getEnv());
     container.addBinding("resources", null);
@@ -324,23 +323,20 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         return volume.toString();
       }).collect(Collectors.toList()));
 
-    TemplatedResource readinessProbe;
+    TemplatedResource probe;
     if (StringUtils.isNotEmpty(settings.getHealthEndpoint())) {
       if (settings.getKubernetes().getUseExecHealthCheck()) {
-        readinessProbe = new JinjaJarResource("/kubernetes/manifests/execReadinessProbe.yml");
-        readinessProbe.addBinding("command", getReadinessExecCommand(settings));
+        probe = new JinjaJarResource("/kubernetes/manifests/execReadinessProbe.yml");
+        probe.addBinding("command", getReadinessExecCommand(settings));
       } else {
-        readinessProbe = new JinjaJarResource("/kubernetes/manifests/httpReadinessProbe.yml");
-        readinessProbe.addBinding("port", settings.getPort());
-        readinessProbe.addBinding("path", settings.getHealthEndpoint());
+        probe = new JinjaJarResource("/kubernetes/manifests/httpReadinessProbe.yml");
+        probe.addBinding("port", settings.getPort());
+        probe.addBinding("path", settings.getHealthEndpoint());
       }
     } else {
-      readinessProbe = new JinjaJarResource("/kubernetes/manifests/tcpSocketReadinessProbe.yml");
-      readinessProbe.addBinding("port", settings.getPort());
+      probe = new JinjaJarResource("/kubernetes/manifests/tcpSocketReadinessProbe.yml");
+      probe.addBinding("port", settings.getPort());
     }
-
-    TemplatedResource livenessProbe = new JinjaJarResource("/kubernetes/manifests/tcpSocketLivenessProbe.yml");
-    livenessProbe.addBinding("port", settings.getPort());
 
     String lifecycle = "{}";
     List<String> preStopCommand = getPreStopCommand(settings);
@@ -367,8 +363,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     port.addBinding("port", settings.getPort());
     container.addBinding("port", port.toString());
     container.addBinding("volumeMounts", volumeMounts);
-    container.addBinding("readinessProbe", readinessProbe.toString());
-    container.addBinding("livenessProbe", livenessProbe.toString());
+    container.addBinding("probe", probe.toString());
     container.addBinding("lifecycle", lifecycle);
     container.addBinding("env", env);
     container.addBinding("resources", resources.toString());

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
@@ -21,9 +21,7 @@
   ],
   {% endif %}
 
-  "readinessProbe": {{ readinessProbe }},
-
-  "livenessProbe": {{ livenessProbe }},
+  "readinessProbe": {{ probe }},
 
   "securityContext": {{ securityContext }},
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketLivenessProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketLivenessProbe.yml
@@ -1,5 +1,0 @@
-{
-  "tcpSocket": {
-    "port": {{ port }}
-  }
-}


### PR DESCRIPTION
Reverts spinnaker/halyard#1253

Adding a `livenessProbe` with no configured `initialDelaySeconds` causes services with long startup times to crash and restart indefinitely. However, we are hesitant to introduce another user-configured value that can only be discovered after an initial failed deployment experience, with no obvious default. Reverting this change until we land on the best way to configure a `livenessProbe` that will work for most users out of the box.