### PR TITLE
fix(integrations): Fix duplicate config block

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/GateProfileFactory.java
@@ -32,6 +32,10 @@ import org.apache.commons.lang.StringUtils;
 import java.util.List;
 
 public abstract class GateProfileFactory extends SpringProfileFactory {
+  // Some versions of gate have integrations in the base halyard config; we'll generate an invalid config
+  // if we add another integrations block.  As a workaround we'll remove that block from the base profile
+  // if we encounter it.
+  private static final String INTEGRATION_BLOCK = "integrations:\n  gremlin:\n    enabled: ${features.gremlin:false}\n    baseUrl: https://api.gremlin.com/v1\n";
 
   @Override
   public SpinnakerArtifact getArtifact() {
@@ -59,7 +63,7 @@ public abstract class GateProfileFactory extends SpringProfileFactory {
 
     profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, gateConfig))
             .appendContents(yamlToString(deploymentConfiguration.getName(), profile, integrationsConfig))
-            .appendContents(profile.getBaseContents())
+            .appendContents(profile.getBaseContents().replace(INTEGRATION_BLOCK,""))
             .setRequiredFiles(requiredFiles);
 
   }


### PR DESCRIPTION
Halyard now adds the integrations block to the gate config, but 1.13.x versions of Spinnaker already have it defined in the hal config, which leads to duplicate 'integrations' blocks, breaking gate startup.

Unfortunately there's not currently a great way of addressing this; as a workaround just remove that block on-the-fly if we encounter it.