### PR TITLE
feat(plugins): add command to update plugin options

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10581,6 +10581,7 @@ hal plugins add PLUGIN [parameters]
  * `--enabled`: To enable or disable the plugin.
  * `--manifest-location`: (*Required*) The location of the plugin's manifest file.
  * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `-O`: (*Default*: `{}`) Set custom options, must be key=value format.
 
 
 ---
@@ -10645,6 +10646,7 @@ hal plugins edit PLUGIN [parameters]
  * `--enabled`: To enable or disable the plugin.
  * `--manifest-location`: The location of the plugin's manifest file.
  * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `-O`: (*Default*: `{}`) Options for plugin. Must be key=value. Strings only!
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AddPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AddPluginCommand.java
@@ -16,11 +16,13 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
 
+import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -41,6 +43,9 @@ public class AddPluginCommand extends AbstractHasPluginCommand {
   @Parameter(names = "--enabled", description = "To enable or disable the plugin.")
   private String enabled;
 
+  @DynamicParameter(names = "-O", description = "Set custom options, must be key=value format.")
+  private HashMap<String, String> options = new HashMap<>();
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -49,7 +54,8 @@ public class AddPluginCommand extends AbstractHasPluginCommand {
         new Plugin()
             .setName(name)
             .setEnabled(isSet(enabled) ? Boolean.parseBoolean(enabled) : false)
-            .setManifestLocation(manifestLocation);
+            .setManifestLocation(manifestLocation)
+            .updateOptions(options);
 
     new OperationHandler<Void>()
         .setFailureMesssage("Failed to add plugin: " + name + ".")

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/EditPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/EditPluginCommand.java
@@ -16,11 +16,13 @@
 
 package com.netflix.spinnaker.halyard.cli.command.v1.plugins;
 
+import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
+import java.util.HashMap;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -40,6 +42,11 @@ public class EditPluginCommand extends AbstractHasPluginCommand {
   @Parameter(names = "--enabled", description = "To enable or disable the plugin.")
   private String enabled;
 
+  @DynamicParameter(
+      names = "-O",
+      description = "Options for plugin. Must be key=value. Strings only!")
+  private HashMap<String, String> options = new HashMap<>();
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -48,6 +55,8 @@ public class EditPluginCommand extends AbstractHasPluginCommand {
     plugin.setEnabled(isSet(enabled) ? Boolean.parseBoolean(enabled) : plugin.getEnabled());
     plugin.setManifestLocation(
         isSet(manifestLocation) ? manifestLocation : plugin.getManifestLocation());
+
+    plugin.updateOptions(options);
 
     new OperationHandler<Void>()
         .setFailureMesssage("Failed to edit plugin " + plugin.getName() + ".")

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Bol.com
+ * Copyright 2019 Armory, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/PluginSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/PluginSpec.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2019 Armory, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.plugins
+
+import com.netflix.spinnaker.halyard.config.error.v1.IllegalConfigException
+import spock.lang.Specification
+
+class PluginSpec extends Specification {
+
+    void "plugin merge works correctly"() {
+        setup:
+        def originalOptions = [
+                example: [
+                        url: 'host',
+                        port: 1000,
+                        nested: [
+                                foo: 'bar',
+                                key: 'value'
+                        ],
+                        list: [
+                                'first',
+                                'second'
+                        ],
+                        changeMe: [
+                                'change',
+                                'to',
+                                'integer'
+                        ],
+                        doNot: 'change'
+                ]
+        ]
+
+        def newOptions = [
+                example: [
+                        url: 'new.host',
+                        port: 2000,
+                        nested: [
+                                foo: 'baz',
+                                cat: 'dog'
+                        ],
+                        list: [
+                                'new',
+                                'list'
+                        ],
+                        changeMe: 200
+                ]
+        ]
+
+        when:
+        def subject = Plugin.merge(originalOptions, newOptions)
+
+        then:
+        def expectedOptions = [
+                example: [
+                        url: 'new.host',
+                        port: 2000,
+                        nested: [
+                                foo: 'baz',
+                                cat: 'dog',
+                                key: 'value'
+                        ],
+                        list: [
+                                'first',
+                                'second',
+                                'new',
+                                'list'
+                        ],
+                        changeMe: 200,
+                        doNot: 'change'
+                ]
+        ]
+        subject == expectedOptions
+    }
+
+    void "parseOptionHelper parses options"() {
+        expect:
+        Plugin.parseOptionHelper(key, value) == expectedMap
+
+        where:
+        key         | value | expectedMap
+        "a.b.c.d"   | "foo"  | [a: [b: [c: [d: "foo"]]]]
+    }
+
+    void "validateKey works correctly"() {
+        when:
+        Plugin.validateKey(key)
+
+        then:
+        noExceptionThrown()
+
+        where:
+        key << ["a", "a.b.c.d"]
+    }
+
+    void "validateKey throws exception on invalid keys"() {
+        when:
+        Plugin.validateKey(key)
+
+        then:
+        thrown(IllegalConfigException)
+
+        where:
+        key         | expectedMessage
+        "a.b.c.d."  | "invalid plugin option key: a.b.c.d."
+        ""          | "invalid plugin option key: "
+        "."         | "invalid plugin option key: ."
+    }
+
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/PluginServiceSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/PluginServiceSpec.groovy
@@ -49,6 +49,10 @@ deploymentConfigurations:
     plugins:
     - name: test-plugin
       manifestLocation: /home/user/test-plugin.yaml
+      options:
+        foo: bar
+        nested:
+          key: value
 """
     def pluginService = makePluginService(config)
 
@@ -60,6 +64,8 @@ deploymentConfigurations:
     result.size() == 1
     result[0].getName() == "test-plugin"
     result[0].getManifestLocation() == "/home/user/test-plugin.yaml"
+    result[0].getOptions().get("foo") == "bar"
+    result[0].getOptions().get("nested").get("key") == "value"
 
     when:
     result = pluginService.getPlugin(DEPLOYMENT, "test-plugin")

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -24,9 +24,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.integrations.IntegrationsConfigWrapper;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
@@ -86,8 +84,11 @@ public class OrcaProfileFactory extends SpringProfileFactory {
         plugins.stream()
             .filter(p -> p.getEnabled())
             .filter(p -> !p.getManifestLocation().isEmpty())
-            .map(p -> p.generateManifest())
-            .collect(Collectors.toMap(m -> m.getName(), m -> m.getOptions()));
+            .map(p -> new AbstractMap.SimpleEntry<>(p, p.generateManifest()))
+            .collect(
+                Collectors.toConcurrentMap(
+                    m -> m.getValue().getName(),
+                    m -> Plugin.merge(m.getValue().getOptions(), m.getKey().getOptions())));
 
     fullyRenderedYaml.put("plugins", pluginMetadata);
 


### PR DESCRIPTION
This PR allows administrators to use halyard in order to manage plugins configurations. Configurations in halyard override the default configurations in the plugin's manifest file. 