### PR TITLE
fix(halyard): Replace non-ASCII quotes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9418,7 +9418,7 @@ hal config security authn ldap disable [parameters]
 ---
 ## hal config security authn ldap edit
 
-Lightweight Directory Access Protocol (LDAP) is a standard way many organizations maintain user credentials and group memberships. Spinnaker uses the standard “bind” approach for user authentication. This is a fancy way of saying that Gate uses your username and password to login to the LDAP server, and if the connection is successful, you’re considered authenticated.
+Lightweight Directory Access Protocol (LDAP) is a standard way many organizations maintain user credentials and group memberships. Spinnaker uses the standard 'bind' approach for user authentication. This is a fancy way of saying that Gate uses your username and password to login to the LDAP server, and if the connection is successful, you're considered authenticated.
 
 #### Usage
 ```

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/ldap/EditLdapCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/ldap/EditLdapCommand.java
@@ -33,9 +33,9 @@ public class EditLdapCommand extends AbstractEditAuthnMethodCommand<Ldap> {
   @Getter
   private String longDescription = String.join(" ", "Lightweight Directory Access Protocol (LDAP)",
       "is a standard way many organizations maintain user credentials and group memberships.",
-      "Spinnaker uses the standard “bind” approach for user authentication.",
+      "Spinnaker uses the standard 'bind' approach for user authentication.",
       "This is a fancy way of saying that Gate uses your username and password to login to the LDAP server,",
-      "and if the connection is successful, you’re considered authenticated.");
+      "and if the connection is successful, you're considered authenticated.");
 
   @Getter
   private AuthnMethod.Method method = AuthnMethod.Method.LDAP;


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4393

The non-ASCII quotes seem to be causing issues for some users; theoretically they should work but rather than worry about debugging encoding issues, just replace them.