### PR TITLE
fix(halyard): Use "kubectl replace --force" for Kubernetes Secret creation

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -478,7 +478,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
           ));
 
       KubernetesV2Utils.SecretSpec spec = executor.getKubernetesV2Utils().createSecretSpec(namespace, getService().getCanonicalName(), secretNamePrefix, files);
-      executor.apply(spec.resource.toString());
+      executor.replace(spec.resource.toString());
       configSources.add(new ConfigSource()
           .setId(spec.name)
           .setMountPath(mountPath)
@@ -498,7 +498,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
               .forEach(s -> files.add(s));
 
       KubernetesV2Utils.SecretSpec spec = executor.getKubernetesV2Utils().createSecretSpec(namespace, getService().getCanonicalName(), secretNamePrefix, files);
-      executor.apply(spec.resource.toString());
+      executor.replace(spec.resource.toString());
       configSources.add(new ConfigSource()
           .setId(spec.name)
           .setMountPath(getSpinnakerStagingDependenciesPath(details.getDeploymentName())));


### PR DESCRIPTION
This PR fixes the issue of deploying Spinnaker in Kubernetes when the halconfig is quite big (~35 accounts and more):
https://community.spinnaker.io/t/halyard-with-v2-metadata-annotations-too-long/894

Unlikely, `kubectl apply`, the `kubectl replace --force` command does not preserves
current data to the annotation. That allows to work around the issue when the halyard config is quite big and could not fit into the annotation.