### PR TITLE
feat(secrets): Support SAML metadata as secret

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Saml.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Saml.java
@@ -30,7 +30,7 @@ public class Saml extends AuthnMethod {
   private final Method method = Method.SAML;
   private final String nodeName = "saml";
 
-  @LocalFile private String metadataLocal;
+  @LocalFile @SecretFile private String metadataLocal;
   private String metadataRemote;
   private String issuerId;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
@@ -47,7 +47,7 @@ public class SamlValidator extends Validator<Saml> {
 
     if (StringUtils.isNotEmpty(saml.getMetadataLocal())) {
       try {
-        new File(new URI("file:" + saml.getMetadataLocal()));
+        new File(new URI("file:" + validatingFileDecrypt(p, saml.getMetadataLocal())));
       } catch (Exception f) {
         p.addProblem(Problem.Severity.ERROR, f.getMessage());
       }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SamlConfig.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SamlConfig.java
@@ -33,6 +33,8 @@ public class SamlConfig {
   boolean enabled;
 
   String issuerId;
+
+  @SecretFile(prefix = "file:")
   String metadataUrl;
 
   @LocalFile
@@ -57,7 +59,7 @@ public class SamlConfig {
 
     this.enabled = saml.isEnabled();
     this.issuerId = saml.getIssuerId();
-    this.metadataUrl = "file:" + saml.getMetadataLocal();
+    this.metadataUrl = saml.getMetadataLocal();
     if (StringUtils.isNotEmpty(saml.getMetadataRemote())) {
       this.metadataUrl = saml.getMetadataRemote();
     }


### PR DESCRIPTION
Corresponding kork PR: https://github.com/spinnaker/kork/pull/372

There have been some requests to support the SAML metadata.xml file as a secret. This does so on the Halyard side and moves the SAML "file:" prefix logic to the object mapper. `metadataRemote` and `metadataLocal` in the halfconfig both get assigned to `metadataUrl` in the service yamls, so we only add the "file:" prefix if `metadataUrl` is a file path.

@plumpy PTAL?