### PR TITLE
feat(s3): Add --path-style-access option to config s3 bucket access style (#4400)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10172,6 +10172,7 @@ Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--endpoint`: An alternate endpoint that your S3-compatible storage can be found at. This is intended for self-hosted storage services with S3-compatible APIs, e.g. Minio. If supplied, this storage type cannot be validated.
  * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--path-style-access`: (*Default*: `false`) when true, use path-style to access bucket; when false, use virtual hosted-style to access bucket.  See https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingExamples.
  * `--region`: This is only required if the bucket you specify doesn't exist yet. In that case, the bucket will be created in that region. See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region.
  * `--root-folder`: The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
  * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/persistentStorage/s3/S3EditCommand.java
@@ -61,6 +61,14 @@ public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3Persiste
   private String region;
 
   @Parameter(
+    names = "--path-style-access",
+	arity = 1,
+	description = "when true, use path-style to access bucket; when false, use virtual hosted-style to access bucket. "
+	  + " See https://docs.aws.amazon.com/AmazonS3/latest/dev/VirtualHosting.html#VirtualHostingExamples."
+  )
+  private Boolean pathStyleAccess = false;
+
+  @Parameter(
     names = "--assume-role",
     description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION
   )
@@ -88,6 +96,7 @@ public class S3EditCommand extends AbstractPersistentStoreEditCommand<S3Persiste
     persistentStore.setRootFolder(isSet(rootFolder) ? rootFolder : persistentStore.getRootFolder());
     persistentStore.setRegion(isSet(region) ? region : persistentStore.getRegion());
     persistentStore.setEndpoint(isSet(endpoint) ? endpoint : persistentStore.getEndpoint());
+    persistentStore.setPathStyleAccess(isSet(pathStyleAccess) ? pathStyleAccess : persistentStore.getPathStyleAccess());
     persistentStore.setAccessKeyId(isSet(accessKeyId) ? accessKeyId : persistentStore.getAccessKeyId());
     persistentStore.setSecretAccessKey(isSet(secretAccessKey) ? secretAccessKey : persistentStore.getSecretAccessKey());
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/S3PersistentStore.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.halyard.config.model.v1.persistentStorage;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.PersistentStore;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
+import com.netflix.spinnaker.halyard.config.model.v1.node.ValidForSpinnakerVersion;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -27,6 +28,8 @@ public class S3PersistentStore extends PersistentStore {
   private String bucket;
   private String rootFolder = "front50";
   private String region;
+  @ValidForSpinnakerVersion(lowerBound = "1.13.0", tooLowMessage = "Spinnaker does not support configuring this behavior before that version.")
+  private Boolean pathStyleAccess;
   private String endpoint;
   private String accessKeyId;
   @Secret private String secretAccessKey;


### PR DESCRIPTION
There are two styles to access s3 bucket: `virtual hosted-style` and `path-style`. Users can config which one they want to use.

I make this option default false which means using `virtual hosted-style` in considering `path-style` access is already deprecated by AWS([Amazon S3 Path Deprecation Plan – The Rest of the Story](https://aws.amazon.com/cn/blogs/aws/amazon-s3-path-deprecation-plan-the-rest-of-the-story/)).
 