### PR TITLE
feat(gcb): Add GCB configuration to Halyard

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/gcb/GoogleCloudBuild.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/gcb/GoogleCloudBuild.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.ci.gcb;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GoogleCloudBuild extends Ci<GoogleCloudBuildAccount> {
+  private boolean enabled;
+  private List<GoogleCloudBuildAccount> accounts = new ArrayList<>();
+
+  @Override
+  public String getNodeName() {
+    return "gcb";
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/gcb/GoogleCloudBuildAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/gcb/GoogleCloudBuildAccount.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.ci.gcb;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class GoogleCloudBuildAccount extends CIAccount {
+  private String name;
+  private String project;
+  private String subscriptionName;
+  @LocalFile @SecretFile private String jsonKey;
+
+  public String getNodeName() {
+    return name;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisCi;
@@ -30,6 +31,7 @@ public class Cis extends Node implements Cloneable {
   TravisCi travis = new TravisCi();
   WerckerCi wercker = new WerckerCi();
   ConcourseCi concourse = new ConcourseCi();
+  GoogleCloudBuild gcb = new GoogleCloudBuild();
 
   public boolean ciEnabled() {
     NodeIterator iterator = getChildren();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/GoogleCloudBuildService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/GoogleCloudBuildService.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.services.v1.ci;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuildAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class GoogleCloudBuildService extends CiService<GoogleCloudBuildAccount, GoogleCloudBuild> {
+  public GoogleCloudBuildService(CiService.Members members) {
+    super(members);
+  }
+
+  public String ciName() {
+    return "gcb";
+  }
+
+  protected List<GoogleCloudBuild> getMatchingCiNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, GoogleCloudBuild.class);
+  }
+
+  protected List<GoogleCloudBuildAccount> getMatchingAccountNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, GoogleCloudBuildAccount.class);
+  }
+
+  @Override
+  public GoogleCloudBuildAccount convertToAccount(Object object) {
+    return objectMapper.convertValue(object, GoogleCloudBuildAccount.class);
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -16,10 +16,8 @@
 
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
-import com.netflix.spinnaker.halyard.config.model.v1.node.Artifacts;
-import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Notifications;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsubs;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService.Type;
@@ -68,6 +66,15 @@ public class EchoProfileFactory extends SpringProfileFactory {
       profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, new ArtifactWrapper(artifacts)));
     }
 
+    Cis cis = deploymentConfiguration.getCi();
+    if (cis != null) {
+      GoogleCloudBuild gcb = cis.getGcb();
+      if (gcb != null) {
+        files.addAll(backupRequiredFiles(gcb, deploymentConfiguration.getName()));
+        profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, new GCBWrapper(gcb)));
+      }
+    }
+
     profile.appendContents(profile.getBaseContents())
         .setRequiredFiles(files);
   }
@@ -87,6 +94,15 @@ public class EchoProfileFactory extends SpringProfileFactory {
 
     ArtifactWrapper(Artifacts artifacts) {
       this.artifacts = artifacts;
+    }
+  }
+
+  @Data
+  private static class GCBWrapper {
+    private GoogleCloudBuild gcb;
+
+    GCBWrapper(GoogleCloudBuild gcb) {
+      this.gcb = gcb;
     }
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/GoogleCloudBuildController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/GoogleCloudBuildController.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 Netflix, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1.ci;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuildAccount;
+import com.netflix.spinnaker.halyard.config.services.v1.ci.GoogleCloudBuildService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/gcb")
+public class GoogleCloudBuildController extends CiController<GoogleCloudBuildAccount, GoogleCloudBuild> {
+  public GoogleCloudBuildController(Members members, GoogleCloudBuildService googleCloudBuildService) {
+    super(members, googleCloudBuildService);
+  }
+}


### PR DESCRIPTION
This PR does not yet add commands for manipulating the config; these will be in the next PR.

* feat(gcb): Add GCB configuration to Halyard 

  The configuration should be added to both igor and echo. This commit only adds functionality for parsing these fields in the halconfig and generating the correct entries in the igor/echo config. A future commit will add 'hal' commands to edit this block in the halconfig.

* feat(gcb): Add service and controller for GCB config 
