### PR TITLE
feat(kubernetes): Support cacheThreads and implement allNamespaces

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8311,6 +8311,7 @@ hal config provider kubernetes account add ACCOUNT [parameters]
 
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
+ * `--cache-threads`: (*Default*: `1`) Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. By default, only 1 agent caches all kinds for all namespaces in the account.
  * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
 during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.
  * `--configure-image-pull-secrets`: (*Default*: `true`) (Only applicable to the v1 provider). When true, Spinnaker will create & manage your image pull secrets for you; when false, you will have to create and attach them to your pod specs by hand.
@@ -8378,6 +8379,7 @@ hal config provider kubernetes account edit ACCOUNT [parameters]
  * `--add-write-permission`: Add this permission to the list of write permissions.
  * `--all-kinds`: (*Default*: `false`) Set the list of kinds to cache and deploy to every kind available to your supplied credentials.
  * `--all-namespaces`: (*Default*: `false`) Set the list of namespaces to cache and deploy to every namespace available to your supplied credentials.
+ * `--cache-threads`: Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. By default, only 1 agent caches all kinds for all namespaces in the account.
  * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
 during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.
  * `--clear-context`: (*Default*: `false`) Removes the currently configured context, defaulting to 'current-context' in your kubeconfig.See http://kubernetes.io/docs/user-guide/kubeconfig-file/#context for more information.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -141,6 +141,13 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
   )
   public Boolean liveManifestCalls;
 
+  @Parameter(
+          names = "--cache-threads",
+          arity = 1,
+          description = KubernetesCommandProperties.CACHE_THREADS
+  )
+  private int cacheThreads = 1;
+
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -160,6 +167,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setOnlySpinnakerManaged(onlySpinnakerManaged);
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     account.setLiveManifestCalls(liveManifestCalls);
+    account.setCacheThreads(cacheThreads);
     return account;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -52,5 +52,8 @@ public class KubernetesCommandProperties {
       + "during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.";
 
   static final String LIVE_MANIFEST_CALLS = "When true, clouddriver will query manifest status during pipeline executions using live data rather than the cache.\n"
-      + "This eliminates all time spent in the \"force cache refresh\" task in pipelines, greatly reducing execution time.";
+          + "This eliminates all time spent in the \"force cache refresh\" task in pipelines, greatly reducing execution time.";
+
+  static final String CACHE_THREADS = "Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. " +
+          "By default, only 1 agent caches all kinds for all namespaces in the account.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -234,6 +234,13 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
   )
   public Boolean liveManifestCalls;
 
+  @Parameter(
+          names = "--cache-threads",
+          arity = 1,
+          description = KubernetesCommandProperties.CACHE_THREADS
+  )
+  private Integer cacheThreads;
+
   @Override
   protected Account editAccount(KubernetesAccount account) {
     boolean contextSet = context != null && !context.isEmpty();
@@ -249,11 +256,15 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
     account.setConfigureImagePullSecrets(isSet(configureImagePullSecrets) ? configureImagePullSecrets : account.getConfigureImagePullSecrets());
     account.setServiceAccount(isSet(serviceAccount) ? serviceAccount : account.getServiceAccount());
 
-    try {
-      account.setNamespaces(
-          updateStringList(account.getNamespaces(), namespaces, addNamespace, removeNamespace));
-    } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Set either --namespaces or --[add/remove]-namespace");
+    if (allNamespaces) {
+      account.setNamespaces(new ArrayList<>());
+    } else {
+      try {
+        account.setNamespaces(
+                updateStringList(account.getNamespaces(), namespaces, addNamespace, removeNamespace));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Set either --namespaces or --[add/remove]-namespace");
+      }
     }
 
     try {
@@ -304,6 +315,7 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
     account.setOnlySpinnakerManaged(isSet(onlySpinnakerManaged) ? onlySpinnakerManaged : account.getOnlySpinnakerManaged());
     account.setCheckPermissionsOnStartup(isSet(checkPermissionsOnStartup) ? checkPermissionsOnStartup : account.getCheckPermissionsOnStartup());
     account.setLiveManifestCalls(isSet(liveManifestCalls) ? liveManifestCalls : account.getLiveManifestCalls());
+    account.setCacheThreads(isSet(cacheThreads) ? cacheThreads : account.getCacheThreads());
     return account;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -75,6 +75,7 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
     deploymentConfiguration = (DeploymentConfiguration) parent;
 
     validateKindConfig(psBuilder, account);
+    validateCacheThreads(psBuilder, account);
 
     // TODO(lwander) validate all config with clouddriver's v2 creds
     switch (account.getProviderVersion()) {
@@ -139,6 +140,12 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
       if (onlySpinnakerManaged) {
         psBuilder.addProblem(WARNING, "Kubernetes accounts at V1 does not support configuring caching behavior for a only spinnaker managed resources.");
       }
+    }
+  }
+
+  private void validateCacheThreads(ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
+    if (account.getCacheThreads() < 1) {
+      psBuilder.addProblem(ERROR, "\"cacheThreads\" should be greater or equal to 1.");
     }
   }
 


### PR DESCRIPTION
This exposes `cacheThreads` in the CLI. Also added `allNamespaces` which was not implemented (I took it as clear the namespaces currently whitelisted).