### PR TITLE
fix(deploy/deck): Port conflict in ports.conf

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePortsProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePortsProfileFactory.java
@@ -35,12 +35,7 @@ public class ApachePortsProfileFactory extends TemplateBackedProfileFactory {
           "Listen {%deck-host%}:{%deck-port%}",
           "",
           "<IfModule ssl_module>",
-          "  Listen 443",
           "  SSLPassPhraseDialog exec:/etc/apache2/passphrase",
-          "</IfModule>",
-          "",
-          "<IfModule mod_gnutls.c>",
-          "  Listen 443",
           "</IfModule>");
 
   @Override


### PR DESCRIPTION
The Deck pod was failing to start after a recent apache2 version bump in the image(2.4.25 to 2.4.38): `(98)Address already in use: AH00072: make_sock: could not bind to address 0.0.0.0:9000`
Happening only when SSL was enabled.
Starting from apache2 2.4.28, having multiple `Listen` directive listening to the same socket is forbidden:
- https://svn.apache.org/repos/asf/httpd/httpd/branches/2.4.x/CHANGES
- https://httpd.apache.org/docs/2.4/mod/mpm_common.html#listen
In this case, no need for multiple Listen directive as we always listen on the same one socket whether SSL is enabled or not.