### PR TITLE
fix(saml): make email address configurable

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9798,6 +9798,7 @@ hal config security authn saml edit [parameters]
  * `--metadata`: The address to your identity provider's metadata XML file. This can be a URL or the path of a local file.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--service-address-url`: The address of the Gate server that will be accesible by the SAML identity provider. This should be the full URL, including port, e.g. [https://gate.org.com:8084/](https://gate.org.com:8084/). If deployed behind a load balancer, this would be the laod balancer's address.
+ * `--user-attribute-mapping-email`: The email field returned from your SAML provider.
  * `--user-attribute-mapping-first-name`: The first name field returned from your SAML provider.
  * `--user-attribute-mapping-last-name`: The last name field returned from your SAML provider.
  * `--user-attribute-mapping-roles`: The roles field returned from your SAML provider.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/saml/EditSamlCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/saml/EditSamlCommand.java
@@ -106,6 +106,11 @@ public class EditSamlCommand extends AbstractEditAuthnMethodCommand<Saml> {
       description = "The roles delimiter field returned from your SAML provider.")
   private String userAttributeMappingRolesDelimiter;
 
+  @Parameter(
+      names = "--user-attribute-mapping-email",
+      description = "The email field returned from your SAML provider.")
+  private String userAttributeMappingEmail;
+
   @Override
   protected AuthnMethod editAuthnMethod(Saml s) {
     s.setIssuerId(isSet(issuerId) ? issuerId : s.getIssuerId());
@@ -145,6 +150,10 @@ public class EditSamlCommand extends AbstractEditAuthnMethodCommand<Saml> {
         isSet(userAttributeMappingUsername)
             ? userAttributeMappingUsername
             : userAttributeMapping.getUsername());
+    userAttributeMapping.setEmail(
+        isSet(userAttributeMappingEmail)
+            ? userAttributeMappingEmail
+            : userAttributeMapping.getEmail());
 
     return s;
   }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Saml.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/Saml.java
@@ -49,5 +49,6 @@ public class Saml extends AuthnMethod {
     private String roles;
     private String rolesDelimiter;
     private String username;
+    private String email;
   }
 }


### PR DESCRIPTION
Adds to https://github.com/spinnaker/gate/pull/907 by making the user attribute for email address configurable through halyard commands

Helps fix : https://github.com/spinnaker/spinnaker/issues/4924