### PR TITLE
list pods instead of namespaces during validation

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -272,7 +272,7 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
       try {
         KubernetesClient client = new DefaultKubernetesClient(config);
 
-        client.namespaces().list();
+        client.pods().list();
       } catch (Exception e) {
         ConfigProblemBuilder pb =
             psBuilder.addProblem(

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpReadinessProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpReadinessProbe.yml
@@ -1,7 +1,7 @@
 {
   "httpGet": {
     "port": {{ port }},
-    "path": "{{ path }}"
+    "path": "{{ path }}",
     "scheme": "{{ scheme }}"
   }
 }


### PR DESCRIPTION
In a large org with structured permissions, Kubernetes namespace ops may not be available. This change lists pods during validation instead of namespaces. Since most or all critical Spinnaker ops are within a particular namespace, listing pods should be sufficient validation of the K8 connection. Even if there are no pods, thats OK since the purpose of this method is to ensure no exception is thrown.

### Issue 4582:
https://github.com/spinnaker/spinnaker/issues/4582