### PR TITLE
fix(cf): All CF account fields now optional on edit

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7152,20 +7152,20 @@ hal config provider cloudfoundry account edit ACCOUNT [parameters]
  * `--add-read-permission`: Add this permission to the list of read permissions.
  * `--add-required-group-membership`: Add this group to the list of required group memberships.
  * `--add-write-permission`: Add this permission to the list of write permissions.
- * `--api-host, --api`: (*Required*) Host of the CloudFoundry Foundation API endpoint ie. `api.sys.somesystem.com`
+ * `--api-host, --api`: Host of the CloudFoundry Foundation API endpoint ie. `api.sys.somesystem.com`
  * `--apps-manager-uri, --appsManagerUri`: Full URI for the Apps Manager application for the CloudFoundry Foundation ie. `https://apps.sys.somesystem.com`
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--metrics-uri, --metricsUri`: Full URI for the metrics application for the CloudFoundry Foundation ie. `https://metrics.sys.somesystem.com`
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--password`: (*Required*) Password for the account to use on for this CloudFoundry Foundation
+ * `--password`: Password for the account to use on for this CloudFoundry Foundation
  * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
  * `--remove-write-permission`: Remove this permission to from list of write permissions.
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
- * `--user`: (*Required*) User name for the account to use on for this CloudFoundry Foundation
+ * `--user`: User name for the account to use on for this CloudFoundry Foundation
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.
 
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudfoundry/CloudFoundryEditAccountCommand.java
@@ -31,7 +31,6 @@ public class CloudFoundryEditAccountCommand extends AbstractEditAccountCommand<C
 
     @Parameter(
             names = {"--api-host", "--api"},
-            required = true,
             description = CloudFoundryCommandProperties.API_HOST_DESCRIPTION
     )
     private String apiHost;
@@ -50,14 +49,12 @@ public class CloudFoundryEditAccountCommand extends AbstractEditAccountCommand<C
 
     @Parameter(
             names = "--password",
-            required = true,
             description = CloudFoundryCommandProperties.PASSWORD_DESCRIPTION
     )
     private String password;
 
     @Parameter(
             names = "--user",
-            required = true,
             description = CloudFoundryCommandProperties.USER_DESCRIPTION
     )
     private String user;


### PR DESCRIPTION
The api-host, user and password fields didn't need to be mandatory.