### PR TITLE
refactor(ci): Rename interface method getAccounts

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractListMastersCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractListMastersCommand.java
@@ -49,7 +49,7 @@ abstract class AbstractListMastersCommand extends AbstractCiCommand {
   @Override
   protected void executeThis() {
     Ci ci = getCi();
-    List<CIAccount> account = ci.getMasters();
+    List<CIAccount> account = ci.getAccounts();
     if (account.isEmpty()) {
       AnsiUi.success("No configured masters for " + getCiName() + ".");
     } else {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/concourse/ConcourseCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/concourse/ConcourseCi.java
@@ -17,10 +17,23 @@
 package com.netflix.spinnaker.halyard.config.model.v1.ci.concourse;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
 public class ConcourseCi extends Ci<ConcourseMaster> {
+  protected List<ConcourseMaster> masters = new ArrayList<>();
+
   @Override
   public String getNodeName() {
     return "concourse";
+  }
+
+  public List<ConcourseMaster> getAccounts() {
+    return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/jenkins/JenkinsCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/jenkins/JenkinsCi.java
@@ -18,10 +18,23 @@
 package com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
 public class JenkinsCi extends Ci<JenkinsMaster> {
+  protected List<JenkinsMaster> masters = new ArrayList<>();
+
   @Override
   public String getNodeName() {
     return "jenkins";
+  }
+
+  public List<JenkinsMaster> getAccounts() {
+    return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/travis/TravisCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/travis/TravisCi.java
@@ -17,10 +17,23 @@
 package com.netflix.spinnaker.halyard.config.model.v1.ci.travis;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
 public class TravisCi extends Ci<TravisMaster> {
+  protected List<TravisMaster> masters = new ArrayList<>();
+
   @Override
   public String getNodeName() {
     return "travis";
+  }
+
+  public List<TravisMaster> getAccounts() {
+    return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/wercker/WerckerCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/wercker/WerckerCi.java
@@ -18,10 +18,23 @@
 package com.netflix.spinnaker.halyard.config.model.v1.ci.wercker;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
 public class WerckerCi extends Ci<WerckerMaster> {
+  protected List<WerckerMaster> masters = new ArrayList<>();
+
   @Override
   public String getNodeName() {
     return "wercker";
+  }
+
+  public List<WerckerMaster> getAccounts() {
+    return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Ci.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Ci.java
@@ -19,7 +19,6 @@ package com.netflix.spinnaker.halyard.config.model.v1.node;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -27,10 +26,11 @@ import java.util.stream.Collectors;
 @EqualsAndHashCode(callSuper = false)
 public abstract class Ci<T extends CIAccount> extends Node implements Cloneable {
   boolean enabled;
-  List<T> masters = new ArrayList<>();
+
+  public abstract List<T> getAccounts();
 
   @Override
   public NodeIterator getChildren() {
-    return NodeIteratorFactory.makeListIterator(masters.stream().map(a -> (Node) a).collect(Collectors.toList()));
+    return NodeIteratorFactory.makeListIterator(getAccounts().stream().map(a -> (Node) a).collect(Collectors.toList()));
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
@@ -53,12 +53,6 @@ public class NodeFilter implements Cloneable {
     return this;
   }
 
-  public NodeFilter withAnyCi() {
-    matchers.add(Node.thisNodeAcceptor(Cis.class));
-    matchers.add(Node.thisNodeAcceptor(Ci.class));
-    return this;
-  }
-
   public NodeFilter setCi(String name) {
     matchers.add(Node.thisNodeAcceptor(Cis.class));
     matchers.add(Node.namedNodeAcceptor(Ci.class, name));

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
@@ -61,20 +61,6 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
     }
   }
 
-  public List<U> getAllCis(String deploymentName) {
-    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).withAnyCi();
-
-    List<U> matching = getMatchingCiNodes(filter);
-
-    if (matching.size() == 0) {
-      throw new ConfigNotFoundException(
-          new ConfigProblemBuilder(Severity.FATAL, "No cis could be found")
-              .build());
-    } else {
-      return matching;
-    }
-  }
-
   public void setEnabled(String deploymentName, boolean enabled) {
     Ci ci = getCi(deploymentName);
     ci.setEnabled(enabled);
@@ -84,15 +70,6 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
     NodeFilter filter = new NodeFilter()
         .setDeployment(deploymentName)
         .setCi(ciName())
-        .withAnyAccount();
-
-    return validateService.validateMatchingFilter(filter);
-  }
-
-  public ProblemSet validateAllCis(String deploymentName) {
-    NodeFilter filter = new NodeFilter()
-        .setDeployment(deploymentName)
-        .withAnyCi()
         .withAnyAccount();
 
     return validateService.validateMatchingFilter(filter);
@@ -130,11 +107,6 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
   public T getCiMaster(String deploymentName, String masterName) {
     NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setCi(ciName()).setMaster(masterName);
-    return getMaster(filter, masterName);
-  }
-
-  public T getAnyCiMaster(String deploymentName, String masterName) {
-    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).withAnyCi().setMaster(masterName);
     return getMaster(filter, masterName);
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
@@ -41,7 +41,9 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
   private final ValidateService validateService;
 
   protected abstract List<T> getMatchingAccountNodes(NodeFilter filter);
+
   protected abstract List<U> getMatchingCiNodes(NodeFilter filter);
+
   public abstract String ciName();
 
   public U getCi(String deploymentName) {
@@ -82,7 +84,7 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
     if (matchingAccounts.size() == 0) {
       throw new ConfigNotFoundException(
-              new ConfigProblemBuilder(Severity.FATAL, "No masters could be found").build());
+          new ConfigProblemBuilder(Severity.FATAL, "No masters could be found").build());
     } else {
       return matchingAccounts;
     }
@@ -94,14 +96,14 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
     switch (matchingAccounts.size()) {
       case 0:
         throw new ConfigNotFoundException(new ConfigProblemBuilder(
-                Severity.FATAL, String.format("No master with name '%s' was found", masterName))
-                .setRemediation("Check if this master was defined in another Continuous Integration service, or create a new one").build());
+            Severity.FATAL, String.format("No master with name '%s' was found", masterName))
+            .setRemediation("Check if this master was defined in another Continuous Integration service, or create a new one").build());
       case 1:
         return matchingAccounts.get(0);
       default:
         throw new IllegalConfigException(new ConfigProblemBuilder(
-                Severity.FATAL, String.format("No master with name '%s' was found", masterName))
-                .setRemediation(String.format("Manually delete/rename duplicate masters with name '%s' in your halconfig file", masterName)).build());
+            Severity.FATAL, String.format("No master with name '%s' was found", masterName))
+            .setRemediation(String.format("Manually delete/rename duplicate masters with name '%s' in your halconfig file", masterName)).build());
     }
   }
 
@@ -130,8 +132,8 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
     if (!removed) {
       throw new HalException(
-              new ConfigProblemBuilder(Severity.FATAL, String.format("Master '%s' wasn't found", masterName))
-                      .build());
+          new ConfigProblemBuilder(Severity.FATAL, String.format("Master '%s' wasn't found", masterName))
+              .build());
     }
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.services.v1.ci;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.config.error.v1.ConfigNotFoundException;
 import com.netflix.spinnaker.halyard.config.error.v1.IllegalConfigException;
 import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
@@ -28,6 +29,7 @@ import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
 
 import java.util.List;
 
@@ -38,7 +40,24 @@ import java.util.List;
 @RequiredArgsConstructor
 public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
   protected final LookupService lookupService;
+  protected final ObjectMapper objectMapper;
   private final ValidateService validateService;
+
+  @Component
+  @RequiredArgsConstructor
+  public static class Members {
+    private final LookupService lookupService;
+    private final ValidateService validateService;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+  }
+
+  public CiService(Members members) {
+    this.lookupService = members.lookupService;
+    this.validateService = members.validateService;
+    this.objectMapper = members.objectMapper;
+  }
+
+  public abstract T convertToAccount(Object object);
 
   protected abstract List<T> getMatchingAccountNodes(NodeFilter filter);
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
@@ -134,10 +134,10 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
   public void setMaster(String deploymentName, String masterName, T newAccount) {
     U ci = getCi(deploymentName);
 
-    for (int i = 0; i < ci.getMasters().size(); i++) {
-      T account = ci.getMasters().get(i);
+    for (int i = 0; i < ci.getAccounts().size(); i++) {
+      T account = ci.getAccounts().get(i);
       if (account.getNodeName().equals(masterName)) {
-        ci.getMasters().set(i, newAccount);
+        ci.getAccounts().set(i, newAccount);
         return;
       }
     }
@@ -147,7 +147,7 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
   public void deleteMaster(String deploymentName, String masterName) {
     U ci = getCi(deploymentName);
-    boolean removed = ci.getMasters().removeIf(master -> master.getName().equals(masterName));
+    boolean removed = ci.getAccounts().removeIf(master -> master.getName().equals(masterName));
 
     if (!removed) {
       throw new HalException(
@@ -158,7 +158,7 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
   public void addMaster(String deploymentName, T newAccount) {
     U ci = getCi(deploymentName);
-    ci.getMasters().add(newAccount);
+    ci.getAccounts().add(newAccount);
   }
 
   public ProblemSet validateMaster(String deploymentName, String masterName) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/ConcourseService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/ConcourseService.java
@@ -27,19 +27,19 @@ import java.util.List;
 
 @Component
 public class ConcourseService extends CiService<ConcourseMaster, ConcourseCi> {
-    public ConcourseService(LookupService lookupService, ValidateService validateService) {
-        super(lookupService, validateService);
-    }
+  public ConcourseService(LookupService lookupService, ValidateService validateService) {
+    super(lookupService, validateService);
+  }
 
-    public String ciName() {
-        return "concourse";
-    }
+  public String ciName() {
+    return "concourse";
+  }
 
-    protected List<ConcourseCi> getMatchingCiNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, ConcourseCi.class);
-    }
+  protected List<ConcourseCi> getMatchingCiNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, ConcourseCi.class);
+  }
 
-    protected List<ConcourseMaster> getMatchingAccountNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, ConcourseMaster.class);
-    }
+  protected List<ConcourseMaster> getMatchingAccountNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, ConcourseMaster.class);
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/ConcourseService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/ConcourseService.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.halyard.config.services.v1.ci;
 
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseMaster;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
 import com.netflix.spinnaker.halyard.config.services.v1.LookupService;
 import com.netflix.spinnaker.halyard.config.services.v1.ValidateService;
@@ -27,8 +28,8 @@ import java.util.List;
 
 @Component
 public class ConcourseService extends CiService<ConcourseMaster, ConcourseCi> {
-  public ConcourseService(LookupService lookupService, ValidateService validateService) {
-    super(lookupService, validateService);
+  public ConcourseService(CiService.Members members) {
+    super(members);
   }
 
   public String ciName() {
@@ -41,5 +42,10 @@ public class ConcourseService extends CiService<ConcourseMaster, ConcourseCi> {
 
   protected List<ConcourseMaster> getMatchingAccountNodes(NodeFilter filter) {
     return lookupService.getMatchingNodesOfType(filter, ConcourseMaster.class);
+  }
+
+  @Override
+  public ConcourseMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, ConcourseMaster.class);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/JenkinsService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/JenkinsService.java
@@ -19,17 +19,16 @@ package com.netflix.spinnaker.halyard.config.services.v1.ci;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
-import com.netflix.spinnaker.halyard.config.services.v1.LookupService;
-import com.netflix.spinnaker.halyard.config.services.v1.ValidateService;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 public class JenkinsService extends CiService<JenkinsMaster, JenkinsCi> {
-  public JenkinsService(LookupService lookupService, ValidateService validateService) {
-    super(lookupService, validateService);
+  public JenkinsService(CiService.Members members) {
+    super(members);
   }
+
 
   public String ciName() {
     return "jenkins";
@@ -41,5 +40,10 @@ public class JenkinsService extends CiService<JenkinsMaster, JenkinsCi> {
 
   protected List<JenkinsMaster> getMatchingAccountNodes(NodeFilter filter) {
     return lookupService.getMatchingNodesOfType(filter, JenkinsMaster.class);
+  }
+
+  @Override
+  public JenkinsMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, JenkinsMaster.class);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/JenkinsService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/JenkinsService.java
@@ -27,19 +27,19 @@ import java.util.List;
 
 @Component
 public class JenkinsService extends CiService<JenkinsMaster, JenkinsCi> {
-    public JenkinsService(LookupService lookupService, ValidateService validateService) {
-        super(lookupService, validateService);
-    }
+  public JenkinsService(LookupService lookupService, ValidateService validateService) {
+    super(lookupService, validateService);
+  }
 
-    public String ciName() {
-        return "jenkins";
-    }
+  public String ciName() {
+    return "jenkins";
+  }
 
-    protected List<JenkinsCi> getMatchingCiNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, JenkinsCi.class);
-    }
+  protected List<JenkinsCi> getMatchingCiNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, JenkinsCi.class);
+  }
 
-    protected List<JenkinsMaster> getMatchingAccountNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, JenkinsMaster.class);
-    }
+  protected List<JenkinsMaster> getMatchingAccountNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, JenkinsMaster.class);
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/TravisService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/TravisService.java
@@ -27,19 +27,19 @@ import java.util.List;
 
 @Component
 public class TravisService extends CiService<TravisMaster, TravisCi> {
-    public TravisService(LookupService lookupService, ValidateService validateService) {
-        super(lookupService, validateService);
-    }
+  public TravisService(LookupService lookupService, ValidateService validateService) {
+    super(lookupService, validateService);
+  }
 
-    public String ciName() {
-        return "travis";
-    }
+  public String ciName() {
+    return "travis";
+  }
 
-    protected List<TravisCi> getMatchingCiNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, TravisCi.class);
-    }
+  protected List<TravisCi> getMatchingCiNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, TravisCi.class);
+  }
 
-    protected List<TravisMaster> getMatchingAccountNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, TravisMaster.class);
-    }
+  protected List<TravisMaster> getMatchingAccountNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, TravisMaster.class);
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/TravisService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/TravisService.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.services.v1.ci;
 
+import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
@@ -27,8 +28,8 @@ import java.util.List;
 
 @Component
 public class TravisService extends CiService<TravisMaster, TravisCi> {
-  public TravisService(LookupService lookupService, ValidateService validateService) {
-    super(lookupService, validateService);
+  public TravisService(CiService.Members members) {
+    super(members);
   }
 
   public String ciName() {
@@ -41,5 +42,10 @@ public class TravisService extends CiService<TravisMaster, TravisCi> {
 
   protected List<TravisMaster> getMatchingAccountNodes(NodeFilter filter) {
     return lookupService.getMatchingNodesOfType(filter, TravisMaster.class);
+  }
+
+  @Override
+  public TravisMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, TravisMaster.class);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/WerckerService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/WerckerService.java
@@ -19,16 +19,14 @@ package com.netflix.spinnaker.halyard.config.services.v1.ci;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.wercker.WerckerCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.wercker.WerckerMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
-import com.netflix.spinnaker.halyard.config.services.v1.LookupService;
-import com.netflix.spinnaker.halyard.config.services.v1.ValidateService;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
 
 @Component
 public class WerckerService extends CiService<WerckerMaster, WerckerCi> {
-  public WerckerService(LookupService lookupService, ValidateService validateService) {
-    super(lookupService, validateService);
+  public WerckerService(CiService.Members members) {
+    super(members);
   }
 
   public String ciName() {
@@ -41,5 +39,10 @@ public class WerckerService extends CiService<WerckerMaster, WerckerCi> {
 
   public List<WerckerMaster> getMatchingAccountNodes(NodeFilter filter) {
     return lookupService.getMatchingNodesOfType(filter, WerckerMaster.class);
+  }
+
+  @Override
+  public WerckerMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, WerckerMaster.class);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/WerckerService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/WerckerService.java
@@ -27,19 +27,19 @@ import java.util.List;
 
 @Component
 public class WerckerService extends CiService<WerckerMaster, WerckerCi> {
-    public WerckerService(LookupService lookupService, ValidateService validateService) {
-        super(lookupService, validateService);
-    }
+  public WerckerService(LookupService lookupService, ValidateService validateService) {
+    super(lookupService, validateService);
+  }
 
-    public String ciName() {
-        return "wercker";
-    }
+  public String ciName() {
+    return "wercker";
+  }
 
-    public List<WerckerCi> getMatchingCiNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, WerckerCi.class);
-    }
+  public List<WerckerCi> getMatchingCiNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, WerckerCi.class);
+  }
 
-    public List<WerckerMaster> getMatchingAccountNodes(NodeFilter filter) {
-        return lookupService.getMatchingNodesOfType(filter, WerckerMaster.class);
-    }
+  public List<WerckerMaster> getMatchingAccountNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, WerckerMaster.class);
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/CiController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/CiController.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
   protected final ObjectMapper objectMapper = new ObjectMapper();
+  private final CiService<T, U> ciService;
 
   @Component
   @RequiredArgsConstructor
@@ -45,25 +46,22 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
     private final HalconfigDirectoryStructure halconfigDirectoryStructure;
   }
 
-  public CiController(Members members) {
+  public CiController(Members members, CiService<T, U> ciService) {
     this.halconfigParser = members.halconfigParser;
     this.halconfigDirectoryStructure = members.halconfigDirectoryStructure;
+    this.ciService = ciService;
   }
 
   private final HalconfigParser halconfigParser;
   private final HalconfigDirectoryStructure halconfigDirectoryStructure;
 
-  protected abstract CiService<T, U> getCiService();
-
-  protected abstract T convertToAccount(Object object);
-
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, U> ci(@PathVariable String deploymentName,
       @ModelAttribute ValidationSettings validationSettings) {
     return GenericGetRequest.<U>builder()
-        .getter(() -> getCiService().getCi(deploymentName))
-        .validator(() -> getCiService().validateCi(deploymentName))
-        .description("Get " + getCiService().ciName() + " ci")
+        .getter(() -> ciService.getCi(deploymentName))
+        .validator(() -> ciService.validateCi(deploymentName))
+        .description("Get " + ciService.ciName() + " ci")
         .build()
         .execute(validationSettings);
   }
@@ -73,9 +71,9 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
       @ModelAttribute ValidationSettings validationSettings,
       @RequestBody boolean enabled) {
     return GenericEnableDisableRequest.builder(halconfigParser)
-        .updater(e -> getCiService().setEnabled(deploymentName, e))
-        .validator(() -> getCiService().validateCi(deploymentName))
-        .description("Edit " + getCiService().ciName() + " settings")
+        .updater(e -> ciService.setEnabled(deploymentName, e))
+        .validator(() -> ciService.validateCi(deploymentName))
+        .description("Edit " + ciService.ciName() + " settings")
         .build()
         .execute(validationSettings, enabled);
   }
@@ -84,9 +82,9 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
   DaemonTask<Halconfig, List<T>> masters(@PathVariable String deploymentName,
       @ModelAttribute ValidationSettings validationSettings) {
     return GenericGetRequest.<List<T>>builder()
-        .getter(() -> getCiService().getAllMasters(deploymentName))
-        .validator(() -> getCiService().validateAllMasters(deploymentName))
-        .description("Get all masters for " + getCiService().ciName())
+        .getter(() -> ciService.getAllMasters(deploymentName))
+        .validator(() -> ciService.validateAllMasters(deploymentName))
+        .description("Get all masters for " + ciService.ciName())
         .build()
         .execute(validationSettings);
   }
@@ -96,8 +94,8 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
       @PathVariable String masterName,
       @ModelAttribute ValidationSettings validationSettings) {
     return GenericGetRequest.<T>builder()
-        .getter(() -> getCiService().getCiMaster(deploymentName, masterName))
-        .validator(() -> getCiService().validateMaster(deploymentName, masterName))
+        .getter(() -> ciService.getCiMaster(deploymentName, masterName))
+        .validator(() -> ciService.validateMaster(deploymentName, masterName))
         .description("Get the " + masterName + " master")
         .build()
         .execute(validationSettings);
@@ -109,8 +107,8 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
       @ModelAttribute ValidationSettings validationSettings) {
     return GenericDeleteRequest.builder(halconfigParser)
         .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-        .deleter(() -> getCiService().deleteMaster(deploymentName, masterName))
-        .validator(() -> getCiService().validateAllMasters(deploymentName))
+        .deleter(() -> ciService.deleteMaster(deploymentName, masterName))
+        .validator(() -> ciService.validateAllMasters(deploymentName))
         .description("Delete the " + masterName + " master")
         .build()
         .execute(validationSettings);
@@ -121,11 +119,11 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
       @PathVariable String masterName,
       @ModelAttribute ValidationSettings validationSettings,
       @RequestBody Object rawMaster) {
-    T account = convertToAccount(rawMaster);
+    T account = ciService.convertToAccount(rawMaster);
     return GenericUpdateRequest.<T>builder(halconfigParser)
         .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-        .updater(m -> getCiService().setMaster(deploymentName, masterName, m))
-        .validator(() -> getCiService().validateMaster(deploymentName, account.getName()))
+        .updater(m -> ciService.setMaster(deploymentName, masterName, m))
+        .validator(() -> ciService.validateMaster(deploymentName, account.getName()))
         .description("Edit the " + masterName + " master")
         .build()
         .execute(validationSettings, account);
@@ -135,11 +133,11 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
   DaemonTask<Halconfig, Void> addMaster(@PathVariable String deploymentName,
       @ModelAttribute ValidationSettings validationSettings,
       @RequestBody Object rawMaster) {
-    T account = convertToAccount(rawMaster);
+    T account = ciService.convertToAccount(rawMaster);
     return GenericUpdateRequest.<T>builder(halconfigParser)
         .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-        .updater(m -> getCiService().addMaster(deploymentName, m))
-        .validator(() -> getCiService().validateMaster(deploymentName, account.getName()))
+        .updater(m -> ciService.addMaster(deploymentName, m))
+        .validator(() -> ciService.validateMaster(deploymentName, account.getName()))
         .description("Add the " + account.getName() + " master")
         .build()
         .execute(validationSettings, account);

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/CiController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/CiController.java
@@ -54,11 +54,12 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
   private final HalconfigDirectoryStructure halconfigDirectoryStructure;
 
   protected abstract CiService<T, U> getCiService();
+
   protected abstract T convertToAccount(Object object);
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
   DaemonTask<Halconfig, U> ci(@PathVariable String deploymentName,
-                              @ModelAttribute ValidationSettings validationSettings) {
+      @ModelAttribute ValidationSettings validationSettings) {
     return GenericGetRequest.<U>builder()
         .getter(() -> getCiService().getCi(deploymentName))
         .validator(() -> getCiService().validateCi(deploymentName))
@@ -79,68 +80,68 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
         .execute(validationSettings, enabled);
   }
 
-    @RequestMapping(value = "/masters", method = RequestMethod.GET)
-    DaemonTask<Halconfig, List<T>> masters(@PathVariable String deploymentName,
-                                                   @ModelAttribute ValidationSettings validationSettings) {
-        return GenericGetRequest.<List<T>>builder()
-                .getter(() -> getCiService().getAllMasters(deploymentName))
-                .validator(() -> getCiService().validateAllMasters(deploymentName))
-                .description("Get all masters for " + getCiService().ciName())
-                .build()
-                .execute(validationSettings);
-    }
+  @RequestMapping(value = "/masters", method = RequestMethod.GET)
+  DaemonTask<Halconfig, List<T>> masters(@PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<T>>builder()
+        .getter(() -> getCiService().getAllMasters(deploymentName))
+        .validator(() -> getCiService().validateAllMasters(deploymentName))
+        .description("Get all masters for " + getCiService().ciName())
+        .build()
+        .execute(validationSettings);
+  }
 
-    @RequestMapping(value = "/masters/{masterName:.+}", method = RequestMethod.GET)
-    DaemonTask<Halconfig, T> master(@PathVariable String deploymentName,
-                                            @PathVariable String masterName,
-                                            @ModelAttribute ValidationSettings validationSettings) {
-        return GenericGetRequest.<T>builder()
-                .getter(() -> getCiService().getCiMaster(deploymentName, masterName))
-                .validator(() -> getCiService().validateMaster(deploymentName, masterName))
-                .description("Get the " + masterName + " master")
-                .build()
-                .execute(validationSettings);
-    }
+  @RequestMapping(value = "/masters/{masterName:.+}", method = RequestMethod.GET)
+  DaemonTask<Halconfig, T> master(@PathVariable String deploymentName,
+      @PathVariable String masterName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<T>builder()
+        .getter(() -> getCiService().getCiMaster(deploymentName, masterName))
+        .validator(() -> getCiService().validateMaster(deploymentName, masterName))
+        .description("Get the " + masterName + " master")
+        .build()
+        .execute(validationSettings);
+  }
 
-    @RequestMapping(value = "/masters/{masterName:.+}", method = RequestMethod.DELETE)
-    DaemonTask<Halconfig, Void> deleteMaster(@PathVariable String deploymentName,
-                                             @PathVariable String masterName,
-                                             @ModelAttribute ValidationSettings validationSettings) {
-        return GenericDeleteRequest.builder(halconfigParser)
-                .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-                .deleter(() -> getCiService().deleteMaster(deploymentName, masterName))
-                .validator(() -> getCiService().validateAllMasters(deploymentName))
-                .description("Delete the " + masterName + " master")
-                .build()
-                .execute(validationSettings);
-    }
+  @RequestMapping(value = "/masters/{masterName:.+}", method = RequestMethod.DELETE)
+  DaemonTask<Halconfig, Void> deleteMaster(@PathVariable String deploymentName,
+      @PathVariable String masterName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericDeleteRequest.builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .deleter(() -> getCiService().deleteMaster(deploymentName, masterName))
+        .validator(() -> getCiService().validateAllMasters(deploymentName))
+        .description("Delete the " + masterName + " master")
+        .build()
+        .execute(validationSettings);
+  }
 
-    @RequestMapping(value = "/masters/{masterName:.+}", method = RequestMethod.PUT)
-    DaemonTask<Halconfig, Void> setMaster(@PathVariable String deploymentName,
-                                          @PathVariable String masterName,
-                                          @ModelAttribute ValidationSettings validationSettings,
-                                          @RequestBody Object rawMaster) {
-        T account = convertToAccount(rawMaster);
-        return GenericUpdateRequest.<T>builder(halconfigParser)
-                .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-                .updater(m -> getCiService().setMaster(deploymentName, masterName, m))
-                .validator(() -> getCiService().validateMaster(deploymentName, account.getName()))
-                .description("Edit the " + masterName + " master")
-                .build()
-                .execute(validationSettings, account);
-    }
+  @RequestMapping(value = "/masters/{masterName:.+}", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setMaster(@PathVariable String deploymentName,
+      @PathVariable String masterName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Object rawMaster) {
+    T account = convertToAccount(rawMaster);
+    return GenericUpdateRequest.<T>builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .updater(m -> getCiService().setMaster(deploymentName, masterName, m))
+        .validator(() -> getCiService().validateMaster(deploymentName, account.getName()))
+        .description("Edit the " + masterName + " master")
+        .build()
+        .execute(validationSettings, account);
+  }
 
-    @RequestMapping(value = "/masters", method = RequestMethod.POST)
-    DaemonTask<Halconfig, Void> addMaster(@PathVariable String deploymentName,
-                                          @ModelAttribute ValidationSettings validationSettings,
-                                          @RequestBody Object rawMaster) {
-        T account = convertToAccount(rawMaster);
-        return GenericUpdateRequest.<T>builder(halconfigParser)
-                .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-                .updater(m -> getCiService().addMaster(deploymentName, m))
-                .validator(() -> getCiService().validateMaster(deploymentName, account.getName()))
-                .description("Add the " + account.getName() + " master")
-                .build()
-                .execute(validationSettings, account);
-    }
+  @RequestMapping(value = "/masters", method = RequestMethod.POST)
+  DaemonTask<Halconfig, Void> addMaster(@PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Object rawMaster) {
+    T account = convertToAccount(rawMaster);
+    return GenericUpdateRequest.<T>builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .updater(m -> getCiService().addMaster(deploymentName, m))
+        .validator(() -> getCiService().validateMaster(deploymentName, account.getName()))
+        .description("Add the " + account.getName() + " master")
+        .build()
+        .execute(validationSettings, account);
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/CiController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/CiController.java
@@ -19,9 +19,9 @@ package com.netflix.spinnaker.halyard.controllers.v1.ci;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
-import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
 import com.netflix.spinnaker.halyard.config.services.v1.ci.CiService;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
@@ -81,12 +81,11 @@ public abstract class CiController<T extends CIAccount, U extends Ci<T>> {
 
     @RequestMapping(value = "/masters", method = RequestMethod.GET)
     DaemonTask<Halconfig, List<T>> masters(@PathVariable String deploymentName,
-                                                   @PathVariable String ciName,
                                                    @ModelAttribute ValidationSettings validationSettings) {
         return GenericGetRequest.<List<T>>builder()
                 .getter(() -> getCiService().getAllMasters(deploymentName))
                 .validator(() -> getCiService().validateAllMasters(deploymentName))
-                .description("Get all masters for " + ciName)
+                .description("Get all masters for " + getCiService().ciName())
                 .build()
                 .execute(validationSettings);
     }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/ConcourseController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/ConcourseController.java
@@ -25,18 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/concourse")
 public class ConcourseController extends CiController<ConcourseMaster, ConcourseCi> {
-  private final ConcourseService concourseService;
-
-  protected ConcourseService getCiService() {
-    return concourseService;
-  }
-
-  protected ConcourseMaster convertToAccount(Object object) {
-    return objectMapper.convertValue(object, ConcourseMaster.class);
-  }
-
   public ConcourseController(CiController.Members members, ConcourseService concourseService) {
-    super(members);
-    this.concourseService = concourseService;
+    super(members, concourseService);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/ConcourseController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/ConcourseController.java
@@ -25,18 +25,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/concourse")
 public class ConcourseController extends CiController<ConcourseMaster, ConcourseCi> {
-    private final ConcourseService concourseService;
+  private final ConcourseService concourseService;
 
-    protected ConcourseService getCiService() {
-        return concourseService;
-    }
+  protected ConcourseService getCiService() {
+    return concourseService;
+  }
 
-    protected ConcourseMaster convertToAccount(Object object) {
-        return objectMapper.convertValue(object, ConcourseMaster.class);
-    }
+  protected ConcourseMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, ConcourseMaster.class);
+  }
 
-    public ConcourseController(CiController.Members members, ConcourseService concourseService) {
-        super(members);
-        this.concourseService = concourseService;
-    }
+  public ConcourseController(CiController.Members members, ConcourseService concourseService) {
+    super(members);
+    this.concourseService = concourseService;
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/JenkinsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/JenkinsController.java
@@ -25,18 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/jenkins")
 public class JenkinsController extends CiController<JenkinsMaster, JenkinsCi> {
-  private final JenkinsService jenkinsService;
-
-  protected JenkinsService getCiService() {
-    return jenkinsService;
-  }
-
-  protected JenkinsMaster convertToAccount(Object object) {
-    return objectMapper.convertValue(object, JenkinsMaster.class);
-  }
-
   public JenkinsController(CiController.Members members, JenkinsService jenkinsService) {
-    super(members);
-    this.jenkinsService = jenkinsService;
+    super(members, jenkinsService);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/JenkinsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/JenkinsController.java
@@ -25,18 +25,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/jenkins")
 public class JenkinsController extends CiController<JenkinsMaster, JenkinsCi> {
-    private final JenkinsService jenkinsService;
+  private final JenkinsService jenkinsService;
 
-    protected JenkinsService getCiService() {
-        return jenkinsService;
-    }
+  protected JenkinsService getCiService() {
+    return jenkinsService;
+  }
 
-    protected JenkinsMaster convertToAccount(Object object) {
-        return objectMapper.convertValue(object, JenkinsMaster.class);
-    }
+  protected JenkinsMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, JenkinsMaster.class);
+  }
 
-    public JenkinsController(CiController.Members members, JenkinsService jenkinsService) {
-        super(members);
-        this.jenkinsService = jenkinsService;
-    }
+  public JenkinsController(CiController.Members members, JenkinsService jenkinsService) {
+    super(members);
+    this.jenkinsService = jenkinsService;
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/TravisController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/TravisController.java
@@ -25,18 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/travis")
 public class TravisController extends CiController<TravisMaster, TravisCi> {
-  private final TravisService travisService;
-
-  protected TravisService getCiService() {
-    return travisService;
-  }
-
-  protected TravisMaster convertToAccount(Object object) {
-    return objectMapper.convertValue(object, TravisMaster.class);
-  }
-
   public TravisController(CiController.Members members, TravisService travisService) {
-    super(members);
-    this.travisService = travisService;
+    super(members, travisService);
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/TravisController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/TravisController.java
@@ -25,18 +25,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/travis")
 public class TravisController extends CiController<TravisMaster, TravisCi> {
-    private final TravisService travisService;
+  private final TravisService travisService;
 
-    protected TravisService getCiService() {
-        return travisService;
-    }
+  protected TravisService getCiService() {
+    return travisService;
+  }
 
-    protected TravisMaster convertToAccount(Object object) {
-        return objectMapper.convertValue(object, TravisMaster.class);
-    }
+  protected TravisMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, TravisMaster.class);
+  }
 
-    public TravisController(CiController.Members members, TravisService travisService) {
-        super(members);
-        this.travisService = travisService;
-    }
+  public TravisController(CiController.Members members, TravisService travisService) {
+    super(members);
+    this.travisService = travisService;
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/WerckerController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/WerckerController.java
@@ -25,18 +25,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/wercker")
 public class WerckerController extends CiController<WerckerMaster, WerckerCi> {
-    private final WerckerService werckerService;
+  private final WerckerService werckerService;
 
-    protected WerckerService getCiService() {
-        return werckerService;
-    }
+  protected WerckerService getCiService() {
+    return werckerService;
+  }
 
-    protected WerckerMaster convertToAccount(Object object) {
-        return objectMapper.convertValue(object, WerckerMaster.class);
-    }
+  protected WerckerMaster convertToAccount(Object object) {
+    return objectMapper.convertValue(object, WerckerMaster.class);
+  }
 
-    public WerckerController(CiController.Members members, WerckerService werckerService) {
-        super(members);
-        this.werckerService = werckerService;
-    }
+  public WerckerController(CiController.Members members, WerckerService werckerService) {
+    super(members);
+    this.werckerService = werckerService;
+  }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/WerckerController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/WerckerController.java
@@ -25,18 +25,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/wercker")
 public class WerckerController extends CiController<WerckerMaster, WerckerCi> {
-  private final WerckerService werckerService;
-
-  protected WerckerService getCiService() {
-    return werckerService;
-  }
-
-  protected WerckerMaster convertToAccount(Object object) {
-    return objectMapper.convertValue(object, WerckerMaster.class);
-  }
-
   public WerckerController(CiController.Members members, WerckerService werckerService) {
-    super(members);
-    this.werckerService = werckerService;
+    super(members, werckerService);
   }
 }


### PR DESCRIPTION
* refactor(ci): Remove unused code 

  Some of the CI methods are unused, as we don't actually have any halyard commands or endpoints to list all CI accounts regardless of type.

* style(ci): Fix indentation 

  Some of the files I added in the last PR ended up with 4-space indents; fix this as a separate commit to reduce the diff on later commits.

* refactor(ci): Move more things to base classes 

  We can make the classes I added in the last PR a bit simpler by pushing some things to the base class.

* refactor(ci): Rename interface method getAccounts 

  We'll allow implementations of CIAccount to call their accounts field whatever they want (masters, accounts, etc.) but will have the top-level interface expose getAccounts().

  Push the 'masters' field down into the existing classes; we can't rename this field in those classes as it would break existing hal configs.
