### PR TITLE
fix(ci): Fix two bugs from refactor of halyard CI commands

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractListMastersCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractListMastersCommand.java
@@ -49,7 +49,7 @@ abstract class AbstractListMastersCommand extends AbstractCiCommand {
   @Override
   protected void executeThis() {
     Ci ci = getCi();
-    List<CIAccount> account = ci.getAccounts();
+    List<CIAccount> account = ci.listAccounts();
     if (account.isEmpty()) {
       AnsiUi.success("No configured masters for " + getCiName() + ".");
     } else {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.halyard.cli.command.v1.GlobalOptions;
 import com.netflix.spinnaker.halyard.config.model.v1.artifacts.ArtifactTemplate;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.CiType;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaServices;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
@@ -490,7 +491,10 @@ public class Daemon {
   }
 
   public static Supplier<CIAccount> getMaster(String deploymentName, String ciName, String masterName, boolean validate) {
-    return () -> ResponseUnwrapper.get(getService().getMaster(deploymentName, ciName, masterName, validate));
+    return () -> {
+      Object rawMaster = ResponseUnwrapper.get(getService().getMaster(deploymentName, ciName, masterName, validate));
+      return getObjectMapper().convertValue(rawMaster, CiType.getCiType(ciName).accountClass);
+    };
   }
 
   public static Supplier<Void> addMaster(String deploymentName, String ciName, boolean validate, CIAccount account) {
@@ -515,7 +519,10 @@ public class Daemon {
   }
 
   public static Supplier<Ci> getCi(String deploymentName, String ciName, boolean validate) {
-    return () -> ResponseUnwrapper.get(getService().getCi(deploymentName, ciName, validate));
+    return () -> {
+      Object ci = ResponseUnwrapper.get(getService().getCi(deploymentName, ciName, validate));
+      return getObjectMapper().convertValue(ci, CiType.getCiType(ciName).ciClass);
+    };
   }
 
   public static Supplier<Void> setCiEnableDisable(String deploymentName, String ciName, boolean validate, boolean enable) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/CiType.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/CiType.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.ci;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseCi;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseMaster;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuildAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsCi;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsMaster;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisCi;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisMaster;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.wercker.WerckerCi;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.wercker.WerckerMaster;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+
+public enum CiType {
+  jenkins(JenkinsCi.class, JenkinsMaster.class),
+  travis(TravisCi.class, TravisMaster.class),
+  wercker(WerckerCi.class, WerckerMaster.class),
+  concourse(ConcourseCi.class, ConcourseMaster.class),
+  gcb(GoogleCloudBuild.class, GoogleCloudBuildAccount.class);
+
+  public final Class<? extends Ci> ciClass;
+  public final Class<? extends CIAccount> accountClass;
+
+  CiType(Class<? extends Ci> ciClass, Class<? extends CIAccount> accountClass) {
+    this.ciClass = ciClass;
+    this.accountClass = accountClass;
+  }
+
+  public static CiType getCiType(String ciType) {
+    try {
+      return CiType.valueOf(ciType);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(String.format("No Continous Integration service with name '%s' handled by halyard", ciType));
+    }
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/concourse/ConcourseCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/concourse/ConcourseCi.java
@@ -33,7 +33,7 @@ public class ConcourseCi extends Ci<ConcourseMaster> {
     return "concourse";
   }
 
-  public List<ConcourseMaster> getAccounts() {
+  public List<ConcourseMaster> listAccounts() {
     return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/gcb/GoogleCloudBuild.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/gcb/GoogleCloudBuild.java
@@ -29,6 +29,10 @@ public class GoogleCloudBuild extends Ci<GoogleCloudBuildAccount> {
   private boolean enabled;
   private List<GoogleCloudBuildAccount> accounts = new ArrayList<>();
 
+  public List<GoogleCloudBuildAccount> listAccounts() {
+    return accounts;
+  }
+
   @Override
   public String getNodeName() {
     return "gcb";

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/jenkins/JenkinsCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/jenkins/JenkinsCi.java
@@ -34,7 +34,7 @@ public class JenkinsCi extends Ci<JenkinsMaster> {
     return "jenkins";
   }
 
-  public List<JenkinsMaster> getAccounts() {
+  public List<JenkinsMaster> listAccounts() {
     return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/travis/TravisCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/travis/TravisCi.java
@@ -33,7 +33,7 @@ public class TravisCi extends Ci<TravisMaster> {
     return "travis";
   }
 
-  public List<TravisMaster> getAccounts() {
+  public List<TravisMaster> listAccounts() {
     return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/wercker/WerckerCi.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/wercker/WerckerCi.java
@@ -34,7 +34,7 @@ public class WerckerCi extends Ci<WerckerMaster> {
     return "wercker";
   }
 
-  public List<WerckerMaster> getAccounts() {
+  public List<WerckerMaster> listAccounts() {
     return masters;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Ci.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Ci.java
@@ -27,10 +27,10 @@ import java.util.stream.Collectors;
 public abstract class Ci<T extends CIAccount> extends Node implements Cloneable {
   boolean enabled;
 
-  public abstract List<T> getAccounts();
+  public abstract List<T> listAccounts();
 
   @Override
   public NodeIterator getChildren() {
-    return NodeIteratorFactory.makeListIterator(getAccounts().stream().map(a -> (Node) a).collect(Collectors.toList()));
+    return NodeIteratorFactory.makeListIterator(listAccounts().stream().map(a -> (Node) a).collect(Collectors.toList()));
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
-import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseCi;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.wercker.WerckerCi;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/CiService.java
@@ -134,10 +134,10 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
   public void setMaster(String deploymentName, String masterName, T newAccount) {
     U ci = getCi(deploymentName);
 
-    for (int i = 0; i < ci.getAccounts().size(); i++) {
-      T account = ci.getAccounts().get(i);
+    for (int i = 0; i < ci.listAccounts().size(); i++) {
+      T account = ci.listAccounts().get(i);
       if (account.getNodeName().equals(masterName)) {
-        ci.getAccounts().set(i, newAccount);
+        ci.listAccounts().set(i, newAccount);
         return;
       }
     }
@@ -147,7 +147,7 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
   public void deleteMaster(String deploymentName, String masterName) {
     U ci = getCi(deploymentName);
-    boolean removed = ci.getAccounts().removeIf(master -> master.getName().equals(masterName));
+    boolean removed = ci.listAccounts().removeIf(master -> master.getName().equals(masterName));
 
     if (!removed) {
       throw new HalException(
@@ -158,7 +158,7 @@ public abstract class CiService<T extends CIAccount, U extends Ci<T>> {
 
   public void addMaster(String deploymentName, T newAccount) {
     U ci = getCi(deploymentName);
-    ci.getAccounts().add(newAccount);
+    ci.listAccounts().add(newAccount);
   }
 
   public ProblemSet validateMaster(String deploymentName, String masterName) {


### PR DESCRIPTION
* fix(ci): Fix error casting CI class from daemon 

  It turns out that removing the objectMapper from the halyard-cli commands broke deserializing the result from the daemon. We'll need to continue to conver the result to the expected class.

  Instead of adding back reflection, make a small enum that keeps track of the classes relevant for each CI system, and call that enum to do the mapping.

* fix(ci): Rename getAccounts to listAccounts 

  The interface method getAccounts starts with 'get' so the JSON serializer is assuming that it is the accessor for a property; this means that requests for jenkins accounts are returning accounts under both 'masters' and 'accounts' because both getMasters and getAccounts are defined.

  We could add @JsonIgnore to the getAccounts interface method, but we don't want to ignore that for gcb, and I don't believe you can override a @JsonIgnore annotation in a subclass (or at least this didn't work when I tried it.)

  Avoid all of this by just calling the interface method listAccounts so it's not confused as an accessor for a property, and then let Google Cloud Build keep its getAccounts accessor.