### PR TITLE
refactor(cf): Improved consistency of `hal config provider cloudfoundry add/edit` parameters

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7107,11 +7107,11 @@ hal config provider cloudfoundry account add ACCOUNT [parameters]
 
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
- * `--api`: (*Required*) Host name of the CloudFoundry Foundation API endpoint without protocol indicator ie. `api.sys.somesystem.com`
- * `--appsManagerUri`: Full URI for the Apps Manager application for the CloudFoundry Foundation ie. `https://apps.sys.somesystem.com`
+ * `--api-host, --api`: (*Required*) Host of the CloudFoundry Foundation API endpoint ie. `api.sys.somesystem.com`
+ * `--apps-manager-uri, --appsManagerUri`: Full URI for the Apps Manager application for the CloudFoundry Foundation ie. `https://apps.sys.somesystem.com`
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
- * `--metricsUri`: Full URI for the metrics application for the CloudFoundry Foundation ie. `https://metrics.sys.somesystem.com`
+ * `--metrics-uri, --metricsUri`: Full URI for the metrics application for the CloudFoundry Foundation ie. `https://metrics.sys.somesystem.com`
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: (*Required*) Password for the account to use on for this CloudFoundry Foundation
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
@@ -7152,11 +7152,11 @@ hal config provider cloudfoundry account edit ACCOUNT [parameters]
  * `--add-read-permission`: Add this permission to the list of read permissions.
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
  * `--add-write-permission`: Add this permission to the list of write permissions.
- * `--api`: (*Required*) Host name of the CloudFoundry Foundation API endpoint without protocol indicator ie. `api.sys.somesystem.com`
- * `--appsManagerUri`: Full URI for the Apps Manager application for the CloudFoundry Foundation ie. `https://apps.sys.somesystem.com`
+ * `--api-host, --api`: (*Required*) Host of the CloudFoundry Foundation API endpoint ie. `api.sys.somesystem.com`
+ * `--apps-manager-uri, --appsManagerUri`: Full URI for the Apps Manager application for the CloudFoundry Foundation ie. `https://apps.sys.somesystem.com`
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
- * `--metricsUri`: Full URI for the metrics application for the CloudFoundry Foundation ie. `https://metrics.sys.somesystem.com`
+ * `--metrics-uri, --metricsUri`: Full URI for the metrics application for the CloudFoundry Foundation ie. `https://metrics.sys.somesystem.com`
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: (*Required*) Password for the account to use on for this CloudFoundry Foundation
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryAddAccountCommand.java
@@ -25,20 +25,20 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudfoundry.Clou
 @Parameters(separators = "=")
 public class CloudFoundryAddAccountCommand extends AbstractAddAccountCommand {
     @Parameter(
-            names = "--api",
+            names = {"--api-host", "--api"},
             required = true,
-            description = CloudFoundryCommandProperties.API_DESCRIPTION
+            description = CloudFoundryCommandProperties.API_HOST_DESCRIPTION
     )
-    private String api;
+    private String apiHost;
 
     @Parameter(
-            names = "--appsManagerUri",
+            names = {"--apps-manager-uri", "--appsManagerUri"},
             description = CloudFoundryCommandProperties.APPS_MANAGER_URI_DESCRIPTION
     )
     private String appsManagerUri;
 
     @Parameter(
-            names = "--metricsUri",
+            names = {"--metrics-uri", "--metricsUri"},
             description = CloudFoundryCommandProperties.METRICS_URI_DESCRIPTION
     )
     private String metricsUri;
@@ -61,7 +61,7 @@ public class CloudFoundryAddAccountCommand extends AbstractAddAccountCommand {
     protected Account buildAccount(String accountName) {
         CloudFoundryAccount cloudFoundryAccount = (CloudFoundryAccount) new CloudFoundryAccount().setName(accountName);
         return cloudFoundryAccount
-                .setApi(api)
+                .setApiHost(apiHost)
                 .setAppsManagerUri(appsManagerUri)
                 .setMetricsUri(metricsUri)
                 .setPassword(password)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryCommandProperties.java
@@ -17,8 +17,8 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudfoundry;
 
 public class CloudFoundryCommandProperties {
-    public static final String API_DESCRIPTION = "Host name of the CloudFoundry Foundation API endpoint without"
-            + " protocol indicator ie. `api.sys.somesystem.com`";
+    public static final String API_HOST_DESCRIPTION = "Host of the CloudFoundry Foundation API endpoint "
+            + "ie. `api.sys.somesystem.com`";
     public static final String APPS_MANAGER_URI_DESCRIPTION = "Full URI for the Apps Manager application for the"
             + " CloudFoundry Foundation ie. `https://apps.sys.somesystem.com`";
     public static final String METRICS_URI_DESCRIPTION = "Full URI for the metrics application for the CloudFoundry "

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryEditAccountCommand.java
@@ -30,20 +30,20 @@ public class CloudFoundryEditAccountCommand extends AbstractEditAccountCommand<C
     }
 
     @Parameter(
-            names = "--api",
+            names = {"--api-host", "--api"},
             required = true,
-            description = CloudFoundryCommandProperties.API_DESCRIPTION
+            description = CloudFoundryCommandProperties.API_HOST_DESCRIPTION
     )
-    private String api;
+    private String apiHost;
 
     @Parameter(
-            names = "--appsManagerUri",
+            names = {"--apps-manager-uri", "--appsManagerUri"},
             description = CloudFoundryCommandProperties.APPS_MANAGER_URI_DESCRIPTION
     )
     private String appsManagerUri;
 
     @Parameter(
-            names = "--metricsUri",
+            names = {"--metrics-uri", "--metricsUri"},
             description = CloudFoundryCommandProperties.METRICS_URI_DESCRIPTION
     )
     private String metricsUri;
@@ -64,7 +64,7 @@ public class CloudFoundryEditAccountCommand extends AbstractEditAccountCommand<C
 
     @Override
     protected Account editAccount(CloudFoundryAccount account) {
-        account.setApi(isSet(api) ? api : account.getApi());
+        account.setApiHost(isSet(apiHost) ? apiHost : account.getApiHost());
         account.setAppsManagerUri(isSet(appsManagerUri) ? appsManagerUri : account.getAppsManagerUri());
         account.setMetricsUri(isSet(metricsUri) ? metricsUri : account.getMetricsUri());
         account.setPassword(isSet(password) ? password : account.getPassword());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudfoundry/CloudFoundryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudfoundry/CloudFoundryAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.cloudfoundry;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import lombok.Data;
@@ -24,7 +25,7 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class CloudFoundryAccount extends Account {
-    String api;
+    @JsonProperty("api") String apiHost;
     String appsManagerUri;
     String metricsUri;
     @Secret

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/cloudfoundry/CloudFoundryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/cloudfoundry/CloudFoundryAccountValidator.java
@@ -43,7 +43,7 @@ public class CloudFoundryAccountValidator extends Validator<CloudFoundryAccount>
         DaemonTaskHandler.message("Validating " + accountName + " with " + CloudFoundryAccountValidator.class.getSimpleName());
 
         String environment = cloudFoundryAccount.getEnvironment();
-        String api = cloudFoundryAccount.getApi();
+        String apiHost = cloudFoundryAccount.getApiHost();
         String appsManagerUri = cloudFoundryAccount.getAppsManagerUri();
         String metricsUri = cloudFoundryAccount.getMetricsUri();
         String password = cloudFoundryAccount.getPassword();
@@ -53,8 +53,8 @@ public class CloudFoundryAccountValidator extends Validator<CloudFoundryAccount>
             problemSetBuilder.addProblem(Problem.Severity.ERROR, "You must provide a user and a password");
         }
 
-        if (StringUtils.isEmpty(api)) {
-            problemSetBuilder.addProblem(Problem.Severity.ERROR, "You must provide a CF api endpoint");
+        if (StringUtils.isEmpty(apiHost)) {
+            problemSetBuilder.addProblem(Problem.Severity.ERROR, "You must provide a CF api endpoint host");
         }
 
         if (StringUtils.isEmpty(appsManagerUri)) {
@@ -72,7 +72,7 @@ public class CloudFoundryAccountValidator extends Validator<CloudFoundryAccount>
                     cloudFoundryAccount.getName(),
                     appsManagerUri,
                     metricsUri,
-                    api,
+                    apiHost,
                     user,
                     password,
                     environment


### PR DESCRIPTION
* `--api` -> `--api-host`
* `--appsManagerUri` -> `--apps-manager-uri`
* `--metricsUri` -> `--metrics-uri`
Still supports the original parameter format for backward compatibility.