### PR TITLE
fix(config): parse 'oauthScopes' stanzas that were incorrectly written

### DIFF
--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -32,6 +32,9 @@ dependencies {
 //  TODO: add clouddriverDCOS once that's merged
   implementation project(':halyard-core')
 
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testImplementation 'org.junit.platform:junit-platform-runner'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
   testImplementation 'org.springframework:spring-test'
   testImplementation 'org.codehaus.groovy:groovy'

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
@@ -83,12 +83,8 @@ public class HalconfigParser {
    * @see Halconfig
    */
   Halconfig parseHalconfig(InputStream is) throws IllegalArgumentException {
-    try {
-      Object obj = yamlParser.load(is);
-      return objectMapper.convertValue(obj, Halconfig.class);
-    } catch (IllegalArgumentException e) {
-      throw e;
-    }
+    Object obj = yamlParser.load(is);
+    return objectMapper.convertValue(obj, Halconfig.class);
   }
 
   /**

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/StrictObjectMapper.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/StrictObjectMapper.java
@@ -23,7 +23,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class StrictObjectMapper extends ObjectMapper {
-  StrictObjectMapper() {
+  public StrictObjectMapper() {
     super();
     this.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
     this.setSerializationInclusion(JsonInclude.Include.NON_NULL);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -140,4 +140,41 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
     String kubernetesKind;
     int maxEntriesPerAgent;
   }
+
+  // These six methods exist for backwards compatibility. Versions of Halyard prior to 1.22 would
+  // write this field out twice: to 'oAuthScopes' and to 'oauthScopes'. Whichever came last in the
+  // file would end up taking precedence. These methods replicate that behavior during parsing, but
+  // will only write out 'oAuthScopes' during serialization. They can be deleted after a few months
+  // (at which point Lombok will generate the first four automatically). If you're reading this in
+  // 2020 or later, you can definitely delete these (and also: whoah, the future is probably so fun,
+  // how are those flying cars working out?)
+  @JsonProperty("oAuthScopes")
+  public List<String> getOAuthScopes() {
+    return oAuthScopes;
+  }
+
+  @JsonProperty("oAuthScopes")
+  public void setOAuthScopes(List<String> oAuthScopes) {
+    this.oAuthScopes = oAuthScopes;
+  }
+
+  @JsonProperty("oAuthServiceAccount")
+  public String getOAuthServiceAccount() {
+    return oAuthServiceAccount;
+  }
+
+  @JsonProperty("oAuthServiceAccount")
+  public void setOAuthServiceAccount(String oAuthServiceAccount) {
+    this.oAuthServiceAccount = oAuthServiceAccount;
+  }
+
+  @JsonProperty("oauthScopes")
+  public void setOauthScopes(List<String> oAuthScopes) {
+    this.oAuthScopes = oAuthScopes;
+  }
+
+  @JsonProperty("oauthServiceAccount")
+  public void setOauthServiceAccount(String oAuthServiceAccount) {
+    this.oAuthServiceAccount = oAuthServiceAccount;
+  }
 }

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/NodeSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/NodeSpec.groovy
@@ -18,7 +18,6 @@ package com.netflix.spinnaker.halyard.config.model.v1
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.*
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder
-import junit.framework.Test
 import spock.lang.Specification
 
 class NodeSpec extends Specification {

--- a/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
+++ b/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 Google, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes;
 
 import static org.assertj.core.api.Assertions.assertThat;

--- a/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
+++ b/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
@@ -1,0 +1,97 @@
+package com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.halyard.config.config.v1.StrictObjectMapper;
+import java.io.IOException;
+import java.io.StringWriter;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+import org.yaml.snakeyaml.Yaml;
+
+@RunWith(JUnitPlatform.class)
+final class KubernetesAccountTest {
+
+  @Test
+  void testLastOAuthScopeIsKept_capitalA() {
+    Yaml yamlParser = new Yaml();
+    Object parsedYaml =
+        yamlParser.load(
+            Joiner.on('\n')
+                .join(
+                    "oauthScopes: [\"lowercase-a\"]", //
+                    "oAuthScopes: [\"uppercase-a\"]"));
+    KubernetesAccount account =
+        new StrictObjectMapper().convertValue(parsedYaml, KubernetesAccount.class);
+
+    assertThat(account.getOAuthScopes()).containsExactly("uppercase-a");
+  }
+
+  @Test
+  void testLastOAuthScopeIsKept_lowercaseA() {
+    Yaml yamlParser = new Yaml();
+    Object parsedYaml =
+        yamlParser.load(
+            Joiner.on('\n')
+                .join(
+                    "oAuthScopes: [\"uppercase-a\"]", //
+                    "oauthScopes: [\"lowercase-a\"]"));
+    KubernetesAccount account =
+        new StrictObjectMapper().convertValue(parsedYaml, KubernetesAccount.class);
+
+    assertThat(account.getOAuthScopes()).containsExactly("lowercase-a");
+  }
+
+  @Test
+  void testLastOAuthServiceAccountIsKept_capitalA() {
+    Yaml yamlParser = new Yaml();
+    Object parsedYaml =
+        yamlParser.load(
+            Joiner.on('\n')
+                .join(
+                    "oauthServiceAccount: \"lowercase-a\"", //
+                    "oAuthServiceAccount: \"uppercase-a\""));
+    KubernetesAccount account =
+        new StrictObjectMapper().convertValue(parsedYaml, KubernetesAccount.class);
+
+    assertThat(account.getOAuthServiceAccount()).isEqualTo("uppercase-a");
+  }
+
+  @Test
+  void testLastOAuthServiceAccountIsKept_lowercaseA() {
+    Yaml yamlParser = new Yaml();
+    Object parsedYaml =
+        yamlParser.load(
+            Joiner.on('\n')
+                .join(
+                    "oAuthServiceAccount: \"uppercase-a\"", //
+                    "oauthServiceAccount: \"lowercase-a\""));
+    KubernetesAccount account =
+        new StrictObjectMapper().convertValue(parsedYaml, KubernetesAccount.class);
+
+    assertThat(account.getOAuthServiceAccount()).isEqualTo("lowercase-a");
+  }
+
+  @Test
+  void testOnlyCapitalAIsWritten() throws IOException {
+    KubernetesAccount account = new KubernetesAccount();
+    account.setOAuthScopes(ImmutableList.of("my-scope"));
+    account.setOAuthServiceAccount("my-service-account");
+
+    String result = getYaml(account);
+
+    assertThat(result).contains("oAuthScopes");
+    assertThat(result).doesNotContain("oauthScopes");
+    assertThat(result).contains("oAuthServiceAccount");
+    assertThat(result).doesNotContain("oauthServiceAccount");
+  }
+
+  private static String getYaml(KubernetesAccount account) throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    new StrictObjectMapper().writeValue(stringWriter, account);
+    return stringWriter.toString();
+  }
+}


### PR DESCRIPTION
The old version of Lombok used in Halyard <=1.21 didn't copy
@JsonProperty annotations to the generated methods. This means Jackson
was seeing the field as 'oAuthScopes' and the getter/setter as a
separate 'oauthScopes' property. The same data would be written to both
properties, and during parsing whichever came last in the file would be
persisted into the object.

With new versions of Lombok (>=1.18.8), the @JsonProperty annotation is
copied to the bean methods, so the 'oauthScopes' property disappears and
Jackson can no longer parse those old files.

This commit adds some methods to support parsing the files generated by
previous versions of Halyard, but will no longer write out the
incorrect duplicate data.