### PR TITLE
fix(deploy): Handle files with special characters

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
@@ -448,7 +448,7 @@ abstract public class Node implements Validatable {
         }
 
         File fFile = new File(fPath);
-        String fName = fFile.getName();
+        String fName = fFile.getName().replaceAll("[^-._a-zA-Z0-9]", "-");
 
         // Hash the path to uniquely flatten all files into the output directory
         Path newName = Paths.get(outputPath, Math.abs(fPath.hashCode()) + "-" + fName);


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4399

When deploying to Kubernetes, supporting files (such as credentials) are added as files in a Kubernetes secret, which does not allow special characters in file names. Strip special characters out of the file names before we generate the staged file for backing up.