### PR TITLE
fix(deploy): Add local profile to deployment configuration

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1ClouddriverBootstrapService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1ClouddriverBootstrapService.java
@@ -24,6 +24,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ClouddriverServ
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedLogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesSharedServiceSettings;
+import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -51,6 +52,7 @@ public class KubernetesV1ClouddriverBootstrapService extends ClouddriverBootstra
     List<String> profiles = new ArrayList<>();
     profiles.add("bootstrap");
     profiles.add("bootstrap-local");
+    profiles.add("local");
     KubernetesSharedServiceSettings kubernetesSharedServiceSettings = new KubernetesSharedServiceSettings(deploymentConfiguration);
     Settings settings = new Settings(profiles);
     String location = kubernetesSharedServiceSettings.getDeployLocation();
@@ -60,6 +62,14 @@ public class KubernetesV1ClouddriverBootstrapService extends ClouddriverBootstra
         .setMonitored(false)
         .setEnabled(true);
     return settings;
+  }
+
+  @Override
+  protected Optional<String> customProfileOutputPath(String profileName) {
+    if (profileName.equals("clouddriver-local.yml")) {
+      return Optional.empty();
+    }
+    return super.customProfileOutputPath(profileName);
   }
 
   public String getArtifactId(String deploymentName) {


### PR DESCRIPTION
The change to update clouddriver to use Spring Cloud Config is causing it to fail to startup when we don't specify 'local' as a profile. Let's add the 'local' profile here so that it discovers the cloud configuration.