### PR TITLE
fix(config/validation): Moved strict account name validation to docker only

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/AccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/AccountValidator.java
@@ -21,21 +21,15 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
-import java.util.regex.Pattern;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AccountValidator extends Validator<Account> {
-  private static final String namePattern = "^[a-z0-9]+([-a-z0-9]*[a-z0-9])?$";
 
   @Override
   public void validate(ConfigProblemSetBuilder p, Account n) {
     if (n.getName() == null) {
       p.addProblem(Severity.FATAL, "Account name must be specified");
-    } else if (!Pattern.matches(namePattern, n.getName())) {
-      p.addProblem(Severity.ERROR, "Account name must match pattern " + namePattern)
-          .setRemediation(
-              "It must start and end with a lower-case character or number, and only contain lower-case characters, numbers, or dashes");
     }
     if (n.getRequiredGroupMembership() != null && !n.getRequiredGroupMembership().isEmpty()) {
       p.addProblem(

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dockerRegistry/DockerRegistryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dockerRegistry/DockerRegistryAccountValidator.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
 import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
+import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -34,10 +35,17 @@ import org.springframework.stereotype.Component;
 @Component
 @Slf4j
 public class DockerRegistryAccountValidator extends Validator<DockerRegistryAccount> {
+  private static final String namePattern = "^[a-z0-9]+([-a-z0-9]*[a-z0-9])?$";
   @Autowired private SecretSessionManager secretSessionManager;
 
   @Override
   public void validate(ConfigProblemSetBuilder p, DockerRegistryAccount n) {
+    if (!Pattern.matches(namePattern, n.getName())) {
+      p.addProblem(Severity.ERROR, "Account name must match pattern " + namePattern)
+          .setRemediation(
+              "It must start and end with a lower-case character or number, and only contain lower-case characters, numbers, or dashes");
+    }
+
     String resolvedPassword = null;
     String password = n.getPassword();
     String passwordCommand = n.getPasswordCommand();


### PR DESCRIPTION
The regex used to validate the account name was applied to accounts for all providers but this is only a requirement for the docker registry provider accounts.

Every account type other than docker registry (and only when used by a kubeV1 account) have no specific format requirements in clouddriver for the account name, yet the regex was applied to every account type. This was limiting for users naming account with schemes that includes various characters.
