### PR TITLE
fix(secrets): Always decrypt monitoring secrets

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/metricStores/datadog/DatadogStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/metricStores/datadog/DatadogStore.java
@@ -39,10 +39,11 @@ public class DatadogStore extends MetricStore {
   @JsonIgnore
   private MetricStores.MetricStoreType metricStoreType = MetricStores.MetricStoreType.DATADOG;
 
-  @Secret
+  @Secret(alwaysDecrypt = true)
   @JsonProperty("api_key")
   private String apiKey;
 
+  @Secret(alwaysDecrypt = true)
   @JsonProperty("app_key")
   private String appKey;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/metricStores/stackdriver/StackdriverStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/metricStores/stackdriver/StackdriverStore.java
@@ -39,7 +39,7 @@ public class StackdriverStore extends MetricStore {
 
   @JsonProperty("credentials_path")
   @LocalFile
-  @SecretFile
+  @SecretFile(alwaysDecrypt = true)
   private String credentialsPath;
 
   private String project;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Secret.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Secret.java
@@ -11,5 +11,9 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Secret {
+    /**
+     * @return true to force a secret to be decrypted even when the service it is attached to supports decryption.
+     * This is true for properties that cannot be decrypted at runtime (e.g. spinnaker-monitoring settings).
+     */
     boolean alwaysDecrypt() default false;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Secret.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Secret.java
@@ -11,4 +11,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Secret {
+    boolean alwaysDecrypt() default false;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SecretFile.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SecretFile.java
@@ -12,4 +12,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface SecretFile {
   String prefix() default "";
+  boolean alwaysDecrypt() default false;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SecretFile.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/SecretFile.java
@@ -12,5 +12,9 @@ import java.lang.annotation.Target;
 @Target(ElementType.FIELD)
 public @interface SecretFile {
   String prefix() default "";
+  /**
+   * @return true to force a secret to be decrypted even when the service it is attached to supports decryption.
+   * This is true for properties that cannot be decrypted at runtime (e.g. spinnaker-monitoring settings).
+   */
   boolean alwaysDecrypt() default false;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
@@ -17,7 +17,6 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.netflix.spinnaker.halyard.config.config.v1.RelaxedObjectMapper;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.RedisPersistentStore;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
@@ -40,9 +39,6 @@ import java.util.Map;
 public class Front50ProfileFactory extends SpringProfileFactory {
   @Autowired
   AccountService accountService;
-
-  @Autowired
-  RelaxedObjectMapper objectMapper;
 
   @Override
   public SpinnakerArtifact getArtifact() {
@@ -105,11 +101,9 @@ public class Front50ProfileFactory extends SpringProfileFactory {
   }
 
   protected ObjectMapper getRelaxedObjectMapper(String deploymentName, Profile profile) {
-    if (!supportsSecretDecryption(deploymentName)) {
-      return new DecryptingObjectMapper(secretSessionManager,
-              profile,
-              halconfigDirectoryStructure.getStagingDependenciesPath(deploymentName)).relax();
-    }
-    return objectMapper;
+    return new DecryptingObjectMapper(secretSessionManager,
+            profile,
+            halconfigDirectoryStructure.getStagingDependenciesPath(deploymentName),
+            !supportsSecretDecryption(deploymentName)).relax();
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ProfileFactory.java
@@ -44,9 +44,6 @@ abstract public class ProfileFactory {
   private Yaml yamlParser;
 
   @Autowired
-  private ObjectMapper strictObjectMapper;
-
-  @Autowired
   protected SecretSessionManager secretSessionManager;
 
   protected String getMinimumSecretDecryptionVersion(String deploymentName) {
@@ -120,14 +117,10 @@ abstract public class ProfileFactory {
   }
 
   protected Map convertToMap(String deploymentName, Profile profile, Object o) {
-    ObjectMapper mapper;
-    if (supportsSecretDecryption(deploymentName)) {
-      mapper = strictObjectMapper;
-    } else {
-      mapper = new DecryptingObjectMapper(secretSessionManager,
+    ObjectMapper mapper = new DecryptingObjectMapper(secretSessionManager,
               profile,
-              halconfigDirectoryStructure.getStagingDependenciesPath(deploymentName));
-    }
+              halconfigDirectoryStructure.getStagingDependenciesPath(deploymentName),
+              !supportsSecretDecryption(deploymentName));
     return mapper.convertValue(o, Map.class);
   }
 }


### PR DESCRIPTION
Monitoring secrets (Datadog, Stackdriver) won't have Kork decryption and need to be mounted decrypted. This is done by adding a `alwaysDecrypt` on `@Secret` and `@SecretFile` and simplifying the object mapper annotation check.