### PR TITLE
fix(ldap): add managerDn and managerPassword to gate's auth configuration

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/LdapConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/LdapConfig.java
@@ -32,6 +32,8 @@ public class LdapConfig {
   String userDnPattern;
   String userSearchBase;
   String userSearchFilter;
+  String managerDn;
+  String managerPassword;
 
   public LdapConfig(Security security) {
     if (!security.getAuthn().getLdap().isEnabled()) {
@@ -45,5 +47,7 @@ public class LdapConfig {
     this.userDnPattern = ldap.getUserDnPattern();
     this.userSearchBase = ldap.getUserSearchBase();
     this.userSearchFilter = ldap.getUserSearchFilter();
+    this.managerDn = ldap.getManagerDn();
+    this.managerPassword = ldap.getManagerPassword();
   }
 }


### PR DESCRIPTION
Is possible to set managerDn and managerPassword for auth using halyard-cli but the values are not reflected in gate.yml