### PR TITLE
feat(localgit): support git origin baseurl overrides

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5577,6 +5577,7 @@ hal config deploy edit [parameters]
 This is only required when Spinnaker is being deployed in non-Kubernetes clustered configuration.
  * `--consul-enabled`: Whether or not to use Consul as a service discovery mechanism to deploy Spinnaker.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--git-origin-baseurl`: This is the git base url that your fork exists under. (defaults to 'git@github.com:')
  * `--git-origin-user`: This is the git user your github fork exists under.
  * `--git-upstream-user`: This is the upstream git user you are configuring to pull changes from & push PRs to.
  * `--image-variant`: The container image variant type to use when deploying a distributed installation of Spinnaker.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -128,6 +128,12 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
   private String gitOriginUser;
 
   @Parameter(
+      names = "--git-origin-baseurl",
+      description =
+          "This is the git base url that your fork exists under. (defaults to 'git@github.com:')")
+  private String gitOriginBaseUrl;
+
+  @Parameter(
       names = "--liveness-probe-enabled",
       arity = 1,
       description =
@@ -161,6 +167,8 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
     gitConfig.setOriginUser(isSet(gitOriginUser) ? gitOriginUser : gitConfig.getOriginUser());
     gitConfig.setUpstreamUser(
         isSet(gitUpstreamUser) ? gitUpstreamUser : gitConfig.getUpstreamUser());
+    gitConfig.setOriginBaseUrl(
+        isSet(gitOriginBaseUrl) ? gitOriginBaseUrl : gitConfig.getOriginBaseUrl());
     deploymentEnvironment.setGitConfig(gitConfig);
 
     DeploymentEnvironment.Consul consul = deploymentEnvironment.getConsul();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -161,6 +161,7 @@ public class DeploymentEnvironment extends Node {
   public static class GitConfig {
     String upstreamUser = "spinnaker";
     String originUser;
+    String originBaseUrl = "git@github.com:";
   }
 
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/git/LocalGitService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/git/LocalGitService.java
@@ -109,7 +109,7 @@ public interface LocalGitService<T> extends LocalService<T> {
     boolean update = env.getUpdateVersions();
 
     bindings.put("update", update ? "true" : "");
-    bindings.put("origin", gitConfig.getOriginUser());
+    bindings.put("origin", gitConfig.getOriginBaseUrl() + gitConfig.getOriginUser());
     bindings.put("upstream", gitConfig.getUpstreamUser());
 
     TemplatedResource prepResource = new StringReplaceJarResource("/git/prep-component.sh");

--- a/halyard-deploy/src/main/resources/git/prep-component.sh
+++ b/halyard-deploy/src/main/resources/git/prep-component.sh
@@ -13,7 +13,7 @@ REPO={%repo%}
 UPDATE={%update%}
 
 ## TODO(lwander): make configurable
-ORIGIN_URL=git@github.com:{%origin%}/${REPO}.git
+ORIGIN_URL={%origin%}/${REPO}.git
 UPSTREAM_URL=git@github.com:{%upstream%}/${REPO}.git
 
 if [ ! -d $ARTIFACT ]; then


### PR DESCRIPTION
## What:
Added `--git-origin-baseurl` flag to setup localgit base repo url, e.g. `git@github.com` or `git@github.company.com`. By default the old behaviour is applied which is use the official `github.com`

## Why:
Teams should be able to leverage their own setup of git, it might be an enterprise version of GitHub or a completely separate git repo not handled by `github.com`