### PR TITLE
fix(*): Don't fail validation if openstack is present

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Providers.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Providers.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.appengine.AppengineProvider;
@@ -40,6 +41,7 @@ import java.util.Optional;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
+@JsonIgnoreProperties({"openstack"})
 public class Providers extends Node implements Cloneable {
   AppengineProvider appengine = new AppengineProvider();
   AwsProvider aws = new AwsProvider();


### PR DESCRIPTION
We removed support for OpenStack, but this is causing Halyard to fail validation if there is an openstack block in the config. This is particularly bad as Halyard adds an empty block by default for each provider, so even users who have never used openstack are seeing validation failures after the release of 1.20.0.

Explicitly ignore the "openstack" field on deserialization so we don't cause validation errors.