### PR TITLE
feat(kubernetes): add flag for Kubernetes custom resources

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8507,6 +8507,7 @@ during clouddriver startup when you have many kubernetes accounts configured. Th
  * `--configure-image-pull-secrets`: (*Default*: `true`) (Only applicable to the v1 provider). When true, Spinnaker will create & manage your image pull secrets for you; when false, you will have to create and attach them to your pod specs by hand.
  * `--context`: The kubernetes context to be managed by Spinnaker. See [http://kubernetes.io/docs/user-guide/kubeconfig-file/#context](http://kubernetes.io/docs/user-guide/kubeconfig-file/#context) for more information.
 When no context is configured for an account the 'current-context' in your kubeconfig is assumed.
+ * `--custom-resources`: (*Default*: `[]`) (V2 Only) List of Kubernetes Custom Resources to be cached by clouddriver and available for use in patch and delete pipeline stages.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--docker-registries`: (*Default*: `[]`) A list of the Spinnaker docker registry account names this Spinnaker account can use as image sources. These docker registry accounts must be registered in your halconfig before you can add them here.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -119,6 +119,12 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
       description = KubernetesCommandProperties.CACHE_THREADS)
   private int cacheThreads = 1;
 
+  @Parameter(
+      names = "--custom-resources",
+      variableArity = true,
+      description = KubernetesCommandProperties.CUSTOM_RESOURCES)
+  public List<String> customResources = new ArrayList<>();
+
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -143,6 +149,14 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     account.setLiveManifestCalls(liveManifestCalls);
     account.setCacheThreads(cacheThreads);
+    customResources.forEach(
+        customResource ->
+            account
+                .getCustomResources()
+                .add(
+                    new KubernetesAccount.CustomKubernetesResource()
+                        .setKubernetesKind(customResource)
+                        .setVersioned(false)));
     return account;
   }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -69,4 +69,6 @@ public class KubernetesCommandProperties {
   static final String CACHE_THREADS =
       "Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. "
           + "By default, only 1 agent caches all kinds for all namespaces in the account.";
+  static final String CUSTOM_RESOURCES =
+      "(V2 Only) List of Kubernetes Custom Resources to be cached by clouddriver and available for use in patch and delete pipeline stages.";
 }


### PR DESCRIPTION
Adds flag `--custom-resources` to specify CRDs that should be cached by clouddriver. Defining custom resources here is required for them to be used in patch and delete pipeline stages.