### PR TITLE
feat(core): Support external configuration using Spring Cloud Config

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -4,6 +4,7 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot'
   implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation 'com.netflix.spinnaker.kork:kork-secrets'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.commons:commons-text:1.6'
   implementation 'ch.qos.logback:logback-classic'

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/converter/LocalFileConverter.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/converter/LocalFileConverter.java
@@ -21,14 +21,21 @@ import com.beust.jcommander.IStringConverter;
 import com.netflix.spinnaker.halyard.core.GlobalApplicationOptions;
 import com.netflix.spinnaker.halyard.core.error.v1.HalException;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import java.io.File;
 import java.io.IOException;
 import org.aspectj.util.FileUtil;
 
 public class LocalFileConverter implements IStringConverter<String> {
 
+  private static final String CONFIG_SERVER_PREFIX = "configserver:";
+
   @Override
   public String convert(String value) {
+    if (EncryptedSecret.isEncryptedSecret(value) || isConfigServerResource(value)) {
+      return value;
+    }
+
     if (GlobalApplicationOptions.getInstance().isUseRemoteDaemon()) {
       try {
         return FileUtil.readAsString(new File(value));
@@ -39,5 +46,9 @@ public class LocalFileConverter implements IStringConverter<String> {
       }
     }
     return new File(value).getAbsolutePath();
+  }
+
+  private boolean isConfigServerResource(String value) {
+    return value.startsWith(CONFIG_SERVER_PREFIX);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
@@ -22,8 +22,8 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccoun
 import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
+import com.netflix.spinnaker.halyard.config.model.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Validator.java
@@ -16,18 +16,18 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.model.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public abstract class Validator<T extends Node> {
-  @Autowired SecretSessionManager secretSessionManager;
+  @Autowired protected SecretSessionManager secretSessionManager;
 
   public abstract void validate(ConfigProblemSetBuilder p, T n);
 
-  public String validatingFileDecrypt(ConfigProblemSetBuilder p, String filePath) {
+  protected String validatingFileDecrypt(ConfigProblemSetBuilder p, String filePath) {
     if (EncryptedSecret.isEncryptedSecret(filePath)) {
       return secretSessionManager.decrypt(filePath);
     } else {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
@@ -24,10 +24,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.ConsulConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.consul.SupportsConsul;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.config.validate.v1.util.ValidatingFileReader;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
-import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
@@ -49,20 +46,11 @@ public class GoogleAccount extends CommonGoogleAccount implements Cloneable, Sup
 
   @JsonIgnore
   public GoogleNamedAccountCredentials getNamedAccountCredentials(
-      String version, SecretSessionManager secretSessionManager, ConfigProblemSetBuilder p) {
-    String jsonKey = null;
-    if (!StringUtils.isEmpty(getJsonPath())) {
-      if (secretSessionManager != null && EncryptedSecret.isEncryptedSecret(getJsonPath())) {
-        jsonKey = secretSessionManager.decrypt(getJsonPath());
-      } else {
-        jsonKey = ValidatingFileReader.contents(p, getJsonPath());
-      }
-
-      if (jsonKey == null) {
-        return null;
-      } else if (jsonKey.isEmpty()) {
-        p.addProblem(Problem.Severity.WARNING, "The supplied credentials file is empty.");
-      }
+      String version, String jsonKey, ConfigProblemSetBuilder p) {
+    if (jsonKey == null) {
+      return null;
+    } else if (jsonKey.isEmpty()) {
+      p.addProblem(Problem.Severity.WARNING, "The supplied credentials file is empty.");
     }
 
     if (StringUtils.isEmpty(getProject())) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -16,32 +16,18 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes;
 
-import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.ERROR;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ValidForSpinnakerVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
-import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
-import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
-import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
-import io.fabric8.kubernetes.api.model.Config;
-import io.fabric8.kubernetes.api.model.NamedContext;
-import io.fabric8.kubernetes.client.internal.KubeConfigUtils;
-import java.io.File;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -105,8 +91,6 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
 
   Boolean debug;
 
-  @Autowired private SecretSessionManager secretSessionManager;
-
   public boolean usesServiceAccount() {
     return serviceAccount != null && serviceAccount;
   }
@@ -120,40 +104,6 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
       return System.getProperty("user.home") + "/.kube/config";
     } else {
       return kubeconfigFile;
-    }
-  }
-
-  protected List<String> contextOptions(ConfigProblemSetBuilder psBuilder) {
-    Config kubeconfig;
-    try {
-      if (EncryptedSecret.isEncryptedSecret(getKubeconfigFile())) {
-        kubeconfig =
-            KubeConfigUtils.parseConfigFromString(
-                secretSessionManager.decrypt(getKubeconfigFile()));
-      } else {
-        File kubeconfigFileOpen = new File(getKubeconfigFile());
-        kubeconfig = KubeConfigUtils.parseConfig(kubeconfigFileOpen);
-      }
-    } catch (IOException e) {
-      psBuilder.addProblem(ERROR, e.getMessage());
-      return null;
-    }
-
-    return kubeconfig.getContexts().stream()
-        .map(NamedContext::getName)
-        .collect(Collectors.toList());
-  }
-
-  protected List<String> dockerRegistriesOptions(ConfigProblemSetBuilder psBuilder) {
-    DeploymentConfiguration context = parentOfType(DeploymentConfiguration.class);
-    DockerRegistryProvider dockerRegistryProvider = context.getProviders().getDockerRegistry();
-
-    if (dockerRegistryProvider != null) {
-      return dockerRegistryProvider.getAccounts().stream()
-          .map(Account::getName)
-          .collect(Collectors.toList());
-    } else {
-      return null;
     }
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/util/PropertyUtils.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/util/PropertyUtils.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 Pivotal, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.util;
+
+public class PropertyUtils {
+  private static final String PLACEHOLDER_PATTERN = ".\\{.*}";
+
+  private static final String CONFIG_SERVER_PREFIX = "configserver:";
+
+  public static boolean anyContainPlaceholder(String... fields) {
+    for (String field : fields) {
+      if (field != null && field.matches(PLACEHOLDER_PATTERN)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static boolean isConfigServerResource(String path) {
+    return path != null && path.startsWith(CONFIG_SERVER_PREFIX);
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/CanaryValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/CanaryValidator.java
@@ -29,7 +29,6 @@ import com.netflix.spinnaker.halyard.config.validate.v1.canary.aws.AwsCanaryVali
 import com.netflix.spinnaker.halyard.config.validate.v1.canary.google.GoogleCanaryValidator;
 import com.netflix.spinnaker.halyard.config.validate.v1.canary.prometheus.PrometheusCanaryValidator;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -39,8 +38,6 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class CanaryValidator extends Validator<Canary> {
-
-  @Autowired private SecretSessionManager secretSessionManager;
 
   @Autowired private String halyardVersion;
 
@@ -75,8 +72,7 @@ public class CanaryValidator extends Validator<Canary> {
         GoogleCanaryServiceIntegration googleCanaryServiceIntegration =
             (GoogleCanaryServiceIntegration) s;
 
-        new GoogleCanaryValidator()
-            .setSecretSessionManager(secretSessionManager)
+        new GoogleCanaryValidator(secretSessionManager)
             .setHalyardVersion(halyardVersion)
             .setRegistry(registry)
             .setTaskScheduler(taskScheduler)

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
@@ -35,8 +35,6 @@ import org.springframework.scheduling.TaskScheduler;
 @EqualsAndHashCode(callSuper = false)
 public class GoogleCanaryAccountValidator extends CanaryAccountValidator {
 
-  private SecretSessionManager secretSessionManager;
-
   private String halyardVersion;
 
   private Registry registry;
@@ -49,6 +47,10 @@ public class GoogleCanaryAccountValidator extends CanaryAccountValidator {
   private long retryIntervalBase = 2;
   private long jitterMultiplier = 1000;
   private long maxRetries = 10;
+
+  GoogleCanaryAccountValidator(SecretSessionManager secretSessionManager) {
+    this.secretSessionManager = secretSessionManager;
+  }
 
   @Override
   public void validate(ConfigProblemSetBuilder p, AbstractCanaryAccount n) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryValidator.java
@@ -32,19 +32,20 @@ import org.springframework.util.CollectionUtils;
 
 public class GoogleCanaryValidator extends Validator<GoogleCanaryServiceIntegration> {
 
-  @Setter private SecretSessionManager secretSessionManager;
-
   @Setter private String halyardVersion;
 
   @Setter private Registry registry;
 
   @Setter TaskScheduler taskScheduler;
 
+  public GoogleCanaryValidator(SecretSessionManager secretSessionManager) {
+    this.secretSessionManager = secretSessionManager;
+  }
+
   @Override
   public void validate(ConfigProblemSetBuilder p, GoogleCanaryServiceIntegration n) {
     GoogleCanaryAccountValidator googleCanaryAccountValidator =
-        new GoogleCanaryAccountValidator()
-            .setSecretSessionManager(secretSessionManager)
+        new GoogleCanaryAccountValidator(secretSessionManager)
             .setHalyardVersion(halyardVersion)
             .setRegistry(registry)
             .setTaskScheduler(taskScheduler);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/prometheus/PrometheusCanaryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/prometheus/PrometheusCanaryAccountValidator.java
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.halyard.config.validate.v1.canary.prometheus;
 
 import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.ERROR;
 
-import com.google.common.base.Strings;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.prometheus.PrometheusCanaryAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
@@ -55,7 +54,7 @@ public class PrometheusCanaryAccountValidator extends CanaryAccountValidator {
     if (StringUtils.isNotEmpty(usernamePasswordFile)) {
       String usernamePassword = validatingFileDecrypt(p, usernamePasswordFile);
 
-      if (Strings.isNullOrEmpty(usernamePassword)) {
+      if (usernamePassword != null && StringUtils.isEmpty(usernamePassword)) {
         p.addProblem(ERROR, "The supplied username password file does not exist or is empty.")
             .setRemediation("Supply a valid username password file.");
       } else if (!usernamePassword.contains(":")) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/prometheus/PrometheusCanaryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/prometheus/PrometheusCanaryAccountValidator.java
@@ -54,7 +54,7 @@ public class PrometheusCanaryAccountValidator extends CanaryAccountValidator {
     if (StringUtils.isNotEmpty(usernamePasswordFile)) {
       String usernamePassword = validatingFileDecrypt(p, usernamePasswordFile);
 
-      if (usernamePassword != null && StringUtils.isEmpty(usernamePassword)) {
+      if (StringUtils.isEmpty(usernamePassword)) {
         p.addProblem(ERROR, "The supplied username password file does not exist or is empty.")
             .setRemediation("Supply a valid username password file.");
       } else if (!usernamePassword.contains(":")) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/AzsValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/AzsValidator.java
@@ -22,14 +22,10 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.AzsPersistentStore;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AzsValidator extends Validator<AzsPersistentStore> {
-  @Autowired private SecretSessionManager secretSessionManager;
-
   @Override
   public void validate(ConfigProblemSetBuilder ps, AzsPersistentStore n) {
     String connectionString =

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/GCSValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/GCSValidator.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.GcsPersis
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.stereotype.Component;
@@ -34,8 +33,6 @@ public class GCSValidator extends Validator<GcsPersistentStore> {
   @Autowired private AccountService accountService;
 
   @Autowired private Registry registry;
-
-  @Autowired private SecretSessionManager secretSessionManager;
 
   @Autowired TaskScheduler taskScheduler;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/S3Validator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/S3Validator.java
@@ -25,15 +25,11 @@ import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.S3Persist
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.config.validate.v1.providers.aws.AwsAccountValidator;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class S3Validator extends Validator<S3PersistentStore> {
-  @Autowired private SecretSessionManager secretSessionManager;
-
   @Override
   public void validate(ConfigProblemSetBuilder ps, S3PersistentStore n) {
     if (!StringUtils.isEmpty(n.getEndpoint())) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/appengine/AppengineAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/appengine/AppengineAccountValidator.java
@@ -25,15 +25,12 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.appengine.AppengineAccount;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class AppengineAccountValidator extends Validator<AppengineAccount> {
   @Autowired String halyardVersion;
-
-  @Autowired private SecretSessionManager secretSessionManager;
 
   @Override
   public void validate(ConfigProblemSetBuilder p, AppengineAccount account) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureAccountValidator.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import org.springframework.beans.factory.annotation.Autowired;
 
 @EqualsAndHashCode(callSuper = false)
 @Data
@@ -37,7 +36,14 @@ public class AzureAccountValidator extends Validator<AzureAccount> {
 
   private final String halyardVersion;
 
-  @Autowired private SecretSessionManager secretSessionManager;
+  public AzureAccountValidator(
+      List<AzureCredentials> credentialsList,
+      String halyardVersion,
+      SecretSessionManager secretSessionManager) {
+    this.credentialsList = credentialsList;
+    this.halyardVersion = halyardVersion;
+    this.secretSessionManager = secretSessionManager;
+  }
 
   @Override
   public void validate(ConfigProblemSetBuilder p, AzureAccount n) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureProviderValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureProviderValidator.java
@@ -34,7 +34,7 @@ public class AzureProviderValidator extends Validator<AzureProvider> {
     List<AzureCredentials> credentialsList = new ArrayList<>();
 
     AzureAccountValidator azureAccountValidator =
-        new AzureAccountValidator(credentialsList, halyardVersion);
+        new AzureAccountValidator(credentialsList, halyardVersion, secretSessionManager);
 
     n.getAccounts().forEach(account -> azureAccountValidator.validate(p, account));
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/cloudfoundry/CloudFoundryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/cloudfoundry/CloudFoundryAccountValidator.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.config.validate.v1.providers.cloudfoundry;
 import com.netflix.spinnaker.clouddriver.cloudfoundry.security.CloudFoundryCredentials;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudfoundry.CloudFoundryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.util.PropertyUtils;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
@@ -60,13 +61,13 @@ public class CloudFoundryAccountValidator extends Validator<CloudFoundryAccount>
 
     if (StringUtils.isEmpty(apiHost)) {
       problemSetBuilder.addProblem(
-          Problem.Severity.ERROR, "You must provide a CF api endpoint host");
+          Problem.Severity.ERROR, "You must provide a CF API endpoint host");
     }
 
     if (appsManagerUrl == null) {
       problemSetBuilder.addProblem(
           Problem.Severity.WARNING,
-          "To be able to link server groups to CF Appsmanager a URL is required: " + accountName);
+          "To be able to link server groups to CF Apps Manager a URI is required");
     } else if (!isHttp(appsManagerUrl.getProtocol())) {
       problemSetBuilder.addProblem(
           Severity.ERROR,
@@ -76,7 +77,7 @@ public class CloudFoundryAccountValidator extends Validator<CloudFoundryAccount>
     if (metricsUrl == null) {
       problemSetBuilder.addProblem(
           Problem.Severity.WARNING,
-          "To be able to link server groups to CF Metrics a URL is required: " + accountName);
+          "To be able to link server groups to CF Metrics a URL is required");
     } else if (!isHttp(metricsUrl.getProtocol())) {
       problemSetBuilder.addProblem(
           Severity.ERROR, "Metrics URL scheme must be HTTP or HTTPS for account: " + accountName);
@@ -85,8 +86,14 @@ public class CloudFoundryAccountValidator extends Validator<CloudFoundryAccount>
     if (skipSslValidation) {
       problemSetBuilder.addProblem(
           Problem.Severity.WARNING,
-          "SKIPPING SSL server certificate validation of the CloudFoundry API endpoint for account: "
-              + accountName);
+          "SKIPPING SSL server certificate validation of the Cloud Foundry API endpoint");
+    }
+
+    if (PropertyUtils.anyContainPlaceholder(apiHost, user, password)) {
+      problemSetBuilder.addProblem(
+          Problem.Severity.WARNING,
+          "Skipping connection validation because one or more credential contains a placeholder value");
+      return;
     }
 
     CloudFoundryCredentials cloudFoundryCredentials =

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSAccountValidator.java
@@ -13,18 +13,14 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.Docker
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSCluster;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 /** TODO: use clouddriver components for full validation (e.g. account name)) */
 @Component
 public class DCOSAccountValidator extends Validator<DCOSAccount> {
-  @Autowired private SecretSessionManager secretSessionManager;
-
   @Override
   public void validate(final ConfigProblemSetBuilder problems, final DCOSAccount account) {
     DeploymentConfiguration deploymentConfiguration;
@@ -124,6 +120,9 @@ public class DCOSAccountValidator extends Validator<DCOSAccount> {
 
               if (StringUtils.isNotEmpty(c.getServiceKeyFile())) {
                 String resolvedServiceKey = validatingFileDecrypt(problems, c.getServiceKeyFile());
+                if (resolvedServiceKey == null) {
+                  return;
+                }
 
                 if (StringUtils.isEmpty(resolvedServiceKey)) {
                   problems

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSClusterValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSClusterValidator.java
@@ -7,15 +7,12 @@ import com.google.common.base.Strings;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSCluster;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
 
 /** TODO: use clouddriver components for full validation */
 @Component
 public class DCOSClusterValidator extends Validator<DCOSCluster> {
-  @Autowired private SecretSessionManager secretSessionManager;
-
   @Override
   public void validate(final ConfigProblemSetBuilder problems, final DCOSCluster cluster) {
 
@@ -27,7 +24,10 @@ public class DCOSClusterValidator extends Validator<DCOSCluster> {
 
     if (!Strings.isNullOrEmpty(cluster.getCaCertFile())) {
       String resolvedServiceKey = validatingFileDecrypt(problems, cluster.getCaCertFile());
-      if (Strings.isNullOrEmpty(resolvedServiceKey)) {
+      if (resolvedServiceKey == null) {
+        return;
+      }
+      if (StringUtils.isEmpty(resolvedServiceKey)) {
         problems
             .addProblem(ERROR, "The supplied CA certificate file does not exist or is empty.")
             .setRemediation("Supply a valid CA certificate file.");

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSClusterValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/dcos/DCOSClusterValidator.java
@@ -7,7 +7,7 @@ import com.google.common.base.Strings;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSCluster;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 
 /** TODO: use clouddriver components for full validation */

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/google/GoogleProviderValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/google/GoogleProviderValidator.java
@@ -20,7 +20,6 @@ import com.netflix.spinnaker.clouddriver.google.security.GoogleNamedAccountCrede
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleProvider;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import java.util.ArrayList;
 import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,8 +28,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class GoogleProviderValidator extends Validator<GoogleProvider> {
   @Autowired private String halyardVersion;
-
-  @Autowired private SecretSessionManager secretSessionManager;
 
   @Override
   public void validate(ConfigProblemSetBuilder p, GoogleProvider n) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
@@ -20,13 +20,9 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Saml;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
-import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.security.KeyStore;
 import java.util.Collections;
@@ -34,13 +30,10 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SamlValidator extends Validator<Saml> {
-  @Autowired private SecretSessionManager secretSessionManager;
-
   @Override
   public void validate(ConfigProblemSetBuilder p, Saml saml) {
     if (!saml.isEnabled()) {
@@ -85,38 +78,26 @@ public class SamlValidator extends Validator<Saml> {
       p.addProblem(Problem.Severity.ERROR, "No keystore alias specified.");
     }
 
-    InputStream is = null;
     try {
-      if (EncryptedSecret.isEncryptedSecret(saml.getKeyStore())) {
-        is = new ByteArrayInputStream(secretSessionManager.decrypt(saml.getKeyStore()).getBytes());
-      } else {
-        File f = new File(new URI("file:" + saml.getKeyStore()));
-        is = new FileInputStream(f);
+      String keyStore = validatingFileDecrypt(p, saml.getKeyStore());
+      if (keyStore != null) {
+        val keystore = KeyStore.getInstance(KeyStore.getDefaultType());
+
+        // will throw an exception if `keyStorePassword` is invalid
+        keystore.load(
+            new ByteArrayInputStream(keyStore.getBytes()),
+            secretSessionManager.decrypt(saml.getKeyStorePassword()).toCharArray());
+
+        Collections.list(keystore.aliases()).stream()
+            .filter(alias -> alias.equalsIgnoreCase(saml.getKeyStoreAliasName()))
+            .findFirst()
+            .orElseThrow(
+                () ->
+                    new RuntimeException(
+                        "Keystore does not contain alias " + saml.getKeyStoreAliasName()));
       }
-
-      val keystore = KeyStore.getInstance(KeyStore.getDefaultType());
-
-      // will throw an exception if `keyStorePassword` is invalid
-      keystore.load(is, secretSessionManager.decrypt(saml.getKeyStorePassword()).toCharArray());
-
-      Collections.list(keystore.aliases()).stream()
-          .filter(alias -> alias.equalsIgnoreCase(saml.getKeyStoreAliasName()))
-          .findFirst()
-          .orElseThrow(
-              () ->
-                  new RuntimeException(
-                      "Keystore does not contain alias " + saml.getKeyStoreAliasName()));
-
     } catch (Exception e) {
       p.addProblem(Problem.Severity.ERROR, "Keystore validation problem: " + e.getMessage());
-    } finally {
-      if (is != null) {
-        try {
-          is.close();
-        } catch (Exception e) {
-          // ignored.
-        }
-      }
     }
 
     if (saml.getServiceAddress() == null) {

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -8,7 +8,8 @@ dependencies {
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-security:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.kork:kork-secrets:${korkVersion}"
+  implementation "com.netflix.spinnaker.kork:kork-secrets"
+  implementation "com.netflix.spinnaker.kork:kork-config"
   implementation 'com.netflix.frigga:frigga'
   implementation 'com.google.apis:google-api-services-storage'
   implementation 'com.google.apis:google-api-services-compute'

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation 'org.lognet:grpc-spring-boot-starter:2.3.2'
   implementation 'org.codehaus.groovy:groovy'
   implementation "com.netflix.spinnaker.kork:kork-web"
+  implementation "com.netflix.spinnaker.kork:kork-config"
 
   implementation project(':halyard-backup')
   // halyard-cli is required as a dependency even though it is not used directly by halyard-web

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
@@ -17,12 +17,13 @@
 package com.netflix.spinnaker.halyard;
 
 import com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties;
-import java.util.Collections;
-import java.util.HashMap;
+import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder;
+import com.netflix.spinnaker.kork.configserver.ConfigServerBootstrap;
 import java.util.Map;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
+import org.springframework.cloud.config.server.EnableConfigServer;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
@@ -31,22 +32,12 @@ import org.springframework.context.annotation.Import;
 @ComponentScan(value = {"com.netflix.spinnaker.halyard", "com.netflix.spinnaker.endpoint"})
 @EnableAutoConfiguration
 @Import(ResolvedEnvironmentConfigurationProperties.class)
+@EnableConfigServer
 public class Main extends SpringBootServletInitializer {
-  private static final Map<String, Object> DEFAULT_PROPS = buildDefaults();
-
-  private static Map<String, Object> buildDefaults() {
-    Map<String, String> defaults = new HashMap<>();
-    defaults.put("netflix.environment", "test");
-    defaults.put("netflix.account", "${netflix.environment}");
-    defaults.put("netflix.stack", "test");
-    defaults.put("spring.config.node", "${user.home}/.spinnaker/");
-    defaults.put("spring.application.name", "halyard");
-    defaults.put("spring.config.name", "${spring.application.name}");
-    defaults.put("spring.profiles.active", "${netflix.environment},local");
-    return Collections.unmodifiableMap(defaults);
-  }
+  private static final Map<String, Object> DEFAULT_PROPS = new DefaultPropertiesBuilder().build();
 
   public static void main(String... args) {
+    ConfigServerBootstrap.systemProperties("halyard");
     new SpringApplicationBuilder().properties(DEFAULT_PROPS).sources(Main.class).run(args);
   }
 


### PR DESCRIPTION
This PR adds the following features related to external configuration using Spring Cloud Config Server (see the [Spinnaker Config Secrets design doc](https://docs.google.com/document/d/1Y7SIgobc8_CCFmFZLRUGl-76sfHWlprFYGy992S5U4A/edit#heading=h.x4tnoxo2zzyn))

* When the CLI detects that an account configuration file contains the prefix `configserver:`, it doesn't convert to an absolute local path
* On validation, if a field that is required for live validation of a connection to an account contains a property placeholder (e.g. `${some.value}`) that should be resolved via Config Server at service runtime, then live account validation is bypassed
* On validation, if a field that is used as an account configuration file contains the prefix `configserver:`, then the contents of the file is not validated and live account validation is bypassed
* On deployment, if the default kubernetes account used for deployment is configured with a `kubeconfigFile` containing the prefix `configserver:`, then the contents of the file will be retrieved from a config server backend and used for the deployment

This PR contains the following related refactorings: 
* `Validator` subclasses all use the `SecretSessionManager` that already existed in the base class instead of defining their own `SecretSessionManager`
* All attempts to load account configuration files use `ValidatingFileReader` (via `Validator#validatingFileDecrypt` where possible)
* `ValidatingFileReader` was moved to eliminate a package cycle