### PR TITLE
chore(build): Update cloudbuild.yaml file

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,8 +4,8 @@ steps:
   entrypoint: "bash"
   args: [ "-c", "./gradlew halyard-web:installDist -x test"]
 - name: 'gcr.io/cloud-builders/docker'
-  args: ["build", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA", "-t", "gcr.io/$PROJECT_ID/$REPO_NAME:latest", "-f", "Dockerfile.slim", "."]
+  args: ["build", "-t", "gcr.io/$PROJECT_ID/halyard:$COMMIT_SHA", "-t", "gcr.io/$PROJECT_ID/halyard:latest", "-f", "Dockerfile.slim", "."]
 images:
-- 'gcr.io/$PROJECT_ID/$REPO_NAME:$COMMIT_SHA'
-- 'gcr.io/$PROJECT_ID/$REPO_NAME:latest'
+- 'gcr.io/$PROJECT_ID/halyard:$COMMIT_SHA'
+- 'gcr.io/$PROJECT_ID/halyard:latest'
 timeout: 25m


### PR DESCRIPTION
Remove the $REPO_NAME variable from the cloudbuild.yaml file; this is being used to decide the name of the image to push which will not always correspond to the image name. In particular, if we start publishing both alpine and ubuntu images we'll want the image name to have a suffix reflecting that.