### PR TITLE
fix(deploy): Fix case of disabling SSL in apache

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
@@ -68,7 +68,7 @@ public class LocalDebianDeckService extends DeckService implements LocalDebianSe
   @Override
   public String installArtifactCommand(DeploymentDetails deploymentDetails) {
     String install = LocalDebianService.super.installArtifactCommand(deploymentDetails);
-    String ssl = deploymentDetails.getDeploymentConfiguration().getSecurity().getUiSecurity().getSsl().isEnabled() ? "a2enmod ssl" : "";
+    String ssl = deploymentDetails.getDeploymentConfiguration().getSecurity().getUiSecurity().getSsl().isEnabled() ? "a2enmod ssl" : "a2dismod ssl";
     return Strings.join("\n", install, ssl);
   }
 


### PR DESCRIPTION
Ran into an issue with local Debian installer:
`sudo hal config security ui ssl enable`

Properly enables `a2enmod ssl`, however, running:
`sudo hal config security ui ssl disable`
does not properly `a2dismod ssl`.