### PR TITLE
fix(aws): AWS Credentials file not being created if keys are not in halconfig

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ClouddriverService.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import retrofit.http.Body;
@@ -106,9 +105,7 @@ public abstract class ClouddriverService extends SpringService<ClouddriverServic
       String spinnakerHome) {
     String name = "aws/clouddriver-credentials" + spinnakerHome.replace("/", "_");
     AwsProvider awsProvider = deploymentConfiguration.getProviders().getAws();
-    if (awsProvider.isEnabled()
-        && !StringUtils.isEmpty(awsProvider.getAccessKeyId())
-        && !StringUtils.isEmpty(awsProvider.getSecretAccessKey())) {
+    if (awsProvider.isEnabled()) {
       String outputFile = awsCredentialsProfileFactoryBuilder.getOutputFile(spinnakerHome);
       return Optional.of(
           awsCredentialsProfileFactoryBuilder

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/Front50Service.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import retrofit.http.GET;
@@ -82,9 +81,7 @@ public abstract class Front50Service extends SpringService<Front50Service.Front5
     PersistentStore.PersistentStoreType type =
         deploymentConfiguration.getPersistentStorage().getPersistentStoreType();
     S3PersistentStore store = deploymentConfiguration.getPersistentStorage().getS3();
-    if (type == PersistentStore.PersistentStoreType.S3
-        && !StringUtils.isEmpty(store.getAccessKeyId())
-        && !StringUtils.isEmpty(store.getSecretAccessKey())) {
+    if (type == PersistentStore.PersistentStoreType.S3) {
       String outputFile = awsCredentialsProfileFactoryBuilder.getOutputFile(spinnakerHome);
       return Optional.of(
           awsCredentialsProfileFactoryBuilder

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KayentaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KayentaService.java
@@ -92,31 +92,21 @@ public abstract class KayentaService extends SpringService<KayentaService.Kayent
       // between kayenta aws
       // accounts, and front50 and clouddriver configuration.
       if (awsCanaryServiceIntegration.isS3Enabled()) {
-        Optional<AwsCanaryAccount> optionalAwsCanaryAccount =
-            awsCanaryServiceIntegration.getAccounts().stream()
-                .filter(
-                    a ->
-                        !StringUtils.isEmpty(a.getAccessKeyId())
-                            && !StringUtils.isEmpty(a.getSecretAccessKey()))
-                .findFirst();
+        AwsCanaryAccount awsCanaryAccount = awsCanaryServiceIntegration.getAccounts().get(0);
+        String outputFile = awsCredentialsProfileFactoryBuilder.getOutputFile(spinnakerHome);
 
-        if (optionalAwsCanaryAccount.isPresent()) {
-          AwsCanaryAccount awsCanaryAccount = optionalAwsCanaryAccount.get();
-          String outputFile = awsCredentialsProfileFactoryBuilder.getOutputFile(spinnakerHome);
+        awsCredentialsProfileFactoryBuilder.setProfileName(
+            StringUtils.isNotBlank(awsCanaryAccount.getProfileName())
+                ? awsCanaryAccount.getProfileName()
+                : "default");
 
-          awsCredentialsProfileFactoryBuilder.setProfileName(
-              StringUtils.isNotBlank(awsCanaryAccount.getProfileName())
-                  ? awsCanaryAccount.getProfileName()
-                  : "default");
-
-          return Optional.of(
-              awsCredentialsProfileFactoryBuilder
-                  .setArtifact(SpinnakerArtifact.KAYENTA)
-                  .setAccessKeyId(awsCanaryAccount.getAccessKeyId())
-                  .setSecretAccessKey(awsCanaryAccount.getSecretAccessKey())
-                  .build()
-                  .getProfile(name, outputFile, deploymentConfiguration, endpoints));
-        }
+        return Optional.of(
+            awsCredentialsProfileFactoryBuilder
+                .setArtifact(SpinnakerArtifact.KAYENTA)
+                .setAccessKeyId(awsCanaryAccount.getAccessKeyId())
+                .setSecretAccessKey(awsCanaryAccount.getSecretAccessKey())
+                .build()
+                .getProfile(name, outputFile, deploymentConfiguration, endpoints));
       }
     }
 


### PR DESCRIPTION
Issue Summary:

If an AWS service is configured, such as S3 Persistent Store, but credentials are not set on halconfig the DefaultAWSCredentialsProviderChain (https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html) is used to get the secret and access keys and be able to validate the configuration.
But after successful validation the AWS credentials file is not being created using the values from the chain making the deployment of services depending on these configured AWS services fail.

Proposal:
Generate AWS credentials file with values from the DefaultAWSCredentialsProviderChain if AWS Keys are not present in halconfig

Issue Tracker: https://github.com/spinnaker/spinnaker/issues/4436