### PR TITLE
feat(slack): Allow configurable slack endpoint

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/slack/EditSlackCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/slack/EditSlackCommand.java
@@ -37,8 +37,12 @@ public class EditSlackCommand extends AbstractEditNotificationCommand<SlackNotif
   @Parameter(names = "--token", password = true, description = "Your slack bot token.")
   private String token;
 
+  @Parameter(names = "--base-url", description = "Slack endpoint.")
+  private String baseUrl;
+
   @Override
   protected Notification editNotification(SlackNotification notification) {
+    notification.setBaseUrl(isSet(baseUrl) ? baseUrl : notification.getBaseUrl());
     notification.setBotName(isSet(botName) ? botName : notification.getBotName());
     notification.setToken(isSet(token) ? token : notification.getToken());
     return notification;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/notifications/SlackNotification.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/notifications/SlackNotification.java
@@ -29,6 +29,7 @@ import lombok.EqualsAndHashCode;
 public class SlackNotification extends Notification {
   String botName;
   @Secret String token;
+  String baseUrl;
 
   @Override
   @JsonIgnore


### PR DESCRIPTION
Allow slack notifications to be sent to compatible implementations.

spinnaker/spinnaker#4634

spinnaker/echo#633