### PR TITLE
feat(secrets): add decryptAsBytes to enable decryption of binary files

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/secrets/v1/SecretSessionManager.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/secrets/v1/SecretSessionManager.java
@@ -104,6 +104,11 @@ public class SecretSessionManager {
     }
   }
 
+  public byte[] decryptAsBytes(String encrypted) {
+    SecretSession session = getSession();
+    return session.decryptAsBytes(encrypted);
+  }
+
   public String encrypt(String unencryptedString) {
     throw new UnsupportedOperationException();
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Profile.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Profile.java
@@ -42,7 +42,7 @@ public class Profile {
   private String contents = "";
   private List<String> requiredFiles = new ArrayList<>();
   // Secret file content decrypted in memory keyed by generated filename
-  private Map<String, String> decryptedFiles = new HashMap<>();
+  private Map<String, byte[]> decryptedFiles = new HashMap<>();
   private Map<String, String> env = new HashMap<>();
 
   // Name of the profile itself (not the service or artifact)

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -425,7 +425,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
 
     Map<String, Set<Profile>> profilesByDirectory = new HashMap<>();
     List<String> requiredFiles = new ArrayList<>();
-    Map<String, String> requiredEncryptedFiles = new HashMap<>();
+    Map<String, byte[]> requiredEncryptedFiles = new HashMap<>();
     List<ConfigSource> configSources = new ArrayList<>();
     String secretNamePrefix = getServiceName() + "-files";
     String namespace = getNamespace(resolvedConfiguration.getServiceSettings(getService()));

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Utils.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Utils.java
@@ -115,8 +115,8 @@ public class KubernetesV2Utils {
     Map<String, String> contentMap = new HashMap<>();
     for (SecretMountPair pair: files) {
       String contents;
-      if (pair.getContentString() != null) {
-        contents = new String(Base64.getEncoder().encode(pair.getContentString().getBytes()));
+      if (pair.getContentBytes() != null) {
+        contents = new String(Base64.getEncoder().encode(pair.getContentBytes()));
       } else {
         try {
           contents = new String(Base64.getEncoder().encode(IOUtils.toByteArray(new FileInputStream(pair.getContents()))));
@@ -162,7 +162,7 @@ public class KubernetesV2Utils {
   @Data
   static public class SecretMountPair {
     File contents;
-    String contentString;
+    byte[] contentBytes;
     String name;
 
     public SecretMountPair(File inputFile) {
@@ -174,8 +174,8 @@ public class KubernetesV2Utils {
       this.name = outputFile.getName();
     }
 
-    public SecretMountPair(String name, String contentString) {
-      this.contentString = contentString;
+    public SecretMountPair(String name, byte[] contentBytes) {
+      this.contentBytes = contentBytes;
       this.name = name;
     }
   }


### PR DESCRIPTION
Part of spinnaker/spinnaker#3649

Some secrets, such java keystore files, will be binary files, so we want to be able to cache and pass to kubernetes as byte arrays instead of strings. This adds that functionality.

@dibyom 