### PR TITLE
chore(core): Compile using the java compiler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,6 @@ allprojects {
   apply plugin: 'java-library'
   apply plugin: 'groovy'
 
-  sourceSets.main.java.srcDirs = []
-  sourceSets.main.groovy.srcDirs += ["src/main/java"]
-
   test {
     testLogging {
       showStandardStreams = false


### PR DESCRIPTION
Only test code is written in groovy, so we never have to worry about java code depending on groovy code; remove the override that is causing java source files to be compiled with the groovy compiler.