### PR TITLE
fix(build): remove old usage of korkVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,6 @@
 
 buildscript {
   ext {
-    korkVersion = "5.3.7"
     clouddriverVersion = "5.8.0"
     front50Version = "2.1.0"
     fiatVersion = "1.0.5"


### PR DESCRIPTION
Spinnakerbot now uses gradle.properties to autobump the kork version ([example](https://github.com/spinnaker/halyard/commit/06f4375202a66b3d0061f6ce0f9460393617b36e)), so this line can cause conflicts.