### PR TITLE
fix(gcb): Fix gcb command parameters

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3478,10 +3478,10 @@ hal config ci gcb account add ACCOUNT [parameters]
 #### Parameters
 `ACCOUNT`: The name of the master to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--jsonKey`: The path to a JSON service account that Spinnaker will use as credentials
+ * `--json-key`: The path to a JSON service account that Spinnaker will use as credentials
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--project`: (*Required*) The name of the GCP in which to trigger and monitor builds
- * `--subscriptionName`: The name of the PubSub subscription on which to listen for build changes
+ * `--project`: (*Required*) The name of the GCP project in which to trigger and monitor builds
+ * `--subscription-name`: The name of the PubSub subscription on which to listen for build changes
 
 
 ---
@@ -3513,10 +3513,10 @@ hal config ci gcb account edit ACCOUNT [parameters]
 #### Parameters
 `ACCOUNT`: The name of the master to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--jsonKey`: The path to a JSON service account that Spinnaker will use as credentials
+ * `--json-key`: The path to a JSON service account that Spinnaker will use as credentials
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--project`: The name of the GCP in which to trigger and monitor builds
- * `--subscriptionName`: The name of the PubSub subscription on which to listen for build changes
+ * `--project`: The name of the GCP project in which to trigger and monitor builds
+ * `--subscription-name`: The name of the PubSub subscription on which to listen for build changes
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
@@ -49,18 +49,18 @@ public class GoogleCloudBuildAddAccountCommand extends AbstractHasAccountCommand
   @Parameter(
       names = "--project",
       required = true,
-      description = "The name of the GCP in which to trigger and monitor builds"
+      description = "The name of the GCP project in which to trigger and monitor builds"
   )
   private String project;
 
   @Parameter(
-      names = "--subscriptionName",
+      names = "--subscription-name",
       description = "The name of the PubSub subscription on which to listen for build changes"
   )
   private String subscriptionName;
 
   @Parameter(
-      names = "--jsonKey",
+      names = "--json-key",
       description = "The path to a JSON service account that Spinnaker will use as credentials"
   )
   private String jsonKey;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildEditAccountCommand.java
@@ -49,18 +49,18 @@ public class GoogleCloudBuildEditAccountCommand extends AbstractHasAccountComman
 
   @Parameter(
       names = "--project",
-      description = "The name of the GCP in which to trigger and monitor builds"
+      description = "The name of the GCP project in which to trigger and monitor builds"
   )
   private String project;
 
   @Parameter(
-      names = "--subscriptionName",
+      names = "--subscription-name",
       description = "The name of the PubSub subscription on which to listen for build changes"
   )
   public String subscriptionName;
 
   @Parameter(
-      names = "--jsonKey",
+      names = "--json-key",
       description = "The path to a JSON service account that Spinnaker will use as credentials"
   )
   public String jsonKey;


### PR DESCRIPTION
The GCB command parameters are camel case, which is inconsistent with all other halyard commands. Fix this now before the feature is live in Spinnaker and users are depending on these.