### PR TITLE
fix(shutdown): Replace String with StringBodyRequest

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -53,7 +53,7 @@ public class Daemon {
   }
 
   public static String shutdown() {
-    return getService().shutdown("").getOrDefault("message", "");
+    return getService().shutdown(new StringBodyRequest()).getOrDefault("message", "");
   }
 
   public static ShallowTaskList getTasks() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -39,7 +39,7 @@ public interface DaemonService {
   Map<String, String> getHealth();
 
   @POST("/shutdown")
-  Map<String, String> shutdown(@Body String _ignore);
+  Map<String, String> shutdown(@Body StringBodyRequest _ignore);
 
   @GET("/v1/tasks/")
   ShallowTaskList getTasks();


### PR DESCRIPTION
Recent changes broke `shutdown`

```
$ ./hal shutdown
! ERROR 400
? Try the command again with the --debug flag.
```

# With `--debug`
```<--- HTTP 400 http://localhost:8064/shutdown (317ms)
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Pragma: no-cache
Expires: 0
X-Frame-Options: DENY
Content-Type: application/json;charset=UTF-8
Transfer-Encoding: chunked
Date: Wed, 19 Jun 2019 18:19:18 GMT
Connection: close
OkHttp-Sent-Millis: 1560968358743
OkHttp-Received-Millis: 1560968358755

{
  "timestamp" : "2019-06-19T18:19:18.751+0000",
  "status" : 400,
  "error" : "Bad Request",
  "message" : "JSON parse error: Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value (''); nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot construct instance of `java.util.LinkedHashMap` (although at least one Creator exists): no String-argument constructor/factory method to deserialize from String value ('')\n at [Source: (PushbackInputStream); line: 1, column: 1]",
  "path" : "/shutdown"
}
<--- END HTTP (651-byte body)
```