### PR TITLE
fix(deploy): Fix NPE for incorrect file name

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
@@ -484,7 +484,8 @@ public abstract class Node implements Validatable {
                             File parent = newName.toFile().getParentFile();
                             if (!parent.exists()) {
                               parent.mkdirs();
-                            } else if (fFile.getParent().equals(parent.toString())) {
+                            } else if (fFile.getParent() != null
+                                && fFile.getParent().equals(parent.toString())) {
                               // Don't move paths that are already in the right folder
                               return fPath;
                             }


### PR DESCRIPTION
Fixes spinnaker/spinnaker#4499.

If a user's hal config has a file that has no parent directory (which is likely a misconfiguration) we throw an NPE instead of the usual user-facing error that the file doesn't exist.  Protect against the NPE so the usual (and more useful) error message shows up.