### PR TITLE
fix(cli): Use "--no-validate" parameter on "hal config provider * account get"

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractGetAccountCommand.java
@@ -47,7 +47,7 @@ abstract class AbstractGetAccountCommand extends AbstractHasAccountCommand {
         .setSuccessMessage("Account " + accountName + ": ")
         .setFormat(AnsiFormatUtils.Format.STRING)
         .setUserFormatted(true)
-        .setOperation(Daemon.getAccount(currentDeployment, providerName, accountName, false))
+        .setOperation(Daemon.getAccount(currentDeployment, providerName, accountName, !noValidate))
         .get();
   }
 }


### PR DESCRIPTION
## WHAT

This pull request fixes an issue that `hal config provider * account get` doesn't use `--no-validate` parameter.

## WHY

For example, the commands document says that `hal config provider docker-registry account get` supports the `--no-validate` option: 
https://www.spinnaker.io/reference/halyard/commands/#hal-config-provider-docker-registry-account-get

But actually it doesn't work properly because the `validate` option is hard-coded in the code.
( Currently always skip validation )

This pull request fixes the issue.

This issue was introduced in https://github.com/spinnaker/halyard/commit/668ad922ac854a1caede3d49fdfe45e39fa114be#diff-b7acb0a85fc298aec1a196698cbc8fdeR45