### PR TITLE
fix(core): Re-enable resolvedEnv endpoint

### DIFF
--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'org.lognet:grpc-spring-boot-starter:2.3.2'
   implementation 'org.codehaus.groovy:groovy'
+  implementation "com.netflix.spinnaker.kork:kork-web"
 
   implementation project(':halyard-backup')
   // halyard-cli is required as a dependency even though it is not used directly by halyard-web

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard;
 
+import com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -24,13 +25,12 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 @Configuration
-@ComponentScan(
-    value = {
-      "com.netflix.spinnaker.halyard",
-    })
+@ComponentScan(value = {"com.netflix.spinnaker.halyard", "com.netflix.spinnaker.endpoint"})
 @EnableAutoConfiguration
+@Import(ResolvedEnvironmentConfigurationProperties.class)
 public class Main extends SpringBootServletInitializer {
   private static final Map<String, Object> DEFAULT_PROPS = buildDefaults();
 


### PR DESCRIPTION
The resolvedEnv endpoint was inadvertently disabled as part of the boot2 upgrade because it moved to a package that's not in the classpath scan.  Re-enable it.