### PR TITLE
feat(kubernetes): add opt-in livenessProbe with configurable initialD…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5460,6 +5460,8 @@ This is only required when Spinnaker is being deployed in non-Kubernetes cluster
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--git-origin-user`: This is the git user your github fork exists under.
  * `--git-upstream-user`: This is the upstream git user you are configuring to pull changes from & push PRs to.
+ * `--liveness-probe-enabled`: When true, enable Kubernetes liveness probes on Spinnaker services deployed in a Distributed installation. See docs for more information: [https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
+ * `--liveness-probe-initial-delay-seconds`: The number of seconds to wait before performing the first liveness probe. Should be set to the longest service startup time. See docs for more information: [https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
  * `--location`: This is the location spinnaker will be deployed to. When deploying to Kubernetes, use this flag to specify the namespace to deploy to (defaults to 'spinnaker')
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--type`: Distributed: Deploy Spinnaker with one server group per microservice, and a single shared Redis.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -182,12 +182,12 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
     vault.setEnabled(isSet(vaultEnabled) ? vaultEnabled : vault.isEnabled());
     deploymentEnvironment.setVault(vault);
 
-    livenessProbeConfig.setEnabled(
-        isSet(livenessProbesEnabled) ? livenessProbesEnabled : livenessProbeConfig.isEnabled());
-    livenessProbeConfig.setInitialDelaySeconds(
-        isSet(livenessProbeInitialDelaySeconds)
-            ? livenessProbeInitialDelaySeconds
-            : livenessProbeConfig.getInitialDelaySeconds());
+    if (isSet(livenessProbesEnabled)) {
+      livenessProbeConfig.setEnabled(livenessProbesEnabled);
+    }
+    if (isSet(livenessProbeInitialDelaySeconds)) {
+      livenessProbeConfig.setInitialDelaySeconds(livenessProbeInitialDelaySeconds);
+    }
     deploymentEnvironment.setLivenessProbeConfig(livenessProbeConfig);
 
     deploymentEnvironment.setLocation(

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -114,6 +114,20 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
       description = "This is the git user your github fork exists under.")
   private String gitOriginUser;
 
+  @Parameter(
+      names = "--liveness-probe-enabled",
+      arity = 1,
+      description =
+          "When true, enable Kubernetes liveness probes on Spinnaker services deployed in a Distributed installation. See docs for more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/")
+  private Boolean livenessProbesEnabled;
+
+  @Parameter(
+      names = "--liveness-probe-initial-delay-seconds",
+      arity = 1,
+      description =
+          "The number of seconds to wait before performing the first liveness probe. Should be set to the longest service startup time. See docs for more information: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/")
+  private Integer livenessProbeInitialDelaySeconds;
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -146,6 +160,12 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
       vault = new DeploymentEnvironment.Vault();
     }
 
+    DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
+        deploymentEnvironment.getLivenessProbeConfig();
+    if (livenessProbeConfig == null) {
+      livenessProbeConfig = new DeploymentEnvironment.LivenessProbeConfig();
+    }
+
     deploymentEnvironment.setAccountName(
         isSet(accountName) ? accountName : deploymentEnvironment.getAccountName());
     deploymentEnvironment.setBootstrapOnly(
@@ -161,6 +181,14 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
     vault.setAddress(isSet(vaultAddress) ? vaultAddress : vault.getAddress());
     vault.setEnabled(isSet(vaultEnabled) ? vaultEnabled : vault.isEnabled());
     deploymentEnvironment.setVault(vault);
+
+    livenessProbeConfig.setEnabled(
+        isSet(livenessProbesEnabled) ? livenessProbesEnabled : livenessProbeConfig.isEnabled());
+    livenessProbeConfig.setInitialDelaySeconds(
+        isSet(livenessProbeInitialDelaySeconds)
+            ? livenessProbeInitialDelaySeconds
+            : livenessProbeConfig.getInitialDelaySeconds());
+    deploymentEnvironment.setLivenessProbeConfig(livenessProbeConfig);
 
     deploymentEnvironment.setLocation(
         isSet(location) ? location : deploymentEnvironment.getLocation());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -106,6 +106,7 @@ public class DeploymentEnvironment extends Node {
   private Map<String, AffinityConfig> affinity = new HashMap<>();
   private Map<String, String> nodeSelectors = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
+  private LivenessProbeConfig livenessProbeConfig = new LivenessProbeConfig();
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.10.0",
@@ -133,5 +134,11 @@ public class DeploymentEnvironment extends Node {
   public static class GitConfig {
     String upstreamUser = "spinnaker";
     String originUser;
+  }
+
+  @Data
+  public static class LivenessProbeConfig {
+    boolean enabled;
+    Integer initialDelaySeconds;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentEnvironmentValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/DeploymentEnvironmentValidator.java
@@ -60,6 +60,8 @@ public class DeploymentEnvironmentValidator extends Validator<DeploymentEnvironm
       default:
         throw new RuntimeException("Unknown deployment environment type " + type);
     }
+
+    validateLivenessProbeConfig(p, n);
   }
 
   private void validateGitDeployment(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
@@ -110,6 +112,16 @@ public class DeploymentEnvironmentValidator extends Validator<DeploymentEnvironm
           "Account "
               + accountName
               + " is not in a provider that supports distributed installation of Spinnaker yet");
+    }
+  }
+
+  private void validateLivenessProbeConfig(ConfigProblemSetBuilder p, DeploymentEnvironment n) {
+    if (n.getLivenessProbeConfig() != null && n.getLivenessProbeConfig().isEnabled()) {
+      if (n.getLivenessProbeConfig().getInitialDelaySeconds() == null) {
+        p.addProblem(
+            Problem.Severity.FATAL,
+            "Setting `initialDelaySeconds` is required when enabling liveness probes. Use the --liveness-probe-initial-delay-seconds sub-command to set `initialDelaySeconds`.");
+      }
     }
   }
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/container.yml
@@ -21,7 +21,9 @@
   ],
   {% endif %}
 
-  "readinessProbe": {{ probe }},
+  "readinessProbe": {{ readinessProbe }},
+
+  "livenessProbe": {{ livenessProbe }},
 
   "securityContext": {{ securityContext }},
 

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/execProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/execProbe.yml
@@ -5,5 +5,6 @@
               "{{ token }}"{% if not loop.last %}, {% endif %}
       {% endfor %}
     ]
-  }
+  },
+  "initialDelaySeconds": {{ initialDelaySeconds }}
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
@@ -3,5 +3,6 @@
     "port": {{ port }},
     "path": "{{ path }}",
     "scheme": "{{ scheme }}"
-  }
+  },
+  "initialDelaySeconds": {{ initialDelaySeconds }}
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
@@ -1,0 +1,6 @@
+{
+  "tcpSocket": {
+    "port": {{ port }}
+  },
+  "initialDelaySeconds": {{ initialDelaySeconds }}
+}

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketReadinessProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketReadinessProbe.yml
@@ -1,5 +1,0 @@
-{
-  "tcpSocket": {
-    "port": {{ port }}
-  }
-}


### PR DESCRIPTION
…elaySeconds

Closes https://github.com/spinnaker/spinnaker/issues/4023

- Adds two new sub-commands to the `hal config deploy edit` command, modeled off the code for the `vault` sub-commands : `--liveness-probe-enabled` and `--liveness-probe-initial-delay-seconds`.
- Adds liveness probe configuration to Kubernetes v1 and v2 providers, abstracting logic shared with readiness probes into its own method in each of the three affected classes.
- Adds `initialDelaySeconds` to manifest probe templates, and removes "readiness" from the name of each since these are now reused by liveness probes.