### PR TITLE
fix(docs): s/Kubenretes/Kubernetes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8657,7 +8657,7 @@ hal config provider kubernetes disable [parameters]
 ---
 ## hal config provider kubernetes edit
 
-Due to how the Kubenretes provider shards its cache resources, there is opportunity to tune how its caching should be handled. This command exists to allow you tune this caching behavior.
+Due to how the Kubernetes provider shards its cache resources, there is opportunity to tune how its caching should be handled. This command exists to allow you tune this caching behavior.
 
 #### Usage
 ```

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditProviderCommand.java
@@ -34,7 +34,7 @@ public class KubernetesEditProviderCommand
   String shortDescription = "Set provider-wide properties for the Kubernetes provider";
 
   String longDescription =
-      "Due to how the Kubenretes provider shards its cache resources, there is opportunity to "
+      "Due to how the Kubernetes provider shards its cache resources, there is opportunity to "
           + "tune how its caching should be handled. This command exists to allow you tune this caching behavior.";
 
   protected String getProviderName() {


### PR DESCRIPTION
Small edit to output when running `hal config provider kubernetes edit --help`...

`Due to how the Kubenretes provider`

s/Kubenretes/Kubernetes