### PR TITLE
feat(gcb): Add hal commands for manipulating gcb accounts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -167,6 +167,14 @@
  * [**hal config ci concourse master edit**](#hal-config-ci-concourse-master-edit)
  * [**hal config ci concourse master get**](#hal-config-ci-concourse-master-get)
  * [**hal config ci concourse master list**](#hal-config-ci-concourse-master-list)
+ * [**hal config ci gcb**](#hal-config-ci-gcb)
+ * [**hal config ci gcb account**](#hal-config-ci-gcb-account)
+ * [**hal config ci gcb account add**](#hal-config-ci-gcb-account-add)
+ * [**hal config ci gcb account delete**](#hal-config-ci-gcb-account-delete)
+ * [**hal config ci gcb account edit**](#hal-config-ci-gcb-account-edit)
+ * [**hal config ci gcb account list**](#hal-config-ci-gcb-account-list)
+ * [**hal config ci gcb disable**](#hal-config-ci-gcb-disable)
+ * [**hal config ci gcb enable**](#hal-config-ci-gcb-enable)
  * [**hal config ci jenkins**](#hal-config-ci-jenkins)
  * [**hal config ci jenkins disable**](#hal-config-ci-jenkins-disable)
  * [**hal config ci jenkins enable**](#hal-config-ci-jenkins-enable)
@@ -3247,6 +3255,7 @@ hal config ci [subcommands]
 
 #### Subcommands
  * `concourse`: Manage and view Spinnaker configuration for the concourse ci
+ * `gcb`: Manage and view Spinnaker configuration for Google Cloud Build
  * `jenkins`: Manage and view Spinnaker configuration for the jenkins ci
  * `travis`: Manage and view Spinnaker configuration for the travis ci
  * `wercker`: Manage and view Spinnaker configuration for the wercker ci
@@ -3408,6 +3417,145 @@ List the master names for concourse.
 #### Usage
 ```
 hal config ci concourse master list [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci gcb
+
+Manage and view Spinnaker configuration for Google Cloud Build
+
+#### Usage
+```
+hal config ci gcb [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `account`: Manage and view Spinnaker configuration for the Google Cloud Build service account.
+ * `disable`: Set the gcb ci as disabled
+ * `enable`: Set the gcb ci as enabled
+
+---
+## hal config ci gcb account
+
+Manage and view Spinnaker configuration for the Google Cloud Build service account.
+
+#### Usage
+```
+hal config ci gcb account ACCOUNT [parameters] [subcommands]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the master to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `add`: Add a Google Cloud Build account
+ * `delete`: Delete a Google Cloud Build account.
+ * `edit`: Add a Google Cloud Build account
+ * `list`: List the Google Cloud Build accounts.
+
+---
+## hal config ci gcb account add
+
+Add a Google Cloud Build account
+
+#### Usage
+```
+hal config ci gcb account add ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the master to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--jsonKey`: The path to a JSON service account that Spinnaker will use as credentials
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--project`: (*Required*) The name of the GCP in which to trigger and monitor builds
+ * `--subscriptionName`: The name of the PubSub subscription on which to listen for build changes
+
+
+---
+## hal config ci gcb account delete
+
+Delete a Google Cloud Build account.
+
+#### Usage
+```
+hal config ci gcb account delete ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the master to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci gcb account edit
+
+Add a Google Cloud Build account
+
+#### Usage
+```
+hal config ci gcb account edit ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the master to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--jsonKey`: The path to a JSON service account that Spinnaker will use as credentials
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--project`: The name of the GCP in which to trigger and monitor builds
+ * `--subscriptionName`: The name of the PubSub subscription on which to listen for build changes
+
+
+---
+## hal config ci gcb account list
+
+List the Google Cloud Build accounts.
+
+#### Usage
+```
+hal config ci gcb account list [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci gcb disable
+
+Set the gcb ci as disabled
+
+#### Usage
+```
+hal config ci gcb disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci gcb enable
+
+Set the gcb ci as enabled
+
+#### Usage
+```
+hal config ci gcb enable [parameters]
 ```
 
 #### Parameters

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/CiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/CiCommand.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.ci;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.concourse.ConcourseCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb.GoogleCloudBuildCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.jenkins.JenkinsCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.travis.TravisCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.wercker.WerckerCommand;
@@ -42,6 +43,7 @@ public class CiCommand extends NestableCommand {
 
   public CiCommand() {
     registerSubcommand(new ConcourseCommand());
+    registerSubcommand(new GoogleCloudBuildCommand());
     registerSubcommand(new JenkinsCommand());
     registerSubcommand(new TravisCommand());
     registerSubcommand(new WerckerCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAccountCommand.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
 
 /**
- * Interact with the jenkins ci's masters
+ * Interact with Google Cloud Build accounts
  */
 @Parameters(separators = "=")
 public class GoogleCloudBuildAccountCommand extends AbstractHasAccountCommand {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAccountCommand.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
+
+/**
+ * Interact with the jenkins ci's masters
+ */
+@Parameters(separators = "=")
+public class GoogleCloudBuildAccountCommand extends AbstractHasAccountCommand {
+  protected String getCiName() {
+    return "gcb";
+  }
+
+  @Override
+  public String getCommandName() {
+    return "account";
+  }
+
+  public GoogleCloudBuildAccountCommand() {
+    super();
+    registerSubcommand(new GoogleCloudBuildListAccountsCommand());
+    registerSubcommand(new GoogleCloudBuildAddAccountCommand());
+    registerSubcommand(new GoogleCloudBuildEditAccountCommand());
+    registerSubcommand(new GooglecloudBuildDeleteAccountCommand());
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Manage and view Spinnaker configuration for the Google Cloud Build service account.";
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
@@ -66,12 +66,11 @@ public class GoogleCloudBuildAddAccountCommand extends AbstractHasAccountCommand
   private String jsonKey;
 
   protected GoogleCloudBuildAccount buildAccount(String accountName) {
-    GoogleCloudBuildAccount account = new GoogleCloudBuildAccount().setName(accountName);
-    account.setProject(project)
+    return new GoogleCloudBuildAccount()
+        .setName(accountName)
+        .setProject(project)
         .setSubscriptionName(subscriptionName)
         .setJsonKey(jsonKey);
-
-    return account;
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuildAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters(separators = "=")
+public class GoogleCloudBuildAddAccountCommand extends AbstractHasAccountCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  protected String getCiName() {
+    return "gcb";
+  }
+
+  public String getShortDescription() {
+    return "Add a Google Cloud Build account";
+  }
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "add";
+
+  @Parameter(
+      names = "--project",
+      required = true,
+      description = "The name of the GCP in which to trigger and monitor builds"
+  )
+  private String project;
+
+  @Parameter(
+      names = "--subscriptionName",
+      description = "The name of the PubSub subscription on which to listen for build changes"
+  )
+  private String subscriptionName;
+
+  @Parameter(
+      names = "--jsonKey",
+      description = "The path to a JSON service account that Spinnaker will use as credentials"
+  )
+  private String jsonKey;
+
+  protected GoogleCloudBuildAccount buildAccount(String accountName) {
+    GoogleCloudBuildAccount account = new GoogleCloudBuildAccount().setName(accountName);
+    account.setProject(project)
+        .setSubscriptionName(subscriptionName)
+        .setJsonKey(jsonKey);
+
+    return account;
+  }
+
+  @Override
+  protected void executeThis() {
+    String accountName = getAccountName();
+    CIAccount account = buildAccount(accountName);
+    String ciName = getCiName();
+
+    String currentDeployment = getCurrentDeployment();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.addMaster(currentDeployment, ciName, !noValidate, account))
+        .setSuccessMessage(String.format("Added Google Cloud Build account %s.", accountName))
+        .setFailureMesssage(String.format("Failed to add Google Cloud Build account %s.", accountName))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildCommand.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractNamedCiCommand;
+
+/**
+ * Interact with the jenkins ci
+ */
+@Parameters(separators = "=")
+public class GoogleCloudBuildCommand extends AbstractNamedCiCommand {
+  protected String getCiName() {
+    return "gcb";
+  }
+
+  @Override
+  public String getCommandName() {
+    return "gcb";
+  }
+
+  public GoogleCloudBuildCommand() {
+    super();
+    registerSubcommand(new GoogleCloudBuildAccountCommand());
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Manage and view Spinnaker configuration for Google Cloud Build";
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildCommand.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractNamedCiCommand;
 
 /**
- * Interact with the jenkins ci
+ * Interact with the Google Cloud Build ci
  */
 @Parameters(separators = "=")
 public class GoogleCloudBuildCommand extends AbstractNamedCiCommand {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildEditAccountCommand.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuildAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Parameters(separators = "=")
+public class GoogleCloudBuildEditAccountCommand extends AbstractHasAccountCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  protected String getCiName() {
+    return "gcb";
+  }
+
+  public String getShortDescription() {
+    return "Add a Google Cloud Build account";
+  }
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  @Parameter(
+      names = "--project",
+      description = "The name of the GCP in which to trigger and monitor builds"
+  )
+  private String project;
+
+  @Parameter(
+      names = "--subscriptionName",
+      description = "The name of the PubSub subscription on which to listen for build changes"
+  )
+  public String subscriptionName;
+
+  @Parameter(
+      names = "--jsonKey",
+      description = "The path to a JSON service account that Spinnaker will use as credentials"
+  )
+  public String jsonKey;
+
+  protected GoogleCloudBuildAccount editAccount(GoogleCloudBuildAccount account) {
+    if (isSet(project)) {
+      account.setProject(project);
+    }
+
+    if (isSet(subscriptionName)) {
+      account.setSubscriptionName(subscriptionName);
+    }
+
+    if (isSet(jsonKey)) {
+      account.setJsonKey(jsonKey);
+    }
+
+    return account;
+  }
+
+  @Override
+  protected void executeThis() {
+    String accountName = getAccountName();
+    String ciName = getCiName();
+    String currentDeployment = getCurrentDeployment();
+    // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
+    GoogleCloudBuildAccount account = (GoogleCloudBuildAccount) new OperationHandler<CIAccount>()
+        .setOperation(Daemon.getMaster(currentDeployment, ciName, accountName, false))
+        .setFailureMesssage(String.format("Failed to get Google Cloud Build Account %s.", accountName))
+        .get();
+
+    int originalHash = account.hashCode();
+
+    account = editAccount(account);
+
+    if (originalHash == account.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setMaster(currentDeployment, ciName, accountName, !noValidate, account))
+        .setSuccessMessage(String.format("Edited Google Cloud Build account %s.", accountName))
+        .setFailureMesssage(String.format("Failed to edit Google Cloud Build account %s.", accountName))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildListAccountsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildListAccountsCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractCiCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Getter;
+
+import java.util.List;
+
+@Parameters(separators = "=")
+class GoogleCloudBuildListAccountsCommand extends AbstractCiCommand {
+  public String getShortDescription() {
+    return "List the Google Cloud Build accounts.";
+  }
+
+  @Override
+  protected String getCiName() {
+    return "gcb";
+  }
+
+  @Getter
+  private String commandName = "list";
+
+  private Ci getCi() {
+    String currentDeployment = getCurrentDeployment();
+    String ciName = getCiName();
+    return new OperationHandler<Ci>()
+        .setOperation(Daemon.getCi(currentDeployment, ciName, !noValidate))
+        .setFailureMesssage("Failed to get Google Cloud Build account.")
+        .get();
+  }
+
+  @Override
+  protected void executeThis() {
+    Ci ci = getCi();
+    List<CIAccount> account = ci.listAccounts();
+    if (account.isEmpty()) {
+      AnsiUi.success("No configured Google Cloud Build accounts.");
+    } else {
+      AnsiUi.success("Google Cloud Build accounts:");
+      account.forEach(master -> AnsiUi.listItem(master.getName()));
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GooglecloudBuildDeleteAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GooglecloudBuildDeleteAccountCommand.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Delete a specific PROVIDER master
+ * Delete a specific Google Cloud Build account
  */
 @Parameters(separators = "=")
 public class GooglecloudBuildDeleteAccountCommand extends AbstractHasAccountCommand {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GooglecloudBuildDeleteAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GooglecloudBuildDeleteAccountCommand.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Delete a specific PROVIDER master
+ */
+@Parameters(separators = "=")
+public class GooglecloudBuildDeleteAccountCommand extends AbstractHasAccountCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "delete";
+
+  protected String getCiName() {
+    return "gcb";
+  }
+
+  public String getShortDescription() {
+    return "Delete a Google Cloud Build account.";
+  }
+
+  @Override
+  protected void executeThis() {
+    String accountName = getAccountName();
+    String currentDeployment = getCurrentDeployment();
+    String ciName = getCiName();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.deleteMaster(currentDeployment, ciName, accountName, !noValidate))
+        .setSuccessMessage(String.format("Deleted Google Cloud Build account %s.", accountName))
+        .setFailureMesssage(String.format("Failed to delete Google Cloud Build account %s.", accountName))
+        .get();
+    AnsiUi.success("Deleted " + accountName);
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractHasAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractHasAccountCommand.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractCiCommand;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * An abstract definition for commands that accept 'account' as a main parameter
+ */
+@Parameters(separators = "=")
+public abstract class AbstractHasAccountCommand extends AbstractCiCommand {
+  @Parameter(description = "The name of the master to operate on.", arity = 1)
+  List<String> accounts = new ArrayList<>();
+
+  @Override
+  public String getMainParameter() {
+    return "account";
+  }
+
+  public String getAccountName() {
+    switch (accounts.size()) {
+      case 0:
+        throw new IllegalArgumentException("No account name supplied");
+      case 1:
+        return accounts.get(0);
+      default:
+        throw new IllegalArgumentException("More than one account supplied");
+    }
+  }
+}


### PR DESCRIPTION
Prior commits added support for including these in the hal config and for generating service configs including gcb accounts. This commit just adds the hal commands to edit these accounts.