### PR TITLE
fix(install): Fix installation on debian-based systems

### DIFF
--- a/install/debian/InstallHalyard.sh
+++ b/install/debian/InstallHalyard.sh
@@ -340,9 +340,7 @@ function install_halyard() {
   tar --no-same-owner -xvf halyard.tar.gz -C /opt
 
 
-  which systemd-sysusers &>/dev/null
-  if [ "$?" = "0" ]; then
-
+  if which systemd-sysusers &>/dev/null; then
     cat > /usr/lib/sysusers.d/halyard.conf <<EOL
 g halyard - -
 g spinnaker - -


### PR DESCRIPTION
The call to 'which systemd-users' returns an exit status >0 when it fails.  As we're running under 'set -e' this causes the script to immediately exit in failure.

Bash does not exit in failure when the command that produces an exit value >0 is part of an if condition.  That's actually what we want here; just run the command directly in the 'if'.