### PR TITLE
feat(canary): add newrelic as canary service

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -138,6 +138,15 @@
  * [**hal config canary google disable**](#hal-config-canary-google-disable)
  * [**hal config canary google edit**](#hal-config-canary-google-edit)
  * [**hal config canary google enable**](#hal-config-canary-google-enable)
+ * [**hal config canary newrelic**](#hal-config-canary-newrelic)
+ * [**hal config canary newrelic account**](#hal-config-canary-newrelic-account)
+ * [**hal config canary newrelic account add**](#hal-config-canary-newrelic-account-add)
+ * [**hal config canary newrelic account delete**](#hal-config-canary-newrelic-account-delete)
+ * [**hal config canary newrelic account edit**](#hal-config-canary-newrelic-account-edit)
+ * [**hal config canary newrelic account get**](#hal-config-canary-newrelic-account-get)
+ * [**hal config canary newrelic account list**](#hal-config-canary-newrelic-account-list)
+ * [**hal config canary newrelic disable**](#hal-config-canary-newrelic-disable)
+ * [**hal config canary newrelic enable**](#hal-config-canary-newrelic-enable)
  * [**hal config canary prometheus**](#hal-config-canary-prometheus)
  * [**hal config canary prometheus account**](#hal-config-canary-prometheus-account)
  * [**hal config canary prometheus account add**](#hal-config-canary-prometheus-account-add)
@@ -2358,6 +2367,7 @@ hal config canary [parameters] [subcommands]
  * `edit`: Edit Spinnaker's canary analysis settings.
  * `enable`: Set Spinnaker's canary analysis to enabled.
  * `google`: Configure your canary analysis Google service integration settings for Spinnaker.
+ * `newrelic`: Configure your canary analysis New Relic service integration settings for Spinnaker.
  * `prometheus`: Configure your canary analysis Prometheus service integration settings for Spinnaker.
  * `signalfx`: Configure your canary analysis SignalFx service integration settings for Spinnaker.
 
@@ -2924,6 +2934,162 @@ Set Spinnaker's canary analysis Google service integration to enabled.
 #### Usage
 ```
 hal config canary google enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic
+
+Configure your canary analysis New Relic service integration settings for Spinnaker.
+
+#### Usage
+```
+hal config canary newrelic [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `account`: Manage and view Spinnaker configuration for the newrelic service integration's canary accounts.
+ * `disable`: Set Spinnaker's canary analysis newrelic service integration to disabled.
+ * `enable`: Set Spinnaker's canary analysis newrelic service integration to enabled.
+
+---
+## hal config canary newrelic account
+
+Manage and view Spinnaker configuration for the newrelic service integration's canary accounts.
+
+#### Usage
+```
+hal config canary newrelic account ACCOUNT [parameters] [subcommands]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the canary account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `add`: Add a canary account to the NewRelic service integration.
+ * `delete`: Delete a specific newrelic canary account by name.
+ * `edit`: Edit a canary account in the newrelic service integration.
+ * `get`: Get the specified canary account details for the newrelic service integration.
+ * `list`: List the canary account names for the newrelic service integration.
+
+---
+## hal config canary newrelic account add
+
+Add a canary account to the NewRelic service integration.
+
+#### Usage
+```
+hal config canary newrelic account add ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the canary account to operate on.
+ * `--api-key`: (*Required*) (*Sensitive data* - user will be prompted on standard input) Your account's unique New Relic Insights API key. See [https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api](https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api).
+ * `--application-key`: (*Required*) Your New Relic account id. See [https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id).
+ * `--base-url`: (*Required*) The base URL to the New Relic Insights server.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic account delete
+
+Delete a specific newrelic canary account by name.
+
+#### Usage
+```
+hal config canary newrelic account delete ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the canary account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic account edit
+
+Edit a canary account in the newrelic service integration.
+
+#### Usage
+```
+hal config canary newrelic account edit ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the canary account to operate on.
+ * `--api-key`: (*Sensitive data* - user will be prompted on standard input) Your account's unique New Relic Insights API key. See [https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api](https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api).
+ * `--application-key`: Your New Relic account id. See [https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id](https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id).
+ * `--base-url`: The base URL to the New Relic Insights server.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic account get
+
+Get the specified canary account details for the newrelic service integration.
+
+#### Usage
+```
+hal config canary newrelic account get ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the canary account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic account list
+
+List the canary account names for the newrelic service integration.
+
+#### Usage
+```
+hal config canary newrelic account list [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic disable
+
+Set Spinnaker's canary analysis newrelic service integration to disabled.
+
+#### Usage
+```
+hal config canary newrelic disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary newrelic enable
+
+Set Spinnaker's canary analysis newrelic service integration to enabled.
+
+#### Usage
+```
+hal config canary newrelic enable [parameters]
 ```
 
 #### Parameters

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/CanaryNewRelicCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/CanaryNewRelicCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Google, Inc.
+ * Copyright 2019 New Relic Corporation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -14,42 +14,42 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.canary;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.canary.newrelic;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.aws.CanaryAwsCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.datadog.CanaryDatadogCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.google.CanaryGoogleCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.newrelic.CanaryNewRelicCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.prometheus.CanaryPrometheusCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.signalfx.CanarySignalfxCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.EnableDisableCanaryServiceIntegrationCommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.newrelic.account.NewRelicCanaryAccountCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryServiceIntegration;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Parameters(separators = "=")
 @Data
 @EqualsAndHashCode(callSuper = false)
-public class CanaryCommand extends AbstractConfigCommand {
+public class CanaryNewRelicCommand extends AbstractConfigCommand {
 
-  String commandName = "canary";
+  String commandName = NewRelicCanaryServiceIntegration.NAME;
 
-  String shortDescription = "Configure your canary analysis settings for Spinnaker.";
+  String shortDescription =
+      "Configure your canary analysis New Relic service integration settings for Spinnaker.";
 
-  public CanaryCommand() {
-    registerSubcommand(new EnableDisableCanaryCommandBuilder().setEnable(true).build());
-    registerSubcommand(new EnableDisableCanaryCommandBuilder().setEnable(false).build());
-    registerSubcommand(new EditCanaryCommand());
-    registerSubcommand(new CanaryGoogleCommand());
-    registerSubcommand(new CanaryPrometheusCommand());
-    registerSubcommand(new CanaryDatadogCommand());
-    registerSubcommand(new CanarySignalfxCommand());
-    registerSubcommand(new CanaryAwsCommand());
-    registerSubcommand(new CanaryNewRelicCommand());
+  public CanaryNewRelicCommand() {
+    registerSubcommand(
+        new EnableDisableCanaryServiceIntegrationCommandBuilder()
+            .setName("newrelic")
+            .setEnable(true)
+            .build());
+    registerSubcommand(
+        new EnableDisableCanaryServiceIntegrationCommandBuilder()
+            .setName("newrelic")
+            .setEnable(false)
+            .build());
+    registerSubcommand(new NewRelicCanaryAccountCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/account/NewRelicAddCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/account/NewRelicAddCanaryAccountCommand.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.canary.newrelic.account;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.account.AbstractAddCanaryAccountCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryAccount;
+
+@Parameters(separators = "=")
+public class NewRelicAddCanaryAccountCommand extends AbstractAddCanaryAccountCommand {
+
+  @Override
+  protected String getServiceIntegration() {
+    return "NewRelic";
+  }
+
+  @Parameter(
+      names = "--base-url",
+      required = true,
+      description = "The base URL to the New Relic Insights server.")
+  private String baseUrl;
+
+  @Parameter(
+      names = "--api-key",
+      required = true,
+      password = true,
+      description =
+          "Your account's unique New Relic Insights API key. See https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api.")
+  private String apiKey;
+
+  @Parameter(
+      names = "--application-key",
+      required = true,
+      description =
+          "Your New Relic account id. See https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id.")
+  private String applicationKey;
+
+  @Override
+  protected AbstractCanaryAccount buildAccount(Canary canary, String accountName) {
+    NewRelicCanaryAccount account =
+        (NewRelicCanaryAccount) new NewRelicCanaryAccount().setName(accountName);
+
+    account
+        .setEndpoint(new NewRelicCanaryAccount.Endpoint().setBaseUrl(baseUrl))
+        .setApiKey(apiKey)
+        .setApplicationKey(applicationKey);
+
+    return account;
+  }
+
+  @Override
+  protected AbstractCanaryAccount emptyAccount() {
+    return new NewRelicCanaryAccount();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/account/NewRelicCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/account/NewRelicCanaryAccountCommand.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.canary.newrelic.account;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.account.AbstractCanaryAccountCommand;
+
+/** Interact with the New Relic service integration */
+@Parameters(separators = "=")
+public class NewRelicCanaryAccountCommand extends AbstractCanaryAccountCommand {
+
+  @Override
+  protected String getServiceIntegration() {
+    return "newrelic";
+  }
+
+  public NewRelicCanaryAccountCommand() {
+    registerSubcommand(new NewRelicAddCanaryAccountCommand());
+    registerSubcommand(new NewRelicEditCanaryAccountCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/account/NewRelicEditCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/newrelic/account/NewRelicEditCanaryAccountCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.canary.newrelic.account;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.account.AbstractEditCanaryAccountCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryAccount;
+
+@Parameters(separators = "=")
+public class NewRelicEditCanaryAccountCommand
+    extends AbstractEditCanaryAccountCommand<NewRelicCanaryAccount> {
+
+  @Override
+  protected String getServiceIntegration() {
+    return "newrelic";
+  }
+
+  @Parameter(names = "--base-url", description = "The base URL to the New Relic Insights server.")
+  private String baseUrl;
+
+  @Parameter(
+      names = "--api-key",
+      password = true,
+      description =
+          "Your account's unique New Relic Insights API key. See https://docs.newrelic.com/docs/insights/insights-api/get-data/query-insights-event-data-api.")
+  private String apiKey;
+
+  @Parameter(
+      names = "--application-key",
+      description =
+          "Your New Relic account id. See https://docs.newrelic.com/docs/accounts/install-new-relic/account-setup/account-id.")
+  private String applicationKey;
+
+  @Override
+  protected AbstractCanaryAccount editAccount(NewRelicCanaryAccount account) {
+    account.setEndpoint(
+        isSet(baseUrl)
+            ? new NewRelicCanaryAccount.Endpoint().setBaseUrl(baseUrl)
+            : account.getEndpoint());
+    account.setApiKey(isSet(apiKey) ? apiKey : account.getApiKey());
+    account.setApplicationKey(isSet(applicationKey) ? applicationKey : account.getApplicationKey());
+
+    return account;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/AbstractCanaryServiceIntegration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/AbstractCanaryServiceIntegration.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.aws.AwsCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.datadog.DatadogCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryServiceIntegration;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.prometheus.PrometheusCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.signalfx.SignalfxCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Node;
@@ -48,7 +49,10 @@ import lombok.EqualsAndHashCode;
       name = SignalfxCanaryServiceIntegration.NAME),
   @JsonSubTypes.Type(
       value = AwsCanaryServiceIntegration.class,
-      name = AwsCanaryServiceIntegration.NAME)
+      name = AwsCanaryServiceIntegration.NAME),
+  @JsonSubTypes.Type(
+      value = NewRelicCanaryServiceIntegration.class,
+      name = NewRelicCanaryServiceIntegration.NAME)
 })
 @Data
 @EqualsAndHashCode(callSuper = false)

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/Canary.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/Canary.java
@@ -23,6 +23,8 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.datadog.DatadogCanar
 import com.netflix.spinnaker.halyard.config.model.v1.canary.datadog.DatadogCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryServiceIntegration;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.prometheus.PrometheusCanaryAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.prometheus.PrometheusCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.signalfx.SignalfxCanaryAccount;
@@ -45,7 +47,9 @@ public class Canary extends Node implements Cloneable {
           new PrometheusCanaryServiceIntegration(),
           new DatadogCanaryServiceIntegration(),
           new SignalfxCanaryServiceIntegration(),
-          new AwsCanaryServiceIntegration());
+          new AwsCanaryServiceIntegration(),
+          new NewRelicCanaryServiceIntegration());
+
   boolean reduxLoggerEnabled = true;
   String defaultMetricsAccount;
   String defaultStorageAccount;
@@ -80,6 +84,8 @@ public class Canary extends Node implements Cloneable {
         return SignalfxCanaryAccount.class;
       case AwsCanaryServiceIntegration.NAME:
         return AwsCanaryAccount.class;
+      case NewRelicCanaryServiceIntegration.NAME:
+        return NewRelicCanaryAccount.class;
       default:
         throw new IllegalArgumentException(
             "No account type for canary service integration " + serviceIntegrationName + ".");

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/newrelic/NewRelicCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/newrelic/NewRelicCanaryAccount.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic;
+
+import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryServiceIntegration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
+import java.util.Collections;
+import java.util.Set;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Slf4j
+public class NewRelicCanaryAccount extends AbstractCanaryAccount implements Cloneable {
+  private Endpoint endpoint;
+  @Secret private String apiKey;
+  @Secret private String applicationKey;
+  private Set<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes =
+      Collections.singleton(AbstractCanaryServiceIntegration.SupportedTypes.METRICS_STORE);
+
+  @Data
+  public static class Endpoint {
+    private String baseUrl;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/newrelic/NewRelicCanaryServiceIntegration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/newrelic/NewRelicCanaryServiceIntegration.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 New Relic Corporation. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic;
+
+import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryServiceIntegration;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@Slf4j
+public class NewRelicCanaryServiceIntegration
+    extends AbstractCanaryServiceIntegration<NewRelicCanaryAccount> implements Cloneable {
+  public static final String NAME = "newrelic";
+
+  String name = NAME;
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KayentaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KayentaProfileFactory.java
@@ -24,6 +24,8 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.datadog.DatadogCanar
 import com.netflix.spinnaker.halyard.config.model.v1.canary.datadog.DatadogCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.google.GoogleCanaryServiceIntegration;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.newrelic.NewRelicCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.prometheus.PrometheusCanaryAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.prometheus.PrometheusCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.signalfx.SignalfxCanaryAccount;
@@ -93,6 +95,7 @@ public class KayentaProfileFactory extends SpringProfileFactory {
       AwsConfig aws;
       S3Config s3;
       SignalFxConfig signalfx;
+      NewRelicConfig newrelic;
 
       KayentaConfig(Canary canary) {
         for (AbstractCanaryServiceIntegration svc : canary.getServiceIntegrations()) {
@@ -115,6 +118,9 @@ public class KayentaProfileFactory extends SpringProfileFactory {
           } else if (svc instanceof SignalfxCanaryServiceIntegration) {
             SignalfxCanaryServiceIntegration signalfxSvc = (SignalfxCanaryServiceIntegration) svc;
             signalfx = new SignalFxConfig(signalfxSvc);
+          } else if (svc instanceof NewRelicCanaryServiceIntegration) {
+            NewRelicCanaryServiceIntegration newRelicSvc = (NewRelicCanaryServiceIntegration) svc;
+            newrelic = new NewRelicConfig(newRelicSvc);
           }
         }
       }
@@ -202,6 +208,17 @@ public class KayentaProfileFactory extends SpringProfileFactory {
         SignalFxConfig(SignalfxCanaryServiceIntegration signalfxSvc) {
           enabled = signalfxSvc.isEnabled();
           accounts = signalfxSvc.getAccounts();
+        }
+      }
+
+      @Data
+      static class NewRelicConfig {
+        private boolean enabled;
+        List<NewRelicCanaryAccount> accounts;
+
+        NewRelicConfig(NewRelicCanaryServiceIntegration newRelicSvc) {
+          enabled = newRelicSvc.isEnabled();
+          accounts = newRelicSvc.getAccounts();
         }
       }
     }


### PR DESCRIPTION
This allows New Relic to be added as a kayenta canary service via halyard.

The only bit of this I wasn't sure about is how this new field will get generated in to the hal config. I'm guessing that a halyard version update will do something similar to `hal config generate` to get it in there?