### PR TITLE
fix(kubeconfig): Get contents of local kubeconfig files

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KubernetesV2ClouddriverProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KubernetesV2ClouddriverProfileFactory.java
@@ -159,12 +159,12 @@ public class KubernetesV2ClouddriverProfileFactory extends ClouddriverProfileFac
         return secretSessionManager.decrypt(kubeconfigFile);
       }
 
+      String localPath = kubeconfigFile;
       if (CloudConfigResourceService.isCloudConfigResource(kubeconfigFile)) {
-        String localPath = cloudConfigResourceService.getLocalPath(kubeconfigFile);
-        return configFileService.getContents(localPath);
+        localPath = cloudConfigResourceService.getLocalPath(kubeconfigFile);
       }
 
-      return kubeconfigFile;
+      return configFileService.getContents(localPath);
     } catch (Exception e) {
       throw new IllegalStateException(
           "Failed to read kubeconfig file '"


### PR DESCRIPTION
Fix for https://github.com/spinnaker/spinnaker/issues/4906

The method was returning the path of the `kubeconfig` file instead of its contents, when the file was stored locally.