### PR TITLE
feat(plugins): enable/disable downloading plugins

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -547,8 +547,10 @@
  * [**hal plugins add**](#hal-plugins-add)
  * [**hal plugins delete**](#hal-plugins-delete)
  * [**hal plugins disable**](#hal-plugins-disable)
+ * [**hal plugins disableDownloading**](#hal-plugins-disableDownloading)
  * [**hal plugins edit**](#hal-plugins-edit)
  * [**hal plugins enable**](#hal-plugins-enable)
+ * [**hal plugins enableDownloading**](#hal-plugins-enableDownloading)
  * [**hal plugins list**](#hal-plugins-list)
  * [**hal shutdown**](#hal-shutdown)
  * [**hal spin**](#hal-spin)
@@ -10487,8 +10489,10 @@ hal plugins [parameters] [subcommands]
  * `add`: Add a plugin
  * `delete`: Delete a plugin
  * `disable`: Enable or disable all plugins
+ * `disableDownloading`: Enable or disable the ability for Spinnaker services to download jars for plugins
  * `edit`: Edit a plugin
  * `enable`: Enable or disable all plugins
+ * `enableDownloading`: Enable or disable the ability for Spinnaker services to download jars for plugins
  * `list`: List all plugins
 
 ---
@@ -10541,6 +10545,21 @@ hal plugins disable [parameters]
 
 
 ---
+## hal plugins disableDownloading
+
+Enable or disable the ability for Spinnaker services to download jars for plugins
+
+#### Usage
+```
+hal plugins disableDownloading [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
 ## hal plugins edit
 
 Edit a plugin
@@ -10566,6 +10585,21 @@ Enable or disable all plugins
 #### Usage
 ```
 hal plugins enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal plugins enableDownloading
+
+Enable or disable the ability for Spinnaker services to download jars for plugins
+
+#### Usage
+```
+hal plugins enableDownloading [parameters]
 ```
 
 #### Parameters

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/PluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/PluginCommand.java
@@ -37,6 +37,8 @@ public class PluginCommand extends AbstractConfigCommand {
     registerSubcommand(new ListPluginsCommand());
     registerSubcommand(new PluginEnableDisableCommandBuilder().setEnable(true).build());
     registerSubcommand(new PluginEnableDisableCommandBuilder().setEnable(false).build());
+    registerSubcommand(new PluginDownloadingEnableDisableCommandBuilder().setEnable(true).build());
+    registerSubcommand(new PluginDownloadingEnableDisableCommandBuilder().setEnable(false).build());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/PluginDownloadingEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/PluginDownloadingEnableDisableCommandBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
+
+import com.netflix.spinnaker.halyard.cli.command.v1.AbstractEnableDisableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import java.util.function.Supplier;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class PluginDownloadingEnableDisableCommandBuilder implements CommandBuilder {
+  @Setter boolean enable;
+
+  @Override
+  public NestableCommand build() {
+    return new PluginDownloadingEnableDisableCommand(enable);
+  }
+
+  private static class PluginDownloadingEnableDisableCommand extends AbstractEnableDisableCommand {
+    @Override
+    public String getTargetName() {
+      return "Plugins";
+    }
+
+    @Override
+    public String getCommandName() {
+      return isEnable() ? "enableDownloading" : "disableDownloading";
+    }
+
+    private PluginDownloadingEnableDisableCommand(boolean enable) {
+      this.enable = enable;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    boolean enable;
+
+    @Override
+    public String getShortDescription() {
+      return "Enable or disable the ability for Spinnaker services to download jars for plugins";
+    }
+
+    @Override
+    protected Supplier<Void> getOperationSupplier() {
+      String currentDeployment = getCurrentDeployment();
+      boolean enabled = this.isEnable();
+      return Daemon.setPluginDownloadingEnableDisable(currentDeployment, !noValidate, enabled);
+    }
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -1360,6 +1360,15 @@ public class Daemon {
     };
   }
 
+  public static Supplier<Void> setPluginDownloadingEnableDisable(
+      String deploymentName, boolean validate, boolean enable) {
+    return () -> {
+      ResponseUnwrapper.get(
+          getService().setPluginsDownloadingEnabled(deploymentName, validate, enable));
+      return null;
+    };
+  }
+
   private static DaemonService service;
   private static ObjectMapper objectMapper;
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -915,6 +915,12 @@ public interface DaemonService {
       @Query("validate") boolean validate,
       @Body boolean enabled);
 
+  @PUT("/v1/config/deployments/{deploymentName}/plugins/downloadingEnabled/")
+  DaemonTask<Halconfig, Void> setPluginsDownloadingEnabled(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Body boolean enabled);
+
   @DELETE("/v1/config/deployments/{deploymentName}/plugins/{pluginName}/")
   DaemonTask<Halconfig, Void> deletePlugin(
       @Path("deploymentName") String deploymentName,

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -86,7 +86,7 @@ public class DeploymentConfiguration extends Node {
 
   Canary canary = new Canary();
 
-  Plugins plugins = new Plugins();
+  Plugins plugins = new Plugins().setDownloadingEnabled(false);
 
   Webhook webhook = new Webhook();
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Plugins.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Plugins.java
@@ -40,4 +40,5 @@ public class Plugins extends Node {
 
   private List<Plugin> plugins = new ArrayList<>();
   private boolean enabled;
+  private boolean downloadingEnabled;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/PluginService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/PluginService.java
@@ -127,6 +127,14 @@ public class PluginService {
     plugins.setEnabled(enable);
   }
 
+  public void setPluginsDownloadingEnabled(
+      String deploymentName, boolean validate, boolean enable) {
+    DeploymentConfiguration deploymentConfiguration =
+        deploymentService.getDeploymentConfiguration(deploymentName);
+    Plugins plugins = deploymentConfiguration.getPlugins();
+    plugins.setDownloadingEnabled(enable);
+  }
+
   public ProblemSet validateAllPlugins(String deploymentName) {
     NodeFilter filter = new NodeFilter().setDeployment(deploymentName).withAnyPlugin();
     return validateService.validateMatchingFilter(filter);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
@@ -37,7 +37,8 @@ public class PluginProfileFactory extends StringBackedProfileFactory {
       SpinnakerRuntimeSettings endpoints) {
     final Plugins plugins = deploymentConfiguration.getPlugins();
 
-    Map<String, List<Map<String, Object>>> fullyRenderedYaml = new HashMap<>();
+    Map<String, Object> pluginsYaml = new HashMap<>();
+    Map<String, Object> fullyRenderedYaml = new HashMap<>();
 
     List<Map<String, Object>> pluginMetadata =
         plugins.getPlugins().stream()
@@ -46,7 +47,9 @@ public class PluginProfileFactory extends StringBackedProfileFactory {
             .map(p -> composeMetadata(p, p.generateManifest()))
             .collect(Collectors.toList());
 
-    fullyRenderedYaml.put("plugins", pluginMetadata);
+    pluginsYaml.put("pluginConfigurations", pluginMetadata);
+    pluginsYaml.put("downloadingEnabled", plugins.isDownloadingEnabled());
+    fullyRenderedYaml.put("plugins", pluginsYaml);
 
     profile.appendContents(
         yamlToString(deploymentConfiguration.getName(), profile, fullyRenderedYaml));

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PluginsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/PluginsController.java
@@ -118,4 +118,17 @@ public class PluginsController {
         .build()
         .execute(validationSettings, enabled);
   }
+
+  @RequestMapping(value = "/downloadingEnabled", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setPluginsDownloadingEnabled(
+      @PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Boolean enabled) {
+    return GenericEnableDisableRequest.builder(halconfigParser)
+        .updater(t -> pluginService.setPluginsDownloadingEnabled(deploymentName, false, enabled))
+        .validator(() -> pluginService.validateAllPlugins(deploymentName))
+        .description("Enable or disable downloading plugins")
+        .build()
+        .execute(validationSettings, enabled);
+  }
 }


### PR DESCRIPTION
This PR is related to spinnaker/spinnaker#4181 and enables Spinnaker administrators to use halyard to enable downloading of plugin jars, as seen in https://github.com/spinnaker/kork/pull/358. 

Different environments used to run Spinnaker have varying constraints, in order to ensure plugins can be used in all environments, we added the ability to download plugins via Kork at runtime. By default, downloading of plugin jars will be disabled, but if the Spinnaker administrator trusts the download location, they can enable plugin jar downloading. Spinnaker users (application owners) will not have the ability to add plugins.