### PR TITLE
fix(appengine): Allow path to gcloud to be configured

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -334,6 +334,7 @@
  * [**hal config provider appengine account get**](#hal-config-provider-appengine-account-get)
  * [**hal config provider appengine account list**](#hal-config-provider-appengine-account-list)
  * [**hal config provider appengine disable**](#hal-config-provider-appengine-disable)
+ * [**hal config provider appengine edit**](#hal-config-provider-appengine-edit)
  * [**hal config provider appengine enable**](#hal-config-provider-appengine-enable)
  * [**hal config provider aws**](#hal-config-provider-aws)
  * [**hal config provider aws account**](#hal-config-provider-aws-account)
@@ -6266,6 +6267,7 @@ hal config provider appengine [parameters] [subcommands]
 #### Subcommands
  * `account`: Manage and view Spinnaker configuration for the appengine provider's account
  * `disable`: Set the appengine provider as disabled
+ * `edit`: Edit Spinnaker's app engine configuration.
  * `enable`: Set the appengine provider as enabled
 
 ---
@@ -6429,6 +6431,22 @@ hal config provider appengine disable [parameters]
 
 #### Parameters
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider appengine edit
+
+Edit Spinnaker's app engine configuration.
+
+#### Usage
+```
+hal config provider appengine edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--gcloudPath`: The path to the gcloud executable on the machine running clouddriver.
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineCommand.java
@@ -37,6 +37,7 @@ public class AppengineCommand extends AbstractNamedProviderCommand {
 
   public AppengineCommand() {
     super();
+    registerSubcommand(new AppengineEditCommand());
     registerSubcommand(new AppengineAccountCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/appengine/AppengineEditCommand.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.appengine;
+
+import static com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format.STRING;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.appengine.AppengineProvider;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class AppengineEditCommand extends AbstractProviderCommand {
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Edit Spinnaker's app engine configuration.";
+
+  @Parameter(
+      names = "--gcloudPath",
+      description = "The path to the gcloud executable on the machine running clouddriver."
+  )
+  private String gcloudPath;
+
+  protected String getProviderName() {
+    return "appengine";
+  }
+
+  public AppengineEditCommand() {
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+
+    String providerName = getProviderName();
+    new OperationHandler<Provider>()
+        .setFailureMesssage("Failed to get provider " + providerName + ".")
+        .setSuccessMessage("Successfully got provider " + providerName + ".")
+        .setFormat(STRING)
+        .setUserFormatted(true)
+        .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+        .get();
+
+    AppengineProvider provider = (AppengineProvider) new OperationHandler<Provider>()
+        .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+        .setFailureMesssage("Failed to get provider " + providerName + ".")
+        .get();
+
+    int originalHash = provider.hashCode();
+
+    if (isSet(gcloudPath)) {
+      provider.setGcloudPath(gcloudPath);
+    }
+
+    if (originalHash == provider.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to edit update appengine provider.")
+        .setSuccessMessage("Successfully edited appengine provider.")
+        .setOperation(
+            Daemon.setProvider(currentDeployment, getProviderName(), !noValidate, provider))
+        .get();
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/appengine/AppengineProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/appengine/AppengineProvider.java
@@ -17,8 +17,14 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.appengine;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
 
+@Data
+@EqualsAndHashCode(callSuper = true)
 public class AppengineProvider extends Provider<AppengineAccount> {
+  private String gcloudPath;
+
   @Override
   public Provider.ProviderType providerType() {
     return ProviderType.APPENGINE;


### PR DESCRIPTION
Clouddriver searches the the PATH for the gcloud executible; in some cases it is easier to provide a direct path to the executable than to fully control the environment of clouddriver.

(One example is running it on Ubuntu 18.04 on GCE; gcloud is installed in /snap/bin, which is added to the path for login shells but is not in the path for systemd.)

The clouddriver change will just fall back to searching the path if this parameter is unset.