### PR TITLE
feat(telemetry): adds endpoint and enable settings for stats collection

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -532,6 +532,10 @@
  * [**hal config storage oracle edit**](#hal-config-storage-oracle-edit)
  * [**hal config storage s3**](#hal-config-storage-s3)
  * [**hal config storage s3 edit**](#hal-config-storage-s3-edit)
+ * [**hal config telemetry**](#hal-config-telemetry)
+ * [**hal config telemetry disable**](#hal-config-telemetry-disable)
+ * [**hal config telemetry edit**](#hal-config-telemetry-edit)
+ * [**hal config telemetry enable**](#hal-config-telemetry-enable)
  * [**hal config version**](#hal-config-version)
  * [**hal config version edit**](#hal-config-version-edit)
  * [**hal config webhook**](#hal-config-webhook)
@@ -815,6 +819,7 @@ hal config [parameters] [subcommands]
  * `repository`: Configure, validate, and view the specified repository.
  * `security`: Configure Spinnaker's security. This includes external SSL, authentication mechanisms, and authorization policies.
  * `storage`: Show Spinnaker's persistent storage configuration.
+ * `telemetry`: Show Spinnaker's telemetry settings.
  * `version`: Configure & view the current deployment of Spinnaker's version.
  * `webhook`: Show Spinnaker's webhook configuration.
 
@@ -10386,6 +10391,71 @@ Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--region`: This is only required if the bucket you specify doesn't exist yet. In that case, the bucket will be created in that region. See [http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region](http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region).
  * `--root-folder`: The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
  * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
+
+
+---
+## hal config telemetry
+
+Show Spinnaker's telemetry settings.
+
+#### Usage
+```
+hal config telemetry [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `disable`: Set Spinnaker's telemetry settings to disabled.
+ * `edit`: Edit Spinnaker's telemetry settings.
+ * `enable`: Set Spinnaker's telemetry settings to enabled.
+
+---
+## hal config telemetry disable
+
+Set Spinnaker's telemetry settings to disabled.
+
+#### Usage
+```
+hal config telemetry disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config telemetry edit
+
+Edit Spinnaker's telemetry settings.
+
+#### Usage
+```
+hal config telemetry edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--endpoint`: Set the endpoint for telemetry metrics.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config telemetry enable
+
+Set Spinnaker's telemetry settings to enabled.
+
+#### Usage
+```
+hal config telemetry enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
@@ -25,6 +25,7 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.CiCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.ProviderCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.pubsubs.PubsubCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.repository.RepositoryCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry.TelemetryCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.webhook.WebhookCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
@@ -70,6 +71,7 @@ public class ConfigCommand extends AbstractConfigCommand {
     registerSubcommand(new CiCommand());
     registerSubcommand(new ListCommand());
     registerSubcommand(new RepositoryCommand());
+    registerSubcommand(new TelemetryCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/AbstractEnableDisableTelemetryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/AbstractEnableDisableTelemetryCommand.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public abstract class AbstractEnableDisableTelemetryCommand extends AbstractConfigCommand {
+  @Override
+  public String getCommandName() {
+    return isEnable() ? "enable" : "disable";
+  }
+
+  private String subjunctivePerfectAction() {
+    return isEnable() ? "enabled" : "disabled";
+  }
+
+  private String indicativePastPerfectAction() {
+    return isEnable() ? "enabled" : "disabled";
+  }
+
+  protected abstract boolean isEnable();
+
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Override
+  public String getShortDescription() {
+    return "Set Spinnaker's telemetry settings to " + subjunctivePerfectAction() + ".";
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    boolean enable = isEnable();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setTelemetryEnableDisable(currentDeployment, !noValidate, enable))
+        .setFailureMesssage("Failed to " + getCommandName() + " telemetry settings.")
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " telemetry settings.")
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryCommand.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class TelemetryCommand extends AbstractConfigCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "telemetry";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Show Spinnaker's telemetry settings.";
+
+  public TelemetryCommand() {
+    registerSubcommand(new TelemetryEditCommand());
+    registerSubcommand(new TelemetryEnableDisableCommandBuilder().setEnable(true).build());
+    registerSubcommand(new TelemetryEnableDisableCommandBuilder().setEnable(false).build());
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+
+    new OperationHandler<Telemetry>()
+        .setOperation(Daemon.getTelemetry(currentDeployment, !noValidate))
+        .setFailureMesssage("Failed to load telemetry.")
+        .setSuccessMessage("Configured telemetry: ")
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryEditCommand.java
@@ -45,7 +45,9 @@ public class TelemetryEditCommand extends AbstractConfigCommand {
             .setFailureMesssage("Failed to load telemetry settings.")
             .get();
 
-    telemetry.setEndpoint(isSet(endpoint) ? endpoint : telemetry.getEndpoint());
+    if (isSet(endpoint)) {
+      telemetry.setEndpoint(endpoint);
+    }
 
     new OperationHandler<Void>()
         .setOperation(Daemon.setTelemetry(currentDeployment, !noValidate, telemetry))

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryEditCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public class TelemetryEditCommand extends AbstractConfigCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Edit Spinnaker's telemetry settings.";
+
+  @Parameter(names = "--endpoint", description = "Set the endpoint for telemetry metrics.")
+  private String endpoint;
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    Telemetry telemetry =
+        new OperationHandler<Telemetry>()
+            .setOperation(Daemon.getTelemetry(currentDeployment, false))
+            .setFailureMesssage("Failed to load telemetry settings.")
+            .get();
+
+    telemetry.setEndpoint(isSet(endpoint) ? endpoint : telemetry.getEndpoint());
+
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setTelemetry(currentDeployment, !noValidate, telemetry))
+        .setFailureMesssage("Failed to edit telemetry settings.")
+        .setSuccessMessage("Successfully edited telemetry settings.")
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/telemetry/TelemetryEnableDisableCommandBuilder.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class TelemetryEnableDisableCommandBuilder implements CommandBuilder {
+  @Setter boolean enable;
+
+  @Override
+  public NestableCommand build() {
+    return new TelemetryEnableDisableCommand(enable);
+  }
+
+  @Parameters(separators = "=")
+  private static class TelemetryEnableDisableCommand extends AbstractEnableDisableTelemetryCommand {
+    private TelemetryEnableDisableCommand(boolean enable) {
+      this.enable = enable;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    boolean enable;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -1369,6 +1369,30 @@ public class Daemon {
     };
   }
 
+  public static Supplier<Telemetry> getTelemetry(String deploymentName, boolean validate) {
+    return () -> {
+      Object rawTelemetry =
+          ResponseUnwrapper.get(getService().getTelemetry(deploymentName, validate));
+      return getObjectMapper().convertValue(rawTelemetry, new TypeReference<Telemetry>() {});
+    };
+  }
+
+  public static Supplier<Void> setTelemetryEnableDisable(
+      String deploymentName, boolean validate, boolean enable) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setTelemetryEnabled(deploymentName, validate, enable));
+      return null;
+    };
+  }
+
+  public static Supplier<Void> setTelemetry(
+      String deploymentName, boolean validate, Telemetry telemetry) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setTelemetry(deploymentName, validate, telemetry));
+      return null;
+    };
+  }
+
   private static DaemonService service;
   private static ObjectMapper objectMapper;
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -927,6 +927,22 @@ public interface DaemonService {
       @Path("pluginName") String pluginName,
       @Query("validate") boolean validate);
 
+  @GET("/v1/config/deployments/{deploymentName}/telemetry/")
+  DaemonTask<Halconfig, Object> getTelemetry(
+      @Path("deploymentName") String deploymentName, @Query("validate") boolean validate);
+
+  @PUT("/v1/config/deployments/{deploymentName}/telemetry/")
+  DaemonTask<Halconfig, Void> setTelemetry(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Body Telemetry telemetry);
+
+  @PUT("/v1/config/deployments/{deploymentName}/telemetry/enabled/")
+  DaemonTask<Halconfig, Void> setTelemetryEnabled(
+      @Path("deploymentName") String deploymentName,
+      @Query("validate") boolean validate,
+      @Body boolean enabled);
+
   @GET("/v1/spin/install/latest")
   DaemonTask<Halconfig, Object> installSpin();
 }

--- a/halyard-cli/src/test/groovy/com/netflix/spinnaker/halyard/cli/command/v1/CommandTreeSpec.groovy
+++ b/halyard-cli/src/test/groovy/com/netflix/spinnaker/halyard/cli/command/v1/CommandTreeSpec.groovy
@@ -37,6 +37,8 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.saml.S
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.x509.X509Command
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz.AuthzCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.ui.UiSecurityCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry.TelemetryCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry.TelemetryEnableDisableCommandBuilder
 import com.netflix.spinnaker.halyard.cli.command.v1.plugins.AddPluginCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.plugins.DeletePluginCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.plugins.EditPluginCommand
@@ -99,6 +101,7 @@ class CommandTreeSpec extends Specification {
     ConfigCommand   | "security"      | SecurityCommand
     ConfigCommand   | "version"       | VersionConfigCommand
     ConfigCommand   | "ci"            | CiCommand
+    ConfigCommand   | "telemetry"     | TelemetryCommand
 
     SecurityCommand | "api"           | ApiSecurityCommand
     SecurityCommand | "authn"         | AuthnCommand

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -90,6 +90,8 @@ public class DeploymentConfiguration extends Node {
 
   Webhook webhook = new Webhook();
 
+  Telemetry telemetry = new Telemetry();
+
   @Override
   public String getNodeName() {
     return name;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
@@ -349,6 +349,11 @@ public class NodeFilter implements Cloneable {
     return this;
   }
 
+  public NodeFilter setTelemetry() {
+    matchers.add(Node.thisNodeAcceptor(Telemetry.class));
+    return this;
+  }
+
   public NodeFilter() {
     withAnyHalconfigFile();
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.node;
+
+import java.util.UUID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class Telemetry extends Node {
+
+  @Override
+  public String getNodeName() {
+    return "telemetry";
+  }
+
+  private Boolean enabled = true;
+  private String endpoint = "https://fix-me";
+  private String instanceId = UUID.randomUUID().toString();
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/TelemetryService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/TelemetryService.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.services.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class TelemetryService {
+  private final LookupService lookupService;
+  private final ValidateService validateService;
+  private final DeploymentService deploymentService;
+
+  public Telemetry getTelemetry(String deploymentName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setTelemetry();
+
+    return lookupService.getSingularNodeOrDefault(
+        filter, Telemetry.class, Telemetry::new, n -> setTelemetry(deploymentName, n));
+  }
+
+  public void setTelemetry(String deploymentName, Telemetry telemetry) {
+    DeploymentConfiguration deploymentConfiguration =
+        deploymentService.getDeploymentConfiguration(deploymentName);
+    deploymentConfiguration.setTelemetry(telemetry);
+  }
+
+  public void setTelemetryEnabled(String deploymentName, boolean validate, boolean enable) {
+    DeploymentConfiguration deploymentConfiguration =
+        deploymentService.getDeploymentConfiguration(deploymentName);
+    Telemetry telemetry = deploymentConfiguration.getTelemetry();
+    telemetry.setEnabled(enable);
+  }
+
+  public ProblemSet validateTelemetry(String deploymentName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setTelemetry();
+    return validateService.validateMatchingFilter(filter);
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidator.java
@@ -46,28 +46,27 @@ public class LdapValidator extends Validator<Ldap> {
 
     switch (UserSearchMethod.toUserSearchMethod(ldap)) {
       case DN_PATTERN: // fall through.
-      case SEARCH_AND_FILTER:
+      case SEARCH_AND_OR_BASE:
         break;
       case UNSPECIFIED_OR_INVALID: // fall through.
       default:
         p.addProblem(
             Problem.Severity.ERROR,
             "No valid user search method defined. Please "
-                + "specify with either --user-dn-pattern OR (--user-search-base and --user-search-filter).");
+                + "specify with either --user-dn-pattern OR (--user-search-filter with an optional --user-search-base).");
     }
   }
 
   enum UserSearchMethod {
     UNSPECIFIED_OR_INVALID,
     DN_PATTERN,
-    SEARCH_AND_FILTER;
+    SEARCH_AND_OR_BASE;
 
     static UserSearchMethod toUserSearchMethod(Ldap ldap) {
       if (StringUtils.isNotEmpty(ldap.getUserDnPattern())) {
         return DN_PATTERN;
-      } else if (StringUtils.isNotEmpty(ldap.getUserSearchBase())
-          && StringUtils.isNotEmpty(ldap.getUserSearchFilter())) {
-        return SEARCH_AND_FILTER;
+      } else if (StringUtils.isNotEmpty(ldap.getUserSearchFilter())) {
+        return SEARCH_AND_OR_BASE;
       }
       return UNSPECIFIED_OR_INVALID;
     }

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/security/LdapValidatorSpec.groovy
@@ -32,11 +32,13 @@ class LdapValidatorSpec extends Specification {
     problemSet.empty
 
     where:
-    description         | enabled | ldapUrl                     | userDnPattern  | userSearchBase | userSearchFilter | managerDn | managerPassword | groupSearchBase
-    "not enabled"       | false   | null                        | null           | null           | null             | null      | null            | null
-    "user DN pattern"   | true    | "ldaps://ldap.some.com:123" | "some pattern" | null           | null             | null      | null            | null
-    "search and filter" | true    | "ldap://ldap.some.com:123"  | null           | "sub"          | "ou=foo"         | null      | null            | null
-    "search and filter" | true    | "ldap://ldap.some.com:123"  | null           | "sub"          | "ou=foo"         | "admin"   | "secret"        | "ou=company"
+    description                | enabled | ldapUrl                             | userDnPattern  | userSearchBase | userSearchFilter | managerDn | managerPassword | groupSearchBase
+    "not enabled"              | false   | null                                | null           | null           | null             | null      | null            | null
+    "user DN pattern"          | true    | "ldaps://ldap.some.com:123"         | "some pattern" | null           | null             | null      | null            | null
+    "search and filter"        | true    | "ldap://ldap.some.com:123"          | null           | "sub"          | "ou=foo"         | null      | null            | null
+    "search and filter"        | true    | "ldap://ldap.some.com:123"          | null           | "sub"          | "ou=foo"         | "admin"   | "secret"        | "ou=company"
+    "search and root in url"   | true    | "ldap://ldap.some.com:123/root_dn"  | null           | null           | "ou=foo"         | "admin"   | "secret"        | "ou=company"
+    "search and root no mgr"   | true    | "ldap://ldap.some.com:123/root_dn"  | null           | null           | "ou=foo"         | null      | null            | "ou=company"
   }
 
   @Unroll

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -82,6 +82,13 @@ public class EchoProfileFactory extends SpringProfileFactory {
       }
     }
 
+    Telemetry telemetry = deploymentConfiguration.getTelemetry();
+    if (telemetry != null) {
+      profile.appendContents(
+          yamlToString(
+              deploymentConfiguration.getName(), profile, new TelemetryWrapper(telemetry)));
+    }
+
     profile.appendContents(profile.getBaseContents()).setRequiredFiles(files);
   }
 
@@ -109,6 +116,15 @@ public class EchoProfileFactory extends SpringProfileFactory {
 
     GCBWrapper(GoogleCloudBuild gcb) {
       this.gcb = gcb;
+    }
+  }
+
+  @Data
+  private static class TelemetryWrapper {
+    private Telemetry telemetry;
+
+    TelemetryWrapper(Telemetry telemetry) {
+      this.telemetry = telemetry;
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -31,11 +31,9 @@ import org.springframework.stereotype.Component;
 @Component
 public class EchoProfileFactory extends SpringProfileFactory {
 
-  @Autowired
-  String spinconfigBucket;
+  @Autowired String spinconfigBucket;
 
-  @Autowired
-  boolean gcsEnabled;
+  @Autowired boolean gcsEnabled;
 
   @Override
   public SpinnakerArtifact getArtifact() {
@@ -98,7 +96,8 @@ public class EchoProfileFactory extends SpringProfileFactory {
       // so we should only log the version if using our public releases (as indicated by using our
       // public GCS bucket).
       String telemetryVersion = "custom";
-      if (gcsEnabled && spinconfigBucket.equalsIgnoreCase(ResourceConfig.DEFAULT_HALCONFIG_BUCKET)) {
+      if (gcsEnabled
+          && spinconfigBucket.equalsIgnoreCase(ResourceConfig.DEFAULT_HALCONFIG_BUCKET)) {
         telemetryVersion = deploymentConfiguration.getVersion();
       }
       telemetry.setSpinnakerVersion(telemetryVersion);

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/TelemetryController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/TelemetryController.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1;
+
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.services.v1.TelemetryService;
+import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
+import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
+import com.netflix.spinnaker.halyard.util.v1.GenericEnableDisableRequest;
+import com.netflix.spinnaker.halyard.util.v1.GenericGetRequest;
+import com.netflix.spinnaker.halyard.util.v1.GenericUpdateRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/telemetry")
+@RequiredArgsConstructor
+public class TelemetryController {
+  private final TelemetryService telemetryService;
+  private final HalconfigDirectoryStructure halconfigDirectoryStructure;
+  private final HalconfigParser halconfigParser;
+
+  @RequestMapping(value = "/", method = RequestMethod.GET)
+  DaemonTask<Halconfig, Telemetry> getTelemetry(
+      @PathVariable String deploymentName, @ModelAttribute ValidationSettings validationSettings) {
+    return GenericGetRequest.<Telemetry>builder()
+        .getter(() -> telemetryService.getTelemetry(deploymentName))
+        .validator(() -> telemetryService.validateTelemetry(deploymentName))
+        .description("Get telemetry")
+        .build()
+        .execute(validationSettings);
+  }
+
+  @RequestMapping(value = "/enabled", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setTelemetryEnabled(
+      @PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Boolean enabled) {
+    return GenericEnableDisableRequest.builder(halconfigParser)
+        .updater(t -> telemetryService.setTelemetryEnabled(deploymentName, false, enabled))
+        .validator(() -> telemetryService.validateTelemetry(deploymentName))
+        .description("Enable or disable telemetry")
+        .build()
+        .execute(validationSettings, enabled);
+  }
+
+  @RequestMapping(value = "/", method = RequestMethod.PUT)
+  DaemonTask<Halconfig, Void> setTelemetry(
+      @PathVariable String deploymentName,
+      @ModelAttribute ValidationSettings validationSettings,
+      @RequestBody Telemetry telemetry) {
+    return GenericUpdateRequest.<Telemetry>builder(halconfigParser)
+        .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
+        .updater(t -> telemetryService.setTelemetry(deploymentName, t))
+        .validator(() -> telemetryService.validateTelemetry(deploymentName))
+        .description("Edit telemetry settings")
+        .build()
+        .execute(validationSettings, telemetry);
+  }
+}


### PR DESCRIPTION
Adds new configuration fields for telemetry. 

```
telemetry
  enabled (enabled by default)
  endpoint
  instanceId
```

[spinnaker/spinnaker#4738](https://github.com/spinnaker/spinnaker/issues/4738)