### PR TITLE
fix(redis): Ensure redis is started

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRedisService.java
@@ -59,7 +59,7 @@ public class LocalDebianRedisService extends RedisService implements LocalDebian
 
   @Override
   public String installArtifactCommand(DeploymentDetails deploymentDetails) {
-    return "apt-get -q -y --force-yes install redis-server";
+    return "apt-get -q -y --force-yes install redis-server && (systemctl start redis-server.service || true)";
   }
 
   @Override


### PR DESCRIPTION
When installing redis on ubuntu 16.04, it is not enabled by default (as opposed to 14.04 and 18.04 where it is). This breaks our integration tests, and also likely confuses users who need to manually start it even after deploying with halyard. To fix this, ensure the service is started after installing.  (systemctl won't
exist on 14.04, so guard that statement with a || true)