### PR TITLE
feat(gremlin): Allow Gremlin to get configured via Halyard

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5306,6 +5306,7 @@ hal config features edit [parameters]
  * `--artifacts`: Enable artifact support. Read more at spinnaker.io/reference/artifacts
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here https://github.com/Netflix/chaosmonkey/wiki.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--gremlin`: Enable Gremlin fault-injection support.
  * `--infrastructure-stages`: Enable infrastructure stages. Allows for creating Load Balancers as part of pipelines.
  * `--jobs`: Allow Spinnaker to run containers in Kubernetes and Titus as Job stages in pipelines.
  * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -106,6 +106,13 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   )
   private Boolean managedPipelineTemplatesV2UI = null;
 
+  @Parameter(
+          names = "--gremlin",
+          description = "Enable Gremlin fault-injection support.",
+          arity = 1
+  )
+  private Boolean gremlin = null;
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -127,6 +134,7 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setTravis(travis != null ? travis : features.getTravis());
     features.setWercker(wercker != null ? wercker : features.getWercker());
     features.setManagedPipelineTemplatesV2UI(managedPipelineTemplatesV2UI != null ? managedPipelineTemplatesV2UI : features.getManagedPipelineTemplatesV2UI());
+    features.setGremlin(gremlin != null ? gremlin : features.getGremlin());
 
     if (originalHash == features.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -58,6 +58,8 @@ public class Features extends Node {
   private Boolean wercker;
   @ValidForSpinnakerVersion(lowerBound = "1.13.0", tooLowMessage = "Managed Pipeline Templates v2 UI is not available prior to this release.")
   private Boolean managedPipelineTemplatesV2UI;
+  @ValidForSpinnakerVersion(lowerBound = "1.13.0", tooLowMessage = "Gremlin is not available prior to this release.")
+  private Boolean gremlin;
 
   public boolean isAuth(DeploymentConfiguration deploymentConfiguration) {
     return deploymentConfiguration.getSecurity().getAuthn().isEnabled();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
@@ -17,8 +17,10 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.security.ApiSecurity;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
+import com.netflix.spinnaker.halyard.core.resource.v1.StringResource;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
@@ -27,7 +29,9 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public abstract class GateProfileFactory extends SpringProfileFactory {
 
@@ -41,14 +45,20 @@ public abstract class GateProfileFactory extends SpringProfileFactory {
       DeploymentConfiguration deploymentConfiguration,
       SpinnakerRuntimeSettings endpoints) {
     super.setProfile(profile, deploymentConfiguration, endpoints);
+    StringResource configTemplate = new StringResource(profile.getBaseContents());
+    Features features = deploymentConfiguration.getFeatures();
+
     Security security = deploymentConfiguration.getSecurity();
     List<String> requiredFiles = backupRequiredFiles(security.getApiSecurity(), deploymentConfiguration.getName());
     requiredFiles.addAll(backupRequiredFiles(security.getAuthn(), deploymentConfiguration.getName()));
     requiredFiles.addAll(backupRequiredFiles(security.getAuthz(), deploymentConfiguration.getName()));
     GateConfig gateConfig = getGateConfig(endpoints.getServiceSettings(Type.GATE), security);
     gateConfig.getCors().setAllowedOriginsPattern(security.getApiSecurity());
+    Map<String, Object> bindings = new HashMap<>();
+    bindings.put("features.gremlin", Boolean.toString(features.getGremlin() != null ? features.getGremlin() : false));
+
     profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, gateConfig))
-        .appendContents(profile.getBaseContents())
+        .appendContents(configTemplate.setBindings(bindings).toString())
         .setRequiredFiles(requiredFiles);
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
@@ -39,6 +40,8 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     super.setProfile(profile, deploymentConfiguration, endpoints);
 
     profile.appendContents(profile.getBaseContents());
+    Features features = deploymentConfiguration.getFeatures();
+
 
     AwsProvider awsProvider = deploymentConfiguration.getProviders().getAws();
     if (awsProvider.isEnabled()) {
@@ -52,10 +55,11 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     profile.setRequiredFiles(files);
     profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, new WebhookWrapper(webhook)));
 
-    String pipelineTemplates = Boolean.toString(deploymentConfiguration.getFeatures().getPipelineTemplates() != null ? deploymentConfiguration.getFeatures().getPipelineTemplates() : false);
+    String pipelineTemplates = Boolean.toString(features.getPipelineTemplates() != null ? features.getPipelineTemplates() : false);
     profile.appendContents("pipelineTemplates.enabled: " + pipelineTemplates);
     // For backward compatibility
     profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
+    profile.appendContents("features.gremlin: " + Boolean.toString(features.getGremlin() != null ? features.getGremlin() : false));
   }
 
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -116,6 +116,7 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     bindings.put("features.travis", Boolean.toString(features.getTravis() != null ? features.getTravis() : false));
     bindings.put("features.wercker", Boolean.toString(features.getWercker() != null ? features.getWercker() : false));
     bindings.put("features.managedPipelineTemplatesV2UI", Boolean.toString(features.getManagedPipelineTemplatesV2UI() != null ? features.getManagedPipelineTemplatesV2UI() : false));
+    bindings.put("features.gremlin", Boolean.toString(features.getGremlin() != null ? features.getGremlin() : false));
 
     // Configure Kubernetes
     KubernetesProvider kubernetesProvider = deploymentConfiguration.getProviders().getKubernetes();


### PR DESCRIPTION
The idea here is to allow `hal config feature edit` to accept `--gremlin` as an argument.

Then, that setting will appear as `features.gremlin` to `deck`, `orca`, and `gate`.  