### PR TITLE
feat(kubernetes): Allow adding custom pod and service labels

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -31,6 +31,8 @@ public class KubernetesSettings {
   List<String> imagePullSecrets = new ArrayList<>();
   Map<String, String> nodeSelector = new HashMap<>();
   Map<String, String> podAnnotations = new HashMap<>();
+  Map<String, String> podLabels = new HashMap<>();
+  Map<String, String> serviceLabels = new HashMap<>();
   List<ConfigSource> volumes = new ArrayList<>();
   String serviceAccountName = null;
   String serviceType = "ClusterIP";

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -130,6 +130,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
     service.addBinding("port", settings.getPort());
     service.addBinding("type", settings.getKubernetes().getServiceType());
     service.addBinding("nodePort", settings.getKubernetes().getNodePort());
+    service.addBinding("serviceLabels", settings.getKubernetes().getServiceLabels());
 
     return service.toString();
   }
@@ -177,6 +178,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T> {
         .addBinding("version", version)
         .addBinding("podAnnotations", settings.getKubernetes().getPodAnnotations())
         .addBinding("podSpec", getPodSpecYaml(executor, details, resolvedConfiguration))
+        .addBinding("podLabels", settings.getKubernetes().getPodLabels())
         .toString();
   }
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
@@ -32,4 +32,7 @@ spec:
         app.kubernetes.io/managed-by: halyard
         app.kubernetes.io/part-of: spinnaker
         app.kubernetes.io/version: {{ version }}
+        {% for key, value in podLabels.items() %}
+        "{{ key }}" : "{{ value }}"{% if not loop.last %}, {% endif %}
+        {% endfor %}}
     spec: {{ podSpec }}

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: spin
     cluster: spin-{{ name }}
+    {% for key, value in serviceLabels.items() %}
+    "{{ key }}" : "{{ value }}"{% if not loop.last %}, {% endif %}
+    {% endfor %}}
 spec:
   selector:
     app: spin


### PR DESCRIPTION
This allows adding customized labels to the pods and services created by Halyard for Spinnaker services.