### PR TITLE
feat(config): support disable new version check

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8515,6 +8515,7 @@ When no context is configured for an account the 'current-context' in your kubec
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) A list of the Spinnaker docker registry account names this Spinnaker account can use as image sources. These docker registry accounts must be registered in your halconfig before you can add them here.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
+ * `--is-cluster-registry`: (*Default*: `false`) Sync k8s account from this cluster using cluster registry crd only support true/false
  * `--kinds`: (*Default*: `[]`) (V2 Only) A list of resource kinds this Spinnaker account can deploy to and will cache.
 When no kinds are configured, this defaults to 'all kinds described here [https://spinnaker.io/reference/providers/kubernetes-v2/](https://spinnaker.io/reference/providers/kubernetes-v2/)'.
  * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -436,9 +436,11 @@
  * [**hal config provider kubernetes account edit**](#hal-config-provider-kubernetes-account-edit)
  * [**hal config provider kubernetes account get**](#hal-config-provider-kubernetes-account-get)
  * [**hal config provider kubernetes account list**](#hal-config-provider-kubernetes-account-list)
+ * [**hal config provider kubernetes account sync**](#hal-config-provider-kubernetes-account-sync)
  * [**hal config provider kubernetes disable**](#hal-config-provider-kubernetes-disable)
  * [**hal config provider kubernetes edit**](#hal-config-provider-kubernetes-edit)
  * [**hal config provider kubernetes enable**](#hal-config-provider-kubernetes-enable)
+ * [**hal config provider kubernetes sync**](#hal-config-provider-kubernetes-sync)
  * [**hal config provider oracle**](#hal-config-provider-oracle)
  * [**hal config provider oracle account**](#hal-config-provider-oracle-account)
  * [**hal config provider oracle account add**](#hal-config-provider-oracle-account-add)
@@ -8469,6 +8471,7 @@ hal config provider kubernetes [parameters] [subcommands]
  * `disable`: Set the kubernetes provider as disabled
  * `edit`: Set provider-wide properties for the Kubernetes provider
  * `enable`: Set the kubernetes provider as enabled
+ * `sync`: sync account from the kubernetes provider cluster registry.
 
 ---
 ## hal config provider kubernetes account
@@ -8493,6 +8496,7 @@ hal config provider kubernetes account ACCOUNT [parameters] [subcommands]
  * `edit`: Edit an account in the kubernetes provider.
  * `get`: Get the specified account details for the kubernetes provider.
  * `list`: List the account names for the kubernetes provider.
+ * `sync`: sync account from the kubernetes provider cluster registry.
 
 ---
 ## hal config provider kubernetes account add
@@ -8515,7 +8519,6 @@ When no context is configured for an account the 'current-context' in your kubec
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) A list of the Spinnaker docker registry account names this Spinnaker account can use as image sources. These docker registry accounts must be registered in your halconfig before you can add them here.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
- * `--is-cluster-registry`: (*Default*: `false`) Sync k8s account from this cluster using cluster registry crd only support true/false
  * `--kinds`: (*Default*: `[]`) (V2 Only) A list of resource kinds this Spinnaker account can deploy to and will cache.
 When no kinds are configured, this defaults to 'all kinds described here [https://spinnaker.io/reference/providers/kubernetes-v2/](https://spinnaker.io/reference/providers/kubernetes-v2/)'.
  * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
@@ -8646,6 +8649,23 @@ hal config provider kubernetes account list [parameters]
 
 
 ---
+## hal config provider kubernetes account sync
+
+sync account from the kubernetes provider cluster registry.
+
+#### Usage
+```
+hal config provider kubernetes account sync ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
 ## hal config provider kubernetes disable
 
 Set the kubernetes provider as disabled
@@ -8687,6 +8707,23 @@ hal config provider kubernetes enable [parameters]
 
 #### Parameters
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider kubernetes sync
+
+sync account from the kubernetes provider cluster registry.
+
+#### Usage
+```
+hal config provider kubernetes sync ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--kubeconfig-file`: The path to your kubeconfig file. By default, it will be under the Spinnaker user's home directory in the typical .kube/config location.
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -23,6 +23,8 @@ dependencies {
     force = true
   }
   implementation 'org.nibor.autolink:autolink:0.10.0'
+  implementation 'io.swagger:swagger-annotations:1.5.12'
+  implementation 'io.alauda:cluster-registry-client-java:1.0.3'
 
   implementation project(':halyard-config')
   implementation project(':halyard-core')

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAccountCommand.java
@@ -42,5 +42,6 @@ public class KubernetesAccountCommand extends AbstractAccountCommand {
     super();
     registerSubcommand(new KubernetesAddAccountCommand());
     registerSubcommand(new KubernetesEditAccountCommand());
+    registerSubcommand(new KubernetesSyncAccountCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -119,12 +119,6 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
       description = KubernetesCommandProperties.CACHE_THREADS)
   private int cacheThreads = 1;
 
-  @Parameter(
-            names = "--is-cluster-registry",
-            arity = 1,
-            description = KubernetesCommandProperties.CLUSTER_REGISTRY)
-  private Boolean isClusterRegistry = false;
-
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -149,7 +143,6 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     account.setLiveManifestCalls(liveManifestCalls);
     account.setCacheThreads(cacheThreads);
-    account.setIsClusterRegistry(isClusterRegistry);
     return account;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -119,6 +119,12 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
       description = KubernetesCommandProperties.CACHE_THREADS)
   private int cacheThreads = 1;
 
+  @Parameter(
+            names = "--is-cluster-registry",
+            arity = 1,
+            description = KubernetesCommandProperties.CLUSTER_REGISTRY)
+  private Boolean isClusterRegistry = false;
+
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -143,6 +149,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     account.setLiveManifestCalls(liveManifestCalls);
     account.setCacheThreads(cacheThreads);
+    account.setIsClusterRegistry(isClusterRegistry);
     return account;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommand.java
@@ -43,5 +43,6 @@ public class KubernetesCommand extends AbstractNamedProviderCommand {
     super();
     registerSubcommand(new KubernetesAccountCommand());
     registerSubcommand(new KubernetesEditProviderCommand());
+    registerSubcommand(new KubernetesSyncAccountCommand());
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -69,4 +69,7 @@ public class KubernetesCommandProperties {
   static final String CACHE_THREADS =
       "Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. "
           + "By default, only 1 agent caches all kinds for all namespaces in the account.";
+
+    static final String CLUSTER_REGISTRY =
+        "Sync k8s account from this cluster using cluster registry crd only support true/false";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -70,6 +70,6 @@ public class KubernetesCommandProperties {
       "Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. "
           + "By default, only 1 agent caches all kinds for all namespaces in the account.";
 
-    static final String CLUSTER_REGISTRY =
-        "Sync k8s account from this cluster using cluster registry crd only support true/false";
+  static final String CLUSTER_REGISTRY =
+      "Sync k8s account from this cluster using cluster registry crd only support true/false";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesSyncAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesSyncAccountCommand.java
@@ -11,96 +11,99 @@ import com.netflix.spinnaker.halyard.cli.utils.k8s.K8s;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import java.util.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-import java.util.*;
-
 @Parameters(separators = "=")
-public  class KubernetesSyncAccountCommand extends AbstractHasAccountCommand {
+public class KubernetesSyncAccountCommand extends AbstractHasAccountCommand {
 
-    @Getter(AccessLevel.PROTECTED)
-    private Map<String, NestableCommand> subcommands = new HashMap<>();
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
 
-    @Getter(AccessLevel.PUBLIC)
-    private String commandName = "sync";
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "sync";
 
-    @Parameter(
-            names = "--kubeconfig-file",
-            converter = LocalFileConverter.class,
-            description = KubernetesCommandProperties.KUBECONFIG_DESCRIPTION)
-    private String kubeconfigFile;
+  @Parameter(
+      names = "--kubeconfig-file",
+      converter = LocalFileConverter.class,
+      description = KubernetesCommandProperties.KUBECONFIG_DESCRIPTION)
+  private String kubeconfigFile;
 
-    protected Account buildAccount(String accountName) {
-        KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
-        account.setKubeconfigFile(kubeconfigFile);
-        return account;
-    }
+  protected Account buildAccount(String accountName) {
+    KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
+    account.setKubeconfigFile(kubeconfigFile);
+    return account;
+  }
 
-    protected Account emptyAccount() {
-        return new KubernetesAccount();
-    }
+  protected Account emptyAccount() {
+    return new KubernetesAccount();
+  }
 
-    public String getShortDescription() {
-        return "sync account from the " + getProviderName() + " provider cluster registry.";
-    }
+  public String getShortDescription() {
+    return "sync account from the " + getProviderName() + " provider cluster registry.";
+  }
 
-    @Override
-    protected List<String> options(String fieldName) {
-        String currentDeployment = getCurrentDeployment();
-        String accountName = getAccountName("hal-default-account");
-        Account account = buildAccount(accountName);
-        String providerName = getProviderName();
+  @Override
+  protected List<String> options(String fieldName) {
+    String currentDeployment = getCurrentDeployment();
+    String accountName = getAccountName("hal-default-account");
+    Account account = buildAccount(accountName);
+    String providerName = getProviderName();
 
-        return new OperationHandler<List<String>>()
-                .setFailureMesssage("Failed to get options for field " + fieldName)
-                .setOperation(
-                        Daemon.getNewAccountOptions(currentDeployment, providerName, fieldName, account))
-                .get();
-    }
+    return new OperationHandler<List<String>>()
+        .setFailureMesssage("Failed to get options for field " + fieldName)
+        .setOperation(
+            Daemon.getNewAccountOptions(currentDeployment, providerName, fieldName, account))
+        .get();
+  }
 
-    @Override
-    protected void executeThis() {
-        String accountName = getAccountName();
-        Account account = buildAccount(accountName);
-        String providerName = getProviderName();
-        String currentDeployment = getCurrentDeployment();
-        if (providerName.equals("kubernetes")) {
-            Provider provider = getProvider();
-            List<Account> accounts = provider.getAccounts();
-            Set<String> accountNameSet = new HashSet<>();
-            for (Account a: accounts){
-                accountNameSet.add(a.getName());
-            }
-            KubernetesAccount k8sAccount = (KubernetesAccount) account;
-            List<KubernetesAccount> kubernetesAccounts = K8s.ListCluster(k8sAccount.getKubeconfigFile());
-            for(KubernetesAccount K8sAC: kubernetesAccounts){
-                if (accounts.contains(K8sAC.getName())){
-                    System.out.printf("account %s exist should not add\n",K8sAC.getName());
-                    continue;
-                }
-                new OperationHandler<Void>()
-                        .setFailureMesssage(
-                                "Failed to add account " + K8sAC.getName() + " for provider " + providerName + ".")
-                        .setSuccessMessage(
-                                "Successfully added account " + K8sAC.getName() + " for provider " + providerName + ".")
-                        .setOperation(Daemon.addAccount(currentDeployment, providerName, !noValidate, K8sAC))
-                        .get();
-            }
+  @Override
+  protected void executeThis() {
+    String accountName = getAccountName();
+    Account account = buildAccount(accountName);
+    String providerName = getProviderName();
+    String currentDeployment = getCurrentDeployment();
+    if (providerName.equals("kubernetes")) {
+      Provider provider = getProvider();
+      List<Account> accounts = provider.getAccounts();
+      Set<String> accountNameSet = new HashSet<>();
+      for (Account a : accounts) {
+        accountNameSet.add(a.getName());
+      }
+      KubernetesAccount k8sAccount = (KubernetesAccount) account;
+      List<KubernetesAccount> kubernetesAccounts = K8s.ListCluster(k8sAccount.getKubeconfigFile());
+      for (KubernetesAccount K8sAC : kubernetesAccounts) {
+        if (accounts.contains(K8sAC.getName())) {
+          System.out.printf("account %s exist should not add\n", K8sAC.getName());
+          continue;
         }
+        new OperationHandler<Void>()
+            .setFailureMesssage(
+                "Failed to add account " + K8sAC.getName() + " for provider " + providerName + ".")
+            .setSuccessMessage(
+                "Successfully added account "
+                    + K8sAC.getName()
+                    + " for provider "
+                    + providerName
+                    + ".")
+            .setOperation(Daemon.addAccount(currentDeployment, providerName, !noValidate, K8sAC))
+            .get();
+      }
     }
+  }
 
-    private Provider getProvider() {
-        String currentDeployment = getCurrentDeployment();
-        String providerName = getProviderName();
-        return new OperationHandler<Provider>()
-                .setFailureMesssage("Failed to get provider " + providerName + ".")
-                .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
-                .get();
-    }
+  private Provider getProvider() {
+    String currentDeployment = getCurrentDeployment();
+    String providerName = getProviderName();
+    return new OperationHandler<Provider>()
+        .setFailureMesssage("Failed to get provider " + providerName + ".")
+        .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+        .get();
+  }
 
-    @Override
-    protected String getProviderName() {
-        return "kubernetes";
-    }
+  @Override
+  protected String getProviderName() {
+    return "kubernetes";
+  }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesSyncAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesSyncAccountCommand.java
@@ -1,0 +1,106 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.kubernetes;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractHasAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.utils.k8s.K8s;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.util.*;
+
+@Parameters(separators = "=")
+public  class KubernetesSyncAccountCommand extends AbstractHasAccountCommand {
+
+    @Getter(AccessLevel.PROTECTED)
+    private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+    @Getter(AccessLevel.PUBLIC)
+    private String commandName = "sync";
+
+    @Parameter(
+            names = "--kubeconfig-file",
+            converter = LocalFileConverter.class,
+            description = KubernetesCommandProperties.KUBECONFIG_DESCRIPTION)
+    private String kubeconfigFile;
+
+    protected Account buildAccount(String accountName) {
+        KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
+        account.setKubeconfigFile(kubeconfigFile);
+        return account;
+    }
+
+    protected Account emptyAccount() {
+        return new KubernetesAccount();
+    }
+
+    public String getShortDescription() {
+        return "sync account from the " + getProviderName() + " provider cluster registry.";
+    }
+
+    @Override
+    protected List<String> options(String fieldName) {
+        String currentDeployment = getCurrentDeployment();
+        String accountName = getAccountName("hal-default-account");
+        Account account = buildAccount(accountName);
+        String providerName = getProviderName();
+
+        return new OperationHandler<List<String>>()
+                .setFailureMesssage("Failed to get options for field " + fieldName)
+                .setOperation(
+                        Daemon.getNewAccountOptions(currentDeployment, providerName, fieldName, account))
+                .get();
+    }
+
+    @Override
+    protected void executeThis() {
+        String accountName = getAccountName();
+        Account account = buildAccount(accountName);
+        String providerName = getProviderName();
+        String currentDeployment = getCurrentDeployment();
+        if (providerName.equals("kubernetes")) {
+            Provider provider = getProvider();
+            List<Account> accounts = provider.getAccounts();
+            Set<String> accountNameSet = new HashSet<>();
+            for (Account a: accounts){
+                accountNameSet.add(a.getName());
+            }
+            KubernetesAccount k8sAccount = (KubernetesAccount) account;
+            List<KubernetesAccount> kubernetesAccounts = K8s.ListCluster(k8sAccount.getKubeconfigFile());
+            for(KubernetesAccount K8sAC: kubernetesAccounts){
+                if (accounts.contains(K8sAC.getName())){
+                    System.out.printf("account %s exist should not add\n",K8sAC.getName());
+                    continue;
+                }
+                new OperationHandler<Void>()
+                        .setFailureMesssage(
+                                "Failed to add account " + K8sAC.getName() + " for provider " + providerName + ".")
+                        .setSuccessMessage(
+                                "Successfully added account " + K8sAC.getName() + " for provider " + providerName + ".")
+                        .setOperation(Daemon.addAccount(currentDeployment, providerName, !noValidate, K8sAC))
+                        .get();
+            }
+        }
+    }
+
+    private Provider getProvider() {
+        String currentDeployment = getCurrentDeployment();
+        String providerName = getProviderName();
+        return new OperationHandler<Provider>()
+                .setFailureMesssage("Failed to get provider " + providerName + ".")
+                .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+                .get();
+    }
+
+    @Override
+    protected String getProviderName() {
+        return "kubernetes";
+    }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/utils/k8s/K8s.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/utils/k8s/K8s.java
@@ -1,0 +1,79 @@
+package com.netflix.spinnaker.halyard.cli.utils.k8s;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import io.alauda.devops.java.clusterregistry.client.apis.ClusterregistryK8sIoV1alpha1Api;
+import io.alauda.devops.java.clusterregistry.client.models.V1alpha1Cluster;
+import io.alauda.devops.java.clusterregistry.client.models.V1alpha1ClusterList;
+import io.kubernetes.client.ApiClient;
+import io.kubernetes.client.ApiException;
+import io.kubernetes.client.Configuration;
+import io.kubernetes.client.apis.CoreV1Api;
+import io.kubernetes.client.models.V1Secret;
+import io.kubernetes.client.models.V1SecretList;
+import io.kubernetes.client.util.ClientBuilder;
+import io.kubernetes.client.util.KubeConfig;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class K8s {
+
+    public static ClusterregistryK8sIoV1alpha1Api GetApi(String kubeconfig) throws IOException {
+        ApiClient client =
+                ClientBuilder.kubeconfig(KubeConfig.loadKubeConfig(new FileReader(kubeconfig))).build();
+        Configuration.setDefaultApiClient(client);
+        ClusterregistryK8sIoV1alpha1Api api = new ClusterregistryK8sIoV1alpha1Api(client);
+        return api;
+    }
+
+    public static List<KubernetesAccount> ListCluster(String kubeconfig) {
+        List<KubernetesAccount> clusters = new ArrayList<>();
+        try {
+            V1alpha1ClusterList v1alpha1ClusterList = GetApi(kubeconfig).listClusterForAllNamespaces("", "", false, "", 0
+                    , "", "", 0, false);
+            for (V1alpha1Cluster c: v1alpha1ClusterList.getItems()) {
+                clusters.add(ConvertK8sAccount(c));
+            }
+        } catch (ApiException | IOException e) {
+            e.printStackTrace();
+        }
+        return clusters;
+    }
+    public static KubernetesAccount ConvertK8sAccount(V1alpha1Cluster cluster) throws ApiException, IOException {
+        System.out.printf("cluster name:%s\n",cluster.getMetadata().getName());
+        System.out.printf("secret: %s\n", cluster.getSpec().getAuthInfo().getUser().getName());
+        KubernetesAccount account = new KubernetesAccount();
+        account.setName(cluster.getMetadata().getName());
+        account.setProviderVersion(Provider.ProviderVersion.V2);
+        CoreV1Api api = new CoreV1Api();
+        V1SecretList v1SecretList = api.listNamespacedSecret(
+                cluster.getSpec().getAuthInfo().getUser().getNamespace(),
+                null, null, null, null,
+                null, null, null, null);
+        for (V1Secret sec: v1SecretList.getItems()) {
+            if (sec.getMetadata().getName().equals(cluster.getSpec().getAuthInfo().getUser().getName())){
+                for(String key: sec.getData().keySet()){
+                    String str = System.getProperties().getProperty("user.home") + "/.hal/tmp-k8s-conf-" + account.getName();
+                    Path path = Paths.get(str);
+                    if(!Files.exists(path)) {
+                        try {
+                            Files.createFile(path);
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    Files.write(path, sec.getData().get(key));
+                    account.setKubeconfigFile(str);
+                }
+            }
+        }
+
+        return account;
+    }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/utils/k8s/testK8s.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/utils/k8s/testK8s.java
@@ -1,16 +1,13 @@
 package com.netflix.spinnaker.halyard.cli.utils.k8s;
 
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
-
 import java.util.List;
 
 public class testK8s {
-    public static void main(String[] args) {
-        List<KubernetesAccount> kubernetesAccounts = K8s.ListCluster("/Users/ruizou/.kube/config");
-        for (KubernetesAccount k:
-             kubernetesAccounts) {
-            System.out.println(k.getName());
-        }
+  public static void main(String[] args) {
+    List<KubernetesAccount> kubernetesAccounts = K8s.ListCluster("/Users/ruizou/.kube/config");
+    for (KubernetesAccount k : kubernetesAccounts) {
+      System.out.println(k.getName());
     }
+  }
 }
-

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/utils/k8s/testK8s.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/utils/k8s/testK8s.java
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.halyard.cli.utils.k8s;
+
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+
+import java.util.List;
+
+public class testK8s {
+    public static void main(String[] args) {
+        List<KubernetesAccount> kubernetesAccounts = K8s.ListCluster("/Users/ruizou/.kube/config");
+        for (KubernetesAccount k:
+             kubernetesAccounts) {
+            System.out.println(k.getName());
+        }
+    }
+}
+

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -91,6 +91,8 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
 
   Boolean debug;
 
+  Boolean isClusterRegistry;
+
   public boolean usesServiceAccount() {
     return serviceAccount != null && serviceAccount;
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -23,11 +23,12 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ValidForSpinnakerVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.apache.commons.lang3.StringUtils;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -90,8 +91,6 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
   Boolean onlySpinnakerManaged;
 
   Boolean debug;
-
-  Boolean isClusterRegistry;
 
   public boolean usesServiceAccount() {
     return serviceAccount != null && serviceAccount;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidator.java
@@ -29,16 +29,25 @@ import java.io.File;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
 public class HalconfigValidator extends Validator<Halconfig> {
+
   @Autowired VersionsService versionsService;
+
+  @Value("${spinnaker.config.versionCheckEnabled}")
+  public boolean versionCheckEnabled;
 
   @Override
   public void validate(ConfigProblemSetBuilder p, Halconfig n) {
     try {
+      if (!versionCheckEnabled) {
+        log.warn("you had been disabled version check, your spinnaker and halyard my be old");
+        return;
+      }
       String runningVersion = versionsService.getRunningHalyardVersion();
       String latestVersion = versionsService.getLatestHalyardVersion();
 

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidatorSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/validate/v1/HalconfigValidatorSpec.groovy
@@ -29,6 +29,7 @@ class HalconfigValidatorSpec extends Specification {
     versionsServiceMock.getLatestHalyardVersion() >> latest
     versionsServiceMock.getRunningHalyardVersion() >> current
     HalconfigValidator validator = new HalconfigValidator()
+    validator.versionCheckEnabled = true
     validator.versionsService = versionsServiceMock
 
     ConfigProblemSetBuilder problemBuilder = new ConfigProblemSetBuilder(null);

--- a/halyard-web/config/halyard.yml
+++ b/halyard-web/config/halyard.yml
@@ -18,6 +18,7 @@ spinnaker:
         enabled: true
       writerEnabled: false
       bucket: halconfig
+    versionCheckEnabled: true
 
 management:
   endpoint:


### PR DESCRIPTION
in some enviroment there are no internet. some command will block by version check.
eg: `hal config provider kubernetes account add`
I add a config (`spinnaker.config.versionCheckEnabled`). user cloud disable version check.

Signed-off-by: xiaorui.zou <zourui@mskj.com>