### PR TITLE
fix(deps): upgrade fabric8 to 4.1.1 in response to okhttp upgrade to …

### DIFF
--- a/halyard-backup/halyard-backup.gradle
+++ b/halyard-backup/halyard-backup.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io:2.6'
   implementation 'org.apache.commons:commons-compress:1.14'
-  implementation 'io.fabric8:kubernetes-client'
+  implementation 'io.fabric8:kubernetes-client:4.1.1'
   implementation 'org.codehaus.groovy:groovy'
 
   implementation project(':halyard-config')

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -25,7 +25,7 @@ dependencies {
   implementation 'commons-collections:commons-collections:3.2.1'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io:2.6'
-  implementation 'io.fabric8:kubernetes-client'
+  implementation 'io.fabric8:kubernetes-client:4.1.1'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.jcraft:jsch'
 

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -18,7 +18,7 @@ dependencies {
   implementation 'commons-io:commons-io:2.6'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.squareup.okhttp:okhttp'
-  implementation 'io.fabric8:kubernetes-client'
+  implementation 'io.fabric8:kubernetes-client:4.1.1'
   implementation 'io.fabric8:fabric8-utils:2.2.216'
   implementation 'redis.clients:jedis'
   implementation 'org.codehaus.groovy:groovy'


### PR DESCRIPTION
…address connection leaks

- On Monday, Halyard pulled in an updated version of kork, which [updated its okhttp version](https://github.com/spinnaker/kork/pull/317). The new okhttp version throws errors on connection leaks. This caused the nightly integration tests to fail because Halyard's current fabric8 version has issues with connection leaks.
- Upgrades fabric8 library to version 4.1.1, which [addresses connection leaks](https://github.com/fabric8io/kubernetes-client/releases?after=kubernetes-client-1.4.14.redhat-000036).
- To do: upgrade Clouddriver's fabric8 version and address breaking HPA API change for the Kubernetes v1 provider.