### PR TITLE
feat(plugins): adding halyard commands for plugins

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -543,6 +543,13 @@
  * [**hal deploy details**](#hal-deploy-details)
  * [**hal deploy diff**](#hal-deploy-diff)
  * [**hal deploy rollback**](#hal-deploy-rollback)
+ * [**hal plugins**](#hal-plugins)
+ * [**hal plugins add**](#hal-plugins-add)
+ * [**hal plugins delete**](#hal-plugins-delete)
+ * [**hal plugins disable**](#hal-plugins-disable)
+ * [**hal plugins edit**](#hal-plugins-edit)
+ * [**hal plugins enable**](#hal-plugins-enable)
+ * [**hal plugins list**](#hal-plugins-list)
  * [**hal shutdown**](#hal-shutdown)
  * [**hal spin**](#hal-spin)
  * [**hal spin install**](#hal-spin-install)
@@ -586,6 +593,7 @@ hal [parameters] [subcommands]
  * `backup`: Backup and restore (remote or local) copies of your halconfig and all required files.
  * `config`: Configure, validate, and view your halconfig.
  * `deploy`: Manage the deployment of Spinnaker. This includes where it's deployed, what the infrastructure footprint looks like, what the currently running deployment looks like, etc...
+ * `plugins`: Show Spinnaker's configured plugins.
  * `shutdown`: Shutdown the halyard daemon.
  * `spin`: Manage the lifecycle of spin CLI.
  * `task`: This set of commands exposes utilities of dealing with Halyard's task engine.
@@ -10459,6 +10467,125 @@ hal deploy rollback [parameters]
  * `--exclude-service-names`: (*Default*: `[]`) When supplied, do not install or update the specified Spinnaker services.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--service-names`: (*Default*: `[]`) When supplied, only install or update the specified Spinnaker services.
+
+
+---
+## hal plugins
+
+Show Spinnaker's configured plugins.
+
+#### Usage
+```
+hal plugins [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `add`: Add a plugin
+ * `delete`: Delete a plugin
+ * `disable`: Enable or disable all plugins
+ * `edit`: Edit a plugin
+ * `enable`: Enable or disable all plugins
+ * `list`: List all plugins
+
+---
+## hal plugins add
+
+Add a plugin
+
+#### Usage
+```
+hal plugins add PLUGIN [parameters]
+```
+
+#### Parameters
+`PLUGIN`: The name of the plugin to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--enabled`: To enable or disable the plugin.
+ * `--manifest-location`: (*Required*) The location of the plugin's manifest file.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal plugins delete
+
+Delete a plugin
+
+#### Usage
+```
+hal plugins delete PLUGIN [parameters]
+```
+
+#### Parameters
+`PLUGIN`: The name of the plugin to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal plugins disable
+
+Enable or disable all plugins
+
+#### Usage
+```
+hal plugins disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal plugins edit
+
+Edit a plugin
+
+#### Usage
+```
+hal plugins edit PLUGIN [parameters]
+```
+
+#### Parameters
+`PLUGIN`: The name of the plugin to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--enabled`: To enable or disable the plugin.
+ * `--manifest-location`: The location of the plugin's manifest file.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal plugins enable
+
+Enable or disable all plugins
+
+#### Usage
+```
+hal plugins enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal plugins list
+
+List all plugins
+
+#### Usage
+```
+hal plugins list [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommand.java
@@ -58,6 +58,7 @@ public class HalCommand extends NestableCommand {
     registerSubcommand(new TaskCommand());
     registerSubcommand(new VersionCommand());
     registerSubcommand(new SpinCommand());
+    registerSubcommand(new PluginCommand());
   }
 
   static String getVersion() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/PluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/PluginCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.plugins.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class PluginCommand extends AbstractConfigCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "plugins";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Show Spinnaker's configured plugins.";
+
+  public PluginCommand() {
+    registerSubcommand(new AddPluginCommand());
+    registerSubcommand(new EditPluginCommand());
+    registerSubcommand(new DeletePluginCommand());
+    registerSubcommand(new ListPluginsCommand());
+    registerSubcommand(new PluginEnableDisableCommandBuilder().setEnable(true).build());
+    registerSubcommand(new PluginEnableDisableCommandBuilder().setEnable(false).build());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AbstractHasPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AbstractHasPluginCommand.java
@@ -29,7 +29,7 @@ import java.util.List;
 @Parameters(separators = "=")
 public abstract class AbstractHasPluginCommand extends AbstractConfigCommand {
   @Parameter(description = "The name of the plugin to operate on.", arity = 1)
-  List<String> plugins = new ArrayList<>();
+  private List<String> plugins = new ArrayList<>();
 
   @Override
   public String getMainParameter() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AbstractHasPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AbstractHasPluginCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import java.util.ArrayList;
+import java.util.List;
+
+/** An abstract definition for commands that accept plugins as a main parameter */
+@Parameters(separators = "=")
+public abstract class AbstractHasPluginCommand extends AbstractConfigCommand {
+  @Parameter(description = "The name of the plugin to operate on.", arity = 1)
+  List<String> plugins = new ArrayList<>();
+
+  @Override
+  public String getMainParameter() {
+    return "plugin";
+  }
+
+  public Plugin getPlugin() {
+    return new OperationHandler<Plugin>()
+        .setFailureMesssage("Failed to get plugin")
+        .setOperation(Daemon.getPlugin(getCurrentDeployment(), plugins.get(0), false))
+        .get();
+  }
+
+  public String getPluginName() {
+    switch (plugins.size()) {
+      case 0:
+        throw new IllegalArgumentException("No plugin supplied");
+      case 1:
+        return plugins.get(0);
+      default:
+        throw new IllegalArgumentException("More than one plugin supplied");
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AddPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AddPluginCommand.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 Armory Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class AddPluginCommand extends AbstractHasPluginCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "add";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Add a plugin";
+
+  @Parameter(
+      names = "--manifest-location",
+      description = "The location of the plugin's manifest file.",
+      required = true)
+  private String manifestLocation;
+
+  @Parameter(names = "--enabled", description = "To enable or disable the plugin.")
+  private String enabled;
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    String name = getPluginName();
+    Plugin plugin =
+        new Plugin()
+            .setName(name)
+            .setEnabled(isSet(enabled) ? Boolean.parseBoolean(enabled) : false)
+            .setManifestLocation(manifestLocation);
+
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to add plugin: " + name + ".")
+        .setSuccessMessage("Successfully added plugin" + name + ".")
+        .setOperation(Daemon.addPlugin(currentDeployment, !noValidate, plugin))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/DeletePluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/DeletePluginCommand.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class DeletePluginCommand extends AbstractHasPluginCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "delete";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Delete a plugin";
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    Plugin plugin = getPlugin();
+    String name = plugin.getName();
+
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to delete plugin " + name + ".")
+        .setSuccessMessage("Successfully deleted plugin " + name + ".")
+        .setOperation(Daemon.deletePlugin(currentDeployment, name, !noValidate))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/EditPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/EditPluginCommand.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class EditPluginCommand extends AbstractHasPluginCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Edit a plugin";
+
+  @Parameter(
+      names = "--manifest-location",
+      description = "The location of the plugin's manifest file.")
+  private String manifestLocation;
+
+  @Parameter(names = "--enabled", description = "To enable or disable the plugin.")
+  private String enabled;
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    Plugin plugin = getPlugin();
+
+    plugin.setEnabled(isSet(enabled) ? Boolean.parseBoolean(enabled) : plugin.getEnabled());
+    plugin.setManifestLocation(
+        isSet(manifestLocation) ? manifestLocation : plugin.getManifestLocation());
+
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to edit plugin " + plugin.getName() + ".")
+        .setSuccessMessage("Successfully edited plugin " + plugin.getName() + ".")
+        .setOperation(Daemon.setPlugin(currentDeployment, plugin.getName(), !noValidate, plugin))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/ListPluginsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/ListPluginsCommand.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class ListPluginsCommand extends AbstractConfigCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "list";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "List all plugins";
+
+  private List<Plugin> getPlugins() {
+    String currentDeployment = getCurrentDeployment();
+    return new OperationHandler<List<Plugin>>()
+        .setFailureMesssage("Failed to get plugins.")
+        .setOperation(Daemon.getPlugins(currentDeployment, !noValidate))
+        .get();
+  }
+
+  @Override
+  protected void executeThis() {
+    List<Plugin> plugins = getPlugins();
+    if (plugins.isEmpty()) {
+      AnsiUi.success("No configured plugins.");
+    } else {
+      AnsiUi.success("Plugins:");
+      plugins.forEach(plugin -> AnsiUi.listItem(plugin.getName()));
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/PluginEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/PluginEnableDisableCommandBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.AbstractEnableDisableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import java.util.function.Supplier;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class PluginEnableDisableCommandBuilder implements CommandBuilder {
+  @Setter boolean enable;
+
+  @Override
+  public NestableCommand build() {
+    return new PluginEnableDisableCommand(enable);
+  }
+
+  @Parameters(separators = "=")
+  private static class PluginEnableDisableCommand extends AbstractEnableDisableCommand {
+    @Override
+    public String getTargetName() {
+      return "Plugins";
+    }
+
+    private PluginEnableDisableCommand(boolean enable) {
+      this.enable = enable;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    boolean enable;
+
+    @Override
+    public String getShortDescription() {
+      return "Enable or disable all plugins";
+    }
+
+    @Override
+    protected Supplier<Void> getOperationSupplier() {
+      String currentDeployment = getCurrentDeployment();
+      boolean enable = isEnable();
+      return Daemon.setPluginEnableDisable(currentDeployment, !noValidate, enable);
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.ci.CiType;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaServices;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import com.netflix.spinnaker.halyard.config.model.v1.webook.WebhookTrust;
 import com.netflix.spinnaker.halyard.core.DaemonOptions;
@@ -1308,6 +1309,53 @@ public class Daemon {
     return () -> {
       ResponseUnwrapper.get(
           getService().deleteArtifactTemplate(deploymentName, templateName, validate));
+      return null;
+    };
+  }
+
+  public static Supplier<List<Plugin>> getPlugins(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawPlugin = ResponseUnwrapper.get(getService().getPlugins(deploymentName, validate));
+      return getObjectMapper().convertValue(rawPlugin, new TypeReference<List<Plugin>>() {});
+    };
+  }
+
+  public static Supplier<Plugin> getPlugin(
+      String deploymentName, String pluginName, boolean validate) {
+    return () -> {
+      Object rawPlugin =
+          ResponseUnwrapper.get(getService().getPlugin(deploymentName, pluginName, validate));
+      return getObjectMapper().convertValue(rawPlugin, Plugin.class);
+    };
+  }
+
+  public static Supplier<Void> addPlugin(String deploymentName, boolean validate, Plugin plugin) {
+    return () -> {
+      ResponseUnwrapper.get(getService().addPlugin(deploymentName, validate, plugin));
+      return null;
+    };
+  }
+
+  public static Supplier<Void> setPlugin(
+      String deploymentName, String pluginName, boolean validate, Plugin plugin) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setPlugin(deploymentName, pluginName, validate, plugin));
+      return null;
+    };
+  }
+
+  public static Supplier<Void> deletePlugin(
+      String deploymentName, String pluginName, boolean validate) {
+    return () -> {
+      ResponseUnwrapper.get(getService().deletePlugin(deploymentName, pluginName, validate));
+      return null;
+    };
+  }
+
+  public static Supplier<Void> setPluginEnableDisable(
+      String deploymentName, boolean validate, boolean enable) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setPluginsEnabled(deploymentName, validate, enable));
       return null;
     };
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccoun
 import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import com.netflix.spinnaker.halyard.config.model.v1.webook.WebhookTrust;
 import com.netflix.spinnaker.halyard.core.DaemonOptions;
@@ -883,6 +884,41 @@ public interface DaemonService {
   DaemonTask<Halconfig, Void> deleteArtifactTemplate(
       @Path("deploymentName") String deploymentName,
       @Path("templateName") String templateName,
+      @Query("validate") boolean validate);
+
+  @POST("/v1/config/deployments/{deploymentName}/plugins/")
+  DaemonTask<Halconfig, Void> addPlugin(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Body Plugin plugin);
+
+  @GET("/v1/config/deployments/{deploymentName}/plugins/")
+  DaemonTask<Halconfig, Object> getPlugins(
+      @Path("deploymentName") String deploymentName, @Query("validate") boolean validate);
+
+  @GET("/v1/config/deployments/{deploymentName}/plugins/{pluginName}/")
+  DaemonTask<Halconfig, Object> getPlugin(
+      @Path("deploymentName") String deploymentName,
+      @Path("pluginName") String pluginName,
+      @Query("validate") boolean validate);
+
+  @PUT("/v1/config/deployments/{deploymentName}/plugins/{pluginName}/")
+  DaemonTask<Halconfig, Void> setPlugin(
+      @Path("deploymentName") String deploymentName,
+      @Path("pluginName") String pluginName,
+      @Query("validate") boolean validate,
+      @Body Plugin plugin);
+
+  @PUT("/v1/config/deployments/{deploymentName}/plugins/enabled/")
+  DaemonTask<Halconfig, Void> setPluginsEnabled(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Body boolean enabled);
+
+  @DELETE("/v1/config/deployments/{deploymentName}/plugins/{pluginName}/")
+  DaemonTask<Halconfig, Void> deletePlugin(
+      @Path("deploymentName") String deploymentName,
+      @Path("pluginName") String pluginName,
       @Query("validate") boolean validate);
 
   @GET("/v1/spin/install/latest")

--- a/halyard-cli/src/test/groovy/com/netflix/spinnaker/halyard/cli/command/v1/CommandTreeSpec.groovy
+++ b/halyard-cli/src/test/groovy/com/netflix/spinnaker/halyard/cli/command/v1/CommandTreeSpec.groovy
@@ -37,6 +37,10 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.saml.S
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.x509.X509Command
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz.AuthzCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.ui.UiSecurityCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.plugins.AddPluginCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.plugins.DeletePluginCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.plugins.EditPluginCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.plugins.ListPluginsCommand
 import spock.lang.Specification
 import spock.lang.Unroll
 
@@ -117,6 +121,11 @@ class CommandTreeSpec extends Specification {
     LdapCommand     | "disable"       | AuthnMethodEnableDisableCommand
     LdapCommand     | "enable"        | AuthnMethodEnableDisableCommand
     LdapCommand     | "edit"          | EditLdapCommand
+
+    PluginCommand   | "list"          | ListPluginsCommand
+    PluginCommand   | "edit"          | EditPluginCommand
+    PluginCommand   | "delete"        | DeletePluginCommand
+    PluginCommand   | "add"           | AddPluginCommand
   }
 
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -86,6 +86,8 @@ public class DeploymentConfiguration extends Node {
 
   Canary canary = new Canary();
 
+  Plugins plugins = new Plugins();
+
   Webhook webhook = new Webhook();
 
   @Override

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.artifacts.ArtifactTemplate;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaService;
 import com.netflix.spinnaker.halyard.config.model.v1.ha.HaServices;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import com.netflix.spinnaker.halyard.config.model.v1.security.*;
 import com.netflix.spinnaker.halyard.config.model.v1.webook.WebhookTrust;
 import java.util.ArrayList;
@@ -328,6 +329,23 @@ public class NodeFilter implements Cloneable {
   public NodeFilter setArtifactTemplate(String name) {
     matchers.add(Node.thisNodeAcceptor(Artifacts.class));
     matchers.add(Node.namedNodeAcceptor(ArtifactTemplate.class, name));
+    return this;
+  }
+
+  public NodeFilter setPlugin() {
+    matchers.add(Node.thisNodeAcceptor(Plugins.class));
+    return this;
+  }
+
+  public NodeFilter setPlugin(String name) {
+    matchers.add(Node.thisNodeAcceptor(Plugins.class));
+    matchers.add(Node.namedNodeAcceptor(Plugin.class, name));
+    return this;
+  }
+
+  public NodeFilter withAnyPlugin() {
+    matchers.add(Node.thisNodeAcceptor(Plugins.class));
+    matchers.add(Node.thisNodeAcceptor(Plugin.class));
     return this;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Plugins.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Plugins.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.node;
+
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class Plugins extends Node {
+
+  @Override
+  public String getNodeName() {
+    return "plugins";
+  }
+
+  @Override
+  public NodeIterator getChildren() {
+    return NodeIteratorFactory.makeListIterator(
+        plugins.stream().map(a -> (Node) a).collect(Collectors.toList()));
+  }
+
+  private List<Plugin> plugins = new ArrayList<>();
+  private boolean enabled;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Manifest.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Manifest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.plugins;
+
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+import lombok.Data;
+import lombok.Getter;
+
+@Data
+public class Manifest {
+  public String name;
+  public String manifestVersion;
+  public List<String> jars;
+  public Map<String, Object> options;
+
+  static final String regex = "^[a-zA-Z0-9]+\\/[\\w-]+$";
+  static final Pattern pattern = Pattern.compile(regex);
+
+  public void validate() throws HalException {
+
+    if (Stream.of(name, manifestVersion, jars).anyMatch(Objects::isNull)) {
+      throw new HalException(
+          new ConfigProblemBuilder(
+                  Problem.Severity.FATAL, "Invalid plugin manifest, contains null values")
+              .build());
+    }
+
+    Matcher matcher = pattern.matcher(name);
+
+    if (!matcher.find()) {
+      throw new HalException(
+          new ConfigProblemBuilder(Problem.Severity.FATAL, "Invalid plugin name: " + name).build());
+    }
+
+    if (!manifestVersion.equals(ManifestVersion.V1.getName())) {
+      throw new HalException(
+          new ConfigProblemBuilder(
+                  Problem.Severity.FATAL, "Invalid manifest version for plugin: " + name)
+              .build());
+    }
+  }
+
+  public enum ManifestVersion {
+    V1("plugins/v1");
+
+    @Getter String name;
+
+    @Override
+    public String toString() {
+      return this.name;
+    }
+
+    ManifestVersion(String name) {
+      this.name = name;
+    }
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.plugins;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemBuilder;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.representer.Representer;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class Plugin extends Node {
+  public String name;
+  public Boolean enabled;
+  public String manifestLocation;
+
+  @Override
+  public String getNodeName() {
+    return name;
+  }
+
+  public Manifest generateManifest() {
+    Representer representer = new Representer();
+    representer.getPropertyUtils().setSkipMissingProperties(true);
+    Yaml yaml = new Yaml(new Constructor(Manifest.class), representer);
+
+    InputStream manifestContents = downloadManifest();
+    Manifest manifest = yaml.load(manifestContents);
+    manifest.validate();
+    return manifest;
+  }
+
+  public InputStream downloadManifest() {
+    try {
+      if (manifestLocation.startsWith("http:") || manifestLocation.startsWith("https:")) {
+        URL url = new URL(manifestLocation);
+        return url.openStream();
+      } else {
+        return new FileInputStream(manifestLocation);
+      }
+    } catch (IOException e) {
+      throw new HalException(
+          new ProblemBuilder(
+                  Problem.Severity.FATAL,
+                  "Cannot get plugin manifest file from: "
+                      + manifestLocation
+                      + ": "
+                      + e.getMessage())
+              .build());
+    }
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/PluginService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/PluginService.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.services.v1;
+
+import com.netflix.spinnaker.halyard.config.error.v1.ConfigNotFoundException;
+import com.netflix.spinnaker.halyard.config.error.v1.IllegalConfigException;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Plugins;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemBuilder;
+import com.netflix.spinnaker.halyard.core.error.v1.HalException;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PluginService {
+  private final LookupService lookupService;
+  private final ValidateService validateService;
+  private final DeploymentService deploymentService;
+
+  private Plugins getPlugins(String deploymentName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setPlugin();
+
+    return lookupService.getSingularNodeOrDefault(
+        filter, Plugins.class, Plugins::new, n -> setPlugins(deploymentName, n));
+  }
+
+  private void setPlugins(String deploymentName, Plugins newPlugins) {
+    DeploymentConfiguration deploymentConfiguration =
+        deploymentService.getDeploymentConfiguration(deploymentName);
+    deploymentConfiguration.setPlugins(newPlugins);
+  }
+
+  public List<Plugin> getAllPlugins(String deploymentName) {
+    return getPlugins(deploymentName).getPlugins();
+  }
+
+  public Plugin getPlugin(String deploymentName, String pluginName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setPlugin(pluginName);
+    List<Plugin> matchingPlugins = lookupService.getMatchingNodesOfType(filter, Plugin.class);
+
+    switch (matchingPlugins.size()) {
+      case 0:
+        throw new ConfigNotFoundException(
+            new ConfigProblemBuilder(
+                    Problem.Severity.FATAL, "No plugin with name \"" + pluginName + "\" was found")
+                .setRemediation("Create a new plugin with name \"" + pluginName + "\"")
+                .build());
+      case 1:
+        return matchingPlugins.get(0);
+      default:
+        throw new IllegalConfigException(
+            new ConfigProblemBuilder(
+                    Problem.Severity.FATAL,
+                    "More than one plugin named \"" + pluginName + "\" was found")
+                .setRemediation(
+                    "Manually delete/rename duplicate plugins with name \""
+                        + pluginName
+                        + "\" in your halconfig file")
+                .build());
+    }
+  }
+
+  public void setPlugin(String deploymentName, String pluginName, Plugin newPlugin) {
+    List<Plugin> plugins = getAllPlugins(deploymentName);
+    for (int i = 0; i < plugins.size(); i++) {
+      if (plugins.get(i).getNodeName().equals(pluginName)) {
+        plugins.set(i, newPlugin);
+        return;
+      }
+    }
+    throw new HalException(
+        new ConfigProblemBuilder(
+                Problem.Severity.FATAL, "Plugin \"" + pluginName + "\" wasn't found")
+            .build());
+  }
+
+  public void deletePlugin(String deploymentName, String pluginName) {
+    List<Plugin> plugins = getAllPlugins(deploymentName);
+    boolean removed = plugins.removeIf(plugin -> plugin.getName().equals(pluginName));
+
+    if (!removed) {
+      throw new HalException(
+          new ConfigProblemBuilder(
+                  Problem.Severity.FATAL, "Plugin \"" + pluginName + "\" wasn't found")
+              .build());
+    }
+  }
+
+  public void addPlugin(String deploymentName, Plugin newPlugin) {
+    String newPluginName = newPlugin.getName();
+    List<Plugin> plugins = getAllPlugins(deploymentName);
+    for (Plugin plugin : plugins) {
+      if (plugin.getName().equals(newPluginName)) {
+        throw new HalException(
+            new ConfigProblemBuilder(
+                    Problem.Severity.FATAL, "Plugin \"" + newPluginName + "\" already exists")
+                .build());
+      }
+    }
+    plugins.add(newPlugin);
+  }
+
+  public void setPluginsEnabled(String deploymentName, boolean validate, boolean enable) {
+    DeploymentConfiguration deploymentConfiguration =
+        deploymentService.getDeploymentConfiguration(deploymentName);
+    Plugins plugins = deploymentConfiguration.getPlugins();
+    plugins.setEnabled(enable);
+  }
+
+  public ProblemSet validateAllPlugins(String deploymentName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).withAnyPlugin();
+    return validateService.validateMatchingFilter(filter);
+  }
+
+  public ProblemSet validatePlugin(String deploymentName, String pluginName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setPlugin(pluginName);
+    return validateService.validateMatchingFilter(filter);
+  }
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018 Bol.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.plugins
+
+import com.netflix.spinnaker.halyard.core.error.v1.HalException
+import spock.lang.Specification
+
+class ManifestSpec extends Specification {
+
+    void "plugin manifests must have the required fields"() {
+        setup:
+        Manifest manifest = new Manifest();
+
+        when:
+        manifest.setJars(jars)
+        manifest.setManifestVersion(manifestVersion)
+        manifest.setName(name)
+        manifest.setOptions(options)
+        manifest.validate()
+
+        then:
+        thrown HalException
+
+        where:
+        name      | manifestVersion | jars                 | options
+        "foo"     | "plugins/v1"    | Arrays.asList("jar") | null
+        "foo/bar" | null            | Arrays.asList("jar") | null
+        "foo/bar" | "plugins/v1"    | null                 | null
+    }
+
+    void "plugin manifests pass validation"() {
+        setup:
+        Manifest manifest = new Manifest();
+
+        when:
+        manifest.setJars(Arrays.asList("one", "two"))
+        manifest.setManifestVersion("plugins/v1")
+        manifest.setName("foo/bar")
+        manifest.validate()
+
+        then:
+        noExceptionThrown()
+
+    }
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/PluginServiceSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/PluginServiceSpec.groovy
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.services.v1
+
+import com.netflix.spinnaker.halyard.config.error.v1.ConfigNotFoundException
+import spock.lang.Specification
+
+class PluginServiceSpec extends Specification {
+  final String DEPLOYMENT = "default"
+  final HalconfigParserMocker mocker = new HalconfigParserMocker()
+
+  LookupService getMockLookupService(String config) {
+      def lookupService = new LookupService()
+      lookupService.parser = mocker.mockHalconfigParser(config)
+      return lookupService
+  }
+
+  PluginService makePluginService(String config) {
+      def lookupService = getMockLookupService(config)
+      def deploymentService = new DeploymentService()
+      deploymentService.lookupService = lookupService
+      new PluginService(lookupService, new ValidateService(), deploymentService)
+  }
+
+  def "load an existing plugin node"() {
+    setup:
+    String config = """
+halyardVersion: 1
+currentDeployment: $DEPLOYMENT
+deploymentConfigurations:
+- name: $DEPLOYMENT
+  version: 1
+  providers: null
+  plugins:
+    plugins:
+    - name: test-plugin
+      manifestLocation: /home/user/test-plugin.yaml
+"""
+    def pluginService = makePluginService(config)
+
+    when:
+    def result = pluginService.getAllPlugins(DEPLOYMENT)
+
+    then:
+    result != null
+    result.size() == 1
+    result[0].getName() == "test-plugin"
+    result[0].getManifestLocation() == "/home/user/test-plugin.yaml"
+
+    when:
+    result = pluginService.getPlugin(DEPLOYMENT, "test-plugin")
+
+    then:
+    result != null
+    result.getName() == "test-plugin"
+    result.getManifestLocation() == "/home/user/test-plugin.yaml"
+
+    when:
+    pluginService.getPlugin(DEPLOYMENT, 'non-existent-plugin')
+
+    then:
+    thrown(ConfigNotFoundException)
+  }
+
+  def "no error if plugin is empty"() {
+    setup:
+    String config = """
+halyardVersion: 1
+currentDeployment: $DEPLOYMENT
+deploymentConfigurations:
+- name: $DEPLOYMENT
+  version: 1
+  providers: null
+  plugins:
+    plugins: []
+"""
+    def pluginService = makePluginService(config)
+
+    when:
+    def result = pluginService.getAllPlugins(DEPLOYMENT)
+
+    then:
+    result != null
+    result.size() == 0
+
+    when:
+    pluginService.getPlugin(DEPLOYMENT, "test-plugin")
+
+    then:
+    thrown(ConfigNotFoundException)
+  }
+
+  def "no error if plugin is missing"() {
+    setup:
+    String config = """
+halyardVersion: 1
+currentDeployment: $DEPLOYMENT
+deploymentConfigurations:
+- name: $DEPLOYMENT
+  version: 1
+  providers: null
+  plugins:
+"""
+    def pluginService = makePluginService(config)
+
+    when:
+    def result = pluginService.getAllPlugins(DEPLOYMENT)
+
+    then:
+    result != null
+    result.size() == 0
+
+    when:
+
+    pluginService.getPlugin(DEPLOYMENT, "test-template")
+
+    then:
+    thrown(ConfigNotFoundException)
+  }
+
+  def "multiple templates are correctly parsed"() {
+    setup:
+    String config = """
+halyardVersion: 1
+currentDeployment: $DEPLOYMENT
+deploymentConfigurations:
+- name: $DEPLOYMENT
+  version: 1
+  providers: null
+  plugins:
+    plugins:
+    - name: test-plugin
+      manifestLocation: /home/user/test-plugin.yaml
+    - name: test-plugin-2
+      manifestLocation: /home/user/test-plugin-2.yaml
+"""
+    def pluginService = makePluginService(config)
+
+    when:
+    def result = pluginService.getAllPlugins(DEPLOYMENT)
+
+    then:
+    result != null
+    result.size() == 2
+
+    when:
+    result = pluginService.getPlugin(DEPLOYMENT, "test-plugin")
+
+    then:
+    result != null
+    result.getName() == "test-plugin"
+    result.getManifestLocation() == "/home/user/test-plugin.yaml"
+
+    when:
+    result = pluginService.getPlugin(DEPLOYMENT, "test-plugin-2")
+
+    then:
+    result != null
+    result.getName() == "test-plugin-2"
+    result.getManifestLocation() == "/home/user/test-plugin-2.yaml"
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -19,15 +19,21 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.integrations.IntegrationsConfigWrapper;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class OrcaProfileFactory extends SpringProfileFactory {
   @Override
@@ -73,6 +79,20 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     profile.appendContents("pipelineTemplates.enabled: " + pipelineTemplates);
     // For backward compatibility
     profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
+
+    final List<Plugin> plugins = deploymentConfiguration.getPlugins().getPlugins();
+    Map<String, Object> fullyRenderedYaml = new LinkedHashMap<>();
+    Map<String, Object> pluginMetadata =
+        plugins.stream()
+            .filter(p -> p.getEnabled())
+            .filter(p -> !p.getManifestLocation().isEmpty())
+            .map(p -> p.generateManifest())
+            .collect(Collectors.toConcurrentMap(m -> m.getName(), m -> m.getOptions()));
+
+    fullyRenderedYaml.put("plugins", pluginMetadata);
+
+    profile.appendContents(
+        yamlToString(deploymentConfiguration.getName(), profile, fullyRenderedYaml));
   }
 
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -87,7 +87,7 @@ public class OrcaProfileFactory extends SpringProfileFactory {
             .filter(p -> p.getEnabled())
             .filter(p -> !p.getManifestLocation().isEmpty())
             .map(p -> p.generateManifest())
-            .collect(Collectors.toConcurrentMap(m -> m.getName(), m -> m.getOptions()));
+            .collect(Collectors.toMap(m -> m.getName(), m -> m.getOptions()));
 
     fullyRenderedYaml.put("plugins", pluginMetadata);
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Plugins;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Manifest;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import java.util.*;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class PluginProfileFactory extends StringBackedProfileFactory {
+  @Override
+  protected void setProfile(
+      Profile profile,
+      DeploymentConfiguration deploymentConfiguration,
+      SpinnakerRuntimeSettings endpoints) {
+    final Plugins plugins = deploymentConfiguration.getPlugins();
+
+    Map<String, List<Map<String, Object>>> fullyRenderedYaml = new HashMap<>();
+
+    List<Map<String, Object>> pluginMetadata =
+        plugins.getPlugins().stream()
+            .filter(p -> p.getEnabled())
+            .filter(p -> !p.getManifestLocation().isEmpty())
+            .map(p -> composeMetadata(p, p.generateManifest()))
+            .collect(Collectors.toList());
+
+    fullyRenderedYaml.put("plugins", pluginMetadata);
+
+    profile.appendContents(
+        yamlToString(deploymentConfiguration.getName(), profile, fullyRenderedYaml));
+  }
+
+  private Map<String, Object> composeMetadata(Plugin plugin, Manifest manifest) {
+    Map<String, Object> metadata = new LinkedHashMap<>();
+    metadata.put("enabled", plugin.getEnabled());
+    metadata.put("name", manifest.getName());
+    metadata.put("jars", manifest.getJars());
+    metadata.put("manifestVersion", manifest.getManifestVersion());
+    return metadata;
+  }
+
+  @Override
+  protected String getRawBaseProfile() {
+    return "";
+  }
+
+  @Override
+  public SpinnakerArtifact getArtifact() {
+    return SpinnakerArtifact.SPINNAKER;
+  }
+
+  @Override
+  protected String commentPrefix() {
+    return "## ";
+  }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -21,6 +21,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguratio
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.OrcaProfileFactory;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.PluginProfileFactory;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -38,6 +39,8 @@ import retrofit.http.*;
 @Component
 public abstract class OrcaService extends SpringService<OrcaService.Orca> {
   @Autowired OrcaProfileFactory orcaProfileFactory;
+
+  @Autowired PluginProfileFactory pluginProfileFactory;
 
   @Override
   public SpinnakerArtifact getArtifact() {
@@ -72,6 +75,14 @@ public abstract class OrcaService extends SpringService<OrcaService.Orca> {
     appendReadonlyClouddriver(profile, deploymentConfiguration, endpoints);
 
     profiles.add(profile);
+
+    // Plugins
+    String pluginFilename = "plugins.yml";
+    String pluginPath = Paths.get(getConfigOutputPath(), pluginFilename).toString();
+    Profile pluginProfile =
+        pluginProfileFactory.getProfile(
+            pluginFilename, pluginPath, deploymentConfiguration, endpoints);
+    profiles.add(pluginProfile);
     return profiles;
   }
 

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PluginsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PluginsController.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import com.netflix.spinnaker.halyard.config.services.v1.PluginService;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericDeleteRequest;
+import com.netflix.spinnaker.halyard.util.v1.GenericEnableDisableRequest;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
+import com.netflix.spinnaker.halyard.util.v1.GenericUpdateRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/plugins")
+@RequiredArgsConstructor
+public class PluginsController {
+  private final PluginService pluginService;
+  private final HalconfigDirectoryStructure halconfigDirectoryStructure;
+  private final HalconfigParser halconfigParser;
+
+  @RequestMapping(value = "/", method = RequestMethod.GET)
+  DaemonTask<Halconfig, List<Plugin>> getPlugins(
+      @PathVariable String deploymentName, @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<List<Plugin>>builder()
+        .getter(() -> pluginService.getAllPlugins(deploymentName))
+        .validator(() -> pluginService.validateAllPlugins(deploymentName))
+        .description("Get plugins")
+        .build()
+        .execute(validationSettings);
+  }
+
+  @RequestMapping(value = "/{pluginName:.+}", method = RequestMethod.GET)
+  DaemonTask<Halconfig, Plugin> getPlugin(
+      @PathVariable String deploymentName,
+      @PathVariable String pluginName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Plugin>builder()
+        .getter(() -> pluginService.getPlugin(deploymentName, pluginName))
+        .validator(() -> pluginService.validatePlugin(deploymentName, pluginName))
+        .description("Get the " + pluginName + " plugin")
+        .build()
+        .execute(validationSettings);
+  }
+
+  @RequestMapping(value = "/{pluginName:.+}", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setPlugin(
+      @PathVariable String deploymentName,
+      @PathVariable String pluginName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Plugin plugin) {
+    return GenericUpdateRequest.<Plugin>builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .updater(t -> pluginService.setPlugin(deploymentName, pluginName, t))
+        .validator(() -> pluginService.validatePlugin(deploymentName, pluginName))
+        .description("Edit the " + pluginName + " plugin")
+        .build()
+        .execute(validationSettings, plugin);
+  }
+
+  @RequestMapping(value = "/", method = RequestMethod.POST)
+  DaemonTask<Halconfig, Void> addPlugin(
+      @PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Plugin plugin) {
+    return GenericUpdateRequest.<Plugin>builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .updater(t -> pluginService.addPlugin(deploymentName, t))
+        .validator(() -> pluginService.validatePlugin(deploymentName, plugin.getName()))
+        .description("Add the " + plugin.getName() + " plugin")
+        .build()
+        .execute(validationSettings, plugin);
+  }
+
+  @RequestMapping(value = "/{pluginName:.+}", method = RequestMethod.DELETE)
+  DaemonTask<Halconfig, Void> deletePlugin(
+      @PathVariable String deploymentName,
+      @PathVariable String pluginName,
+      @ModelAttribute ValidationSettings validationSettings) {
+    return GenericDeleteRequest.builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .deleter(() -> pluginService.deletePlugin(deploymentName, pluginName))
+        .validator(() -> pluginService.validateAllPlugins(deploymentName))
+        .description("Delete the " + pluginName + " plugin")
+        .build()
+        .execute(validationSettings);
+  }
+
+  @RequestMapping(value = "/enabled", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setPluginsEnabled(
+      @PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Boolean enabled) {
+    return GenericEnableDisableRequest.builder(halconfigParser)
+        .updater(t -> pluginService.setPluginsEnabled(deploymentName, false, enabled))
+        .validator(() -> pluginService.validateAllPlugins(deploymentName))
+        .description("Enable or disable plugins")
+        .build()
+        .execute(validationSettings, enabled);
+  }
+}


### PR DESCRIPTION
This PR is related to https://github.com/spinnaker/spinnaker/issues/4181.

This PR adds commands to Halyard to configure plugins, as well as lay down `plugins.yml` and configuration updates to `orca.yml` on deploy.
These files are used by Kork in order to enable plugins (https://github.com/spinnaker/kork/pull/325). 