### PR TITLE
fix(core): Fix halyard cli

### DIFF
--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -34,6 +34,10 @@ dependencies {
   implementation 'org.codehaus.groovy:groovy'
 
   implementation project(':halyard-backup')
+  // halyard-cli is required as a dependency even though it is not used directly by halyard-web
+  // because the halyard installation only install halyard-web but the CLI expects to find the
+  // halyard-cli jar file in the install directory
+  implementation project(':halyard-cli')
   implementation project(':halyard-config')
   implementation project(':halyard-core')
   implementation project(':halyard-deploy')


### PR DESCRIPTION
The boot2 upgrade removed halyard-cli as a dependency of halyard-web. This was reasonable to do, as halyard-web does not directly depend on any functionality of halyard-cli. Unfortunately, the halyard install
process does not separately install halyard-cli; it only installs halyard-web into /opt/halyard but the CLI nonetheless expects to find its jar file there.

This means that currently the halyard-cli won't run when installed using the Halyard installer. While there's almost certainly a better way of implementing this, just re-add the dependency for now to unbreak halyard.