### PR TITLE
feat(secret): decrypt secrets before sending to deck

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/secrets/BindingsSecretDecrypter.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/secrets/BindingsSecretDecrypter.java
@@ -1,0 +1,40 @@
+package com.netflix.spinnaker.halyard.deploy.config.v1.secrets;
+
+import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.apache.commons.lang3.RandomStringUtils;
+
+public class BindingsSecretDecrypter {
+  protected Profile profile;
+  protected Path decryptedOutputDirectory;
+  protected SecretSessionManager secretSessionManager;
+
+  public BindingsSecretDecrypter(
+      SecretSessionManager secretSessionManager, Profile profile, Path decryptedOutputDirectory) {
+    super();
+    this.secretSessionManager = secretSessionManager;
+    this.profile = profile;
+    this.decryptedOutputDirectory = decryptedOutputDirectory;
+  }
+
+  public String trackSecretFile(String value, String fieldName) {
+    if (EncryptedSecret.isEncryptedSecret(value)) {
+      String name = newRandomFilePath(fieldName);
+      byte[] bytes = secretSessionManager.decryptAsBytes(value);
+      profile.getDecryptedFiles().put(name, bytes);
+      value = getCompleteFilePath(name);
+    }
+    return value;
+  }
+
+  protected String newRandomFilePath(String fieldName) {
+    return fieldName + "-" + RandomStringUtils.randomAlphanumeric(5);
+  }
+
+  protected String getCompleteFilePath(String filename) {
+    return Paths.get(decryptedOutputDirectory.toString(), filename).toString();
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/secrets/BindingsSecretDecrypter.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/config/v1/secrets/BindingsSecretDecrypter.java
@@ -4,37 +4,29 @@ import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
 
+@Component
 public class BindingsSecretDecrypter {
-  protected Profile profile;
-  protected Path decryptedOutputDirectory;
-  protected SecretSessionManager secretSessionManager;
+  private SecretSessionManager secretSessionManager;
 
-  public BindingsSecretDecrypter(
-      SecretSessionManager secretSessionManager, Profile profile, Path decryptedOutputDirectory) {
-    super();
+  @Autowired
+  BindingsSecretDecrypter(SecretSessionManager secretSessionManager) {
     this.secretSessionManager = secretSessionManager;
-    this.profile = profile;
-    this.decryptedOutputDirectory = decryptedOutputDirectory;
   }
 
-  public String trackSecretFile(String value, String fieldName) {
-    if (EncryptedSecret.isEncryptedSecret(value)) {
-      String name = newRandomFilePath(fieldName);
-      byte[] bytes = secretSessionManager.decryptAsBytes(value);
-      profile.getDecryptedFiles().put(name, bytes);
-      value = getCompleteFilePath(name);
+  public String trackSecretFile(Profile profile, Path outputDir, String value, String fieldName) {
+    if (!EncryptedSecret.isEncryptedSecret(value)) {
+      return value;
     }
-    return value;
+    String decryptedFilename = newRandomFileName(fieldName);
+    profile.getDecryptedFiles().put(decryptedFilename, secretSessionManager.decryptAsBytes(value));
+    return outputDir.resolve(decryptedFilename).toString();
   }
 
-  protected String newRandomFilePath(String fieldName) {
+  private String newRandomFileName(String fieldName) {
     return fieldName + "-" + RandomStringUtils.randomAlphanumeric(5);
-  }
-
-  protected String getCompleteFilePath(String filename) {
-    return Paths.get(decryptedOutputDirectory.toString(), filename).toString();
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/AwsCredentialsProfileFactoryBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/AwsCredentialsProfileFactoryBuilder.java
@@ -83,7 +83,9 @@ public class AwsCredentialsProfileFactoryBuilder {
 
     @Override
     protected Map<String, Object> getBindings(
-        DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+        DeploymentConfiguration deploymentConfiguration,
+        Profile profile,
+        SpinnakerRuntimeSettings endpoints) {
       Map<String, Object> result = new HashMap<>();
       result.put("accessKeyId", accessKeyId);
       result.put(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/ProfileFactory.java
@@ -50,6 +50,9 @@ public abstract class ProfileFactory {
    * @return true if the target service supports decryption of secrets
    */
   protected boolean supportsSecretDecryption(String deploymentName) {
+    if (getArtifact().equals(SpinnakerArtifact.DECK)) {
+      return false;
+    }
     String minVersion = getMinimumSecretDecryptionVersion(deploymentName);
     if (minVersion == null) {
       return false;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/TemplateBackedProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/TemplateBackedProfileFactory.java
@@ -28,7 +28,9 @@ public abstract class TemplateBackedProfileFactory extends ProfileFactory {
   protected abstract String getTemplate();
 
   protected abstract Map<String, Object> getBindings(
-      DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints);
+      DeploymentConfiguration deploymentConfiguration,
+      Profile profile,
+      SpinnakerRuntimeSettings endpoints);
 
   protected List<String> requiredFiles(DeploymentConfiguration deploymentConfiguration) {
     return new ArrayList<>();
@@ -46,7 +48,7 @@ public abstract class TemplateBackedProfileFactory extends ProfileFactory {
       SpinnakerRuntimeSettings endpoints) {
     StringResource template = new StringResource(profile.getBaseContents());
     profile.setRequiredFiles(requiredFiles(deploymentConfiguration));
-    Map<String, Object> bindings = getBindings(deploymentConfiguration, endpoints);
+    Map<String, Object> bindings = getBindings(deploymentConfiguration, profile, endpoints);
     profile.setContents(template.setBindings(bindings).toString());
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/consul/ConsulClientProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/consul/ConsulClientProfileFactory.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.consul;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.TemplateBackedProfileFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService.Type;
@@ -51,7 +52,9 @@ public class ConsulClientProfileFactory extends TemplateBackedProfileFactory {
 
   @Override
   protected Map<String, Object> getBindings(
-      DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+      DeploymentConfiguration deploymentConfiguration,
+      Profile profile,
+      SpinnakerRuntimeSettings endpoints) {
     Map<String, Object> bindings = new HashMap<>();
     ServiceSettings consul = endpoints.getServiceSettings(Type.CONSUL_CLIENT);
     bindings.put("scheme", consul.getScheme());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePassphraseProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePassphraseProfileFactory.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.TemplateBackedProfileFactory;
+import com.netflix.spinnaker.kork.secrets.EncryptedSecret;
 import java.util.HashMap;
 import java.util.Map;
 import org.springframework.stereotype.Component;
@@ -52,10 +53,16 @@ public class ApachePassphraseProfileFactory extends TemplateBackedProfileFactory
 
   @Override
   protected Map<String, Object> getBindings(
-      DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+      DeploymentConfiguration deploymentConfiguration,
+      Profile profile,
+      SpinnakerRuntimeSettings endpoints) {
     Map<String, Object> bindings = new HashMap<>();
     ApacheSsl ssl = deploymentConfiguration.getSecurity().getUiSecurity().getSsl();
-    bindings.put("passphrase", ssl.getSslCertificatePassphrase());
+    if (EncryptedSecret.isEncryptedSecret(ssl.getSslCertificatePassphrase())) {
+      bindings.put("passphrase", secretSessionManager.decrypt(ssl.getSslCertificatePassphrase()));
+    } else {
+      bindings.put("passphrase", ssl.getSslCertificatePassphrase());
+    }
     return bindings;
   }
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePassphraseProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePassphraseProfileFactory.java
@@ -58,7 +58,8 @@ public class ApachePassphraseProfileFactory extends TemplateBackedProfileFactory
       SpinnakerRuntimeSettings endpoints) {
     Map<String, Object> bindings = new HashMap<>();
     ApacheSsl ssl = deploymentConfiguration.getSecurity().getUiSecurity().getSsl();
-    if (EncryptedSecret.isEncryptedSecret(ssl.getSslCertificatePassphrase())) {
+    if (EncryptedSecret.isEncryptedSecret(ssl.getSslCertificatePassphrase())
+        && !supportsSecretDecryption(deploymentConfiguration.getName())) {
       bindings.put("passphrase", secretSessionManager.decrypt(ssl.getSslCertificatePassphrase()));
     } else {
       bindings.put("passphrase", ssl.getSslCertificatePassphrase());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePortsProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/ApachePortsProfileFactory.java
@@ -54,7 +54,9 @@ public class ApachePortsProfileFactory extends TemplateBackedProfileFactory {
 
   @Override
   protected Map<String, Object> getBindings(
-      DeploymentConfiguration deploymentConfiguration, SpinnakerRuntimeSettings endpoints) {
+      DeploymentConfiguration deploymentConfiguration,
+      Profile profile,
+      SpinnakerRuntimeSettings endpoints) {
     Map<String, Object> bindings = new HashMap<>();
     bindings.put("deck-host", endpoints.getServiceSettings(Type.DECK).getHost());
     bindings.put("deck-port", endpoints.getServiceSettings(Type.DECK).getPort() + "");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckDockerProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckDockerProfileFactory.java
@@ -20,6 +20,7 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.deck;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.security.ApacheSsl;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
+import com.netflix.spinnaker.halyard.deploy.config.v1.secrets.BindingsSecretDecrypter;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
@@ -56,12 +57,22 @@ public class DeckDockerProfileFactory extends DeckProfileFactory {
     Map<String, String> env = profile.getEnv();
 
     if (apacheSsl.isEnabled()) {
+      BindingsSecretDecrypter bsc =
+          new BindingsSecretDecrypter(
+              secretSessionManager,
+              profile,
+              halconfigDirectoryStructure.getStagingDependenciesPath(
+                  deploymentConfiguration.getName()));
       env.put("DECK_HOST", deckSettings.getHost());
       env.put("DECK_PORT", deckSettings.getPort() + "");
       env.put("API_HOST", gateSettings.getBaseUrl());
-      env.put("DECK_CERT", apacheSsl.getSslCertificateFile());
-      env.put("DECK_KEY", apacheSsl.getSslCertificateKeyFile());
-      env.put("PASSPHRASE", apacheSsl.getSslCertificatePassphrase());
+      env.put(
+          "DECK_CERT",
+          bsc.trackSecretFile(apacheSsl.getSslCertificateFile(), "sslCertificateFile"));
+      env.put(
+          "DECK_KEY",
+          bsc.trackSecretFile(apacheSsl.getSslCertificateKeyFile(), "sslCertificateKeyFile"));
+      env.put("PASSPHRASE", secretSessionManager.decrypt(apacheSsl.getSslCertificatePassphrase()));
     }
 
     env.put(


### PR DESCRIPTION
Deck doesn't have secret decryption implemented, but we still want to allow users to use the secret format for SSL certs, etc, in their hal config. The change here makes sure those secrets are decrypted before building the deck profile.

@ezimanyi PTAL whenever you have a chance? (or let me know if I should tag someone else?)
Thanks!