### PR TITLE
Generalized init container

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Manifest.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Manifest.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
 import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Stream;
 import lombok.Data;
 import lombok.Getter;
 
@@ -30,15 +29,15 @@ import lombok.Getter;
 public class Manifest {
   public String name;
   public String manifestVersion;
-  public List<String> jars;
   public Map<String, Object> options;
+  public Map<String, List<String>> resources;
 
   static final String regex = "^[a-zA-Z0-9]+\\/[\\w-]+$";
   static final Pattern pattern = Pattern.compile(regex);
 
   public void validate() throws HalException {
 
-    if (Stream.of(name, manifestVersion, jars).anyMatch(Objects::isNull)) {
+    if (name == null || manifestVersion == null) {
       throw new HalException(
           new ConfigProblemBuilder(
                   Problem.Severity.FATAL, "Invalid plugin manifest, contains null values")

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
@@ -27,8 +27,10 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.representer.Representer;
@@ -36,23 +38,29 @@ import org.yaml.snakeyaml.representer.Representer;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class Plugin extends Node {
-  public String name;
-  public Boolean enabled;
-  public String manifestLocation;
-  public Map<String, Object> options = new HashMap<>();
+  private String name;
+  private Boolean enabled;
+  private String manifestLocation;
+  private Map<String, Object> options = new HashMap<>();
+
+  @Getter(AccessLevel.NONE)
+  private Manifest manifest;
 
   @Override
   public String getNodeName() {
     return name;
   }
 
-  public Manifest generateManifest() {
+  public Manifest getManifest() {
+    if (manifest != null) {
+      return manifest;
+    }
     Representer representer = new Representer();
     representer.getPropertyUtils().setSkipMissingProperties(true);
     Yaml yaml = new Yaml(new Constructor(Manifest.class), representer);
 
     InputStream manifestContents = downloadManifest();
-    Manifest manifest = yaml.load(manifestContents);
+    manifest = yaml.load(manifestContents);
     manifest.validate();
     return manifest;
   }
@@ -113,6 +121,6 @@ public class Plugin extends Node {
   }
 
   public Map<String, Object> getCombinedOptions() {
-    return Plugin.merge(generateManifest().getOptions(), options);
+    return Plugin.merge(getManifest().getOptions(), options);
   }
 }

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
@@ -26,7 +26,6 @@ class ManifestSpec extends Specification {
         Manifest manifest = new Manifest();
 
         when:
-        manifest.setJars(jars)
         manifest.setManifestVersion(manifestVersion)
         manifest.setName(name)
         manifest.setOptions(options)
@@ -39,7 +38,6 @@ class ManifestSpec extends Specification {
         name      | manifestVersion | jars                 | options
         "foo"     | "plugins/v1"    | Arrays.asList("jar") | null
         "foo/bar" | null            | Arrays.asList("jar") | null
-        "foo/bar" | "plugins/v1"    | null                 | null
     }
 
     void "plugin manifests pass validation"() {
@@ -47,7 +45,6 @@ class ManifestSpec extends Specification {
         Manifest manifest = new Manifest();
 
         when:
-        manifest.setJars(Arrays.asList("one", "two"))
         manifest.setManifestVersion("plugins/v1")
         manifest.setName("foo/bar")
         manifest.validate()

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/ObjectReplaceTemplatedResource.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/ObjectReplaceTemplatedResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.core.resource.v1;
+
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class ObjectReplaceTemplatedResource extends TemplatedResource {
+  public static Logger log = LoggerFactory.getLogger(ObjectReplaceTemplatedResource.class);
+
+  protected String formatKey(String key) {
+    return "'{{%" + key + "%}}'";
+  }
+
+  protected String getRegexSafeFormatKey() {
+    return "(?s).*\\'\\{\\{%.*%\\}\\}\\'.*";
+  }
+
+  @Override
+  public String toString() {
+    String contents = getContents();
+    for (Map.Entry<String, Object> binding : bindings.entrySet()) {
+      Object value = binding.getValue();
+      contents =
+          contents.replace(formatKey(binding.getKey()), value != null ? value.toString() : "");
+    }
+    if (contents.matches(getRegexSafeFormatKey())) {
+      log.warn(
+          "Found part of template that still contains a format key, likely a missing template value for a key, template: "
+              + contents);
+    }
+    return contents;
+  }
+}

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/ObjectResource.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/ObjectResource.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.core.resource.v1;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+
+public class ObjectResource extends ObjectReplaceTemplatedResource {
+  public ObjectResource(String contents) {
+    this.contents = contents;
+  }
+
+  @Getter(AccessLevel.PROTECTED)
+  private String contents;
+}

--- a/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/ObjectReplaceTemplatedResourceSpec.groovy
+++ b/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/ObjectReplaceTemplatedResourceSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.core.resource.v1
+
+import spock.lang.Specification
+
+class ObjectReplaceTemplatedResourceSpec extends Specification {
+    void "Attempt template with unfilled key"() {
+        setup:
+        String template = """'{{%some-unfilled-key%}}'"""
+        def logMock = Mock(org.slf4j.Logger)
+        ObjectReplaceTemplatedResource resource = (ObjectReplaceTemplatedResource)(new ObjectResource(template))
+        resource.log = logMock
+
+        when:
+        1 * logMock.warn(_) >> _
+        resource.toString()
+
+        then:
+        true
+    }
+
+    void "Attempt template with unfilled key multiline"() {
+        setup:
+        String template = """foo
+'{{%some-unfilled-key%}}'
+bar
+"""
+        def logMock = Mock(org.slf4j.Logger)
+        ObjectReplaceTemplatedResource resource = (ObjectReplaceTemplatedResource)(new ObjectResource(template))
+        resource.log = logMock
+
+        when:
+        1 * logMock.warn(_) >> _
+        resource.toString()
+
+        then:
+        true
+    }
+}

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.plugins.Manifest;
 import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
+import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -30,11 +31,20 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 public class PluginProfileFactory extends StringBackedProfileFactory {
-  @Override
-  protected void setProfile(
-      Profile profile,
-      DeploymentConfiguration deploymentConfiguration,
-      SpinnakerRuntimeSettings endpoints) {
+
+  public Profile getProfileByName(
+      String configOutputPath,
+      String serviceName,
+      DeploymentConfiguration deploymentConfiguration) {
+
+    String pluginFilename = "plugins.yml";
+    String pluginPath = Paths.get(configOutputPath, pluginFilename).toString();
+
+    String deploymentName = deploymentConfiguration.getName();
+    String version = getArtifactService().getArtifactVersion(deploymentName, getArtifact());
+    String profileName = serviceName + '-' + pluginFilename;
+    Profile profile = getBaseProfile(profileName, version, pluginPath);
+
     final Plugins plugins = deploymentConfiguration.getPlugins();
 
     Map<String, Object> pluginsYaml = new HashMap<>();
@@ -44,7 +54,8 @@ public class PluginProfileFactory extends StringBackedProfileFactory {
         plugins.getPlugins().stream()
             .filter(p -> p.getEnabled())
             .filter(p -> !p.getManifestLocation().isEmpty())
-            .map(p -> composeMetadata(p, p.generateManifest()))
+            .filter(p -> p.getManifest().getResources().containsKey(serviceName))
+            .map(p -> composeMetadata(p, p.getManifest(), serviceName))
             .collect(Collectors.toList());
 
     pluginsYaml.put("pluginConfigurations", pluginMetadata);
@@ -53,15 +64,25 @@ public class PluginProfileFactory extends StringBackedProfileFactory {
 
     profile.appendContents(
         yamlToString(deploymentConfiguration.getName(), profile, fullyRenderedYaml));
+    return profile;
   }
 
-  private Map<String, Object> composeMetadata(Plugin plugin, Manifest manifest) {
+  public Map<String, Object> composeMetadata(Plugin plugin, Manifest manifest, String serviceName) {
+    if (!manifest.getResources().containsKey(serviceName)) {
+      return null;
+    }
     Map<String, Object> metadata = new LinkedHashMap<>();
     metadata.put("enabled", plugin.getEnabled());
     metadata.put("name", manifest.getName());
-    metadata.put("jars", manifest.getJars());
+    metadata.put("jars", manifest.getResources().get(serviceName));
     return metadata;
   }
+
+  @Override
+  protected void setProfile(
+      Profile profile,
+      DeploymentConfiguration deploymentConfiguration,
+      SpinnakerRuntimeSettings endpoints) {}
 
   @Override
   protected String getRawBaseProfile() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/OrcaService.java
@@ -77,11 +77,9 @@ public abstract class OrcaService extends SpringService<OrcaService.Orca> {
     profiles.add(profile);
 
     // Plugins
-    String pluginFilename = "plugins.yml";
-    String pluginPath = Paths.get(getConfigOutputPath(), pluginFilename).toString();
     Profile pluginProfile =
-        pluginProfileFactory.getProfile(
-            pluginFilename, pluginPath, deploymentConfiguration, endpoints);
+        pluginProfileFactory.getProfileByName(
+            getConfigOutputPath(), getCanonicalName(), deploymentConfiguration);
     profiles.add(pluginProfile);
     return profiles;
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2DeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2DeckService.java
@@ -19,17 +19,22 @@
 package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Plugins;
+import com.netflix.spinnaker.halyard.config.model.v1.plugins.Manifest;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import com.netflix.spinnaker.halyard.deploy.deployment.v1.AccountDeploymentDetails;
+import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.deck.DeckDockerProfileFactory;
+import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ConfigSource;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DeckService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedService.DeployPriority;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesSharedServiceSettings;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -68,6 +73,100 @@ public class KubernetesV2DeckService extends DeckService
     } else {
       return Optional.empty();
     }
+  }
+
+  @Override
+  public List<String> getInitContainers(AccountDeploymentDetails<KubernetesAccount> details) {
+    Plugins plugins = details.getDeploymentConfiguration().getPlugins();
+    if (plugins.isEnabled() && plugins.isDownloadingEnabled()) {
+      List<Map> initContainers =
+          details
+              .getDeploymentConfiguration()
+              .getDeploymentEnvironment()
+              .getInitContainers()
+              .getOrDefault(getServiceName(), new ArrayList<>());
+      initContainers.add(getPluginDownloadingContainer(plugins));
+      details
+          .getDeploymentConfiguration()
+          .getDeploymentEnvironment()
+          .getInitContainers()
+          .put(getServiceName(), initContainers);
+    }
+
+    return KubernetesV2Service.super.getInitContainers(details);
+  }
+
+  private Map<String, Object> getPluginDownloadingContainer(Plugins plugins) {
+    List<Manifest> pluginManifests =
+        plugins.getPlugins().stream()
+            .filter(p -> p.getEnabled())
+            .filter(p -> !p.getManifestLocation().isEmpty())
+            .map(p -> p.getManifest())
+            .filter(m -> m.getResources().containsKey(getCanonicalName()))
+            .distinct()
+            .collect(Collectors.toList());
+
+    Map<String, Object> pluginDownloadingContainer = new HashMap();
+    pluginDownloadingContainer.put("name", "plugin-downloader");
+    pluginDownloadingContainer.put("image", "busybox");
+    pluginDownloadingContainer.put("command", getCommand());
+    pluginDownloadingContainer.put("args", getPluginDownloadingArgs(pluginManifests));
+    pluginDownloadingContainer.put("volumeMounts", getVolumeMounts());
+    return pluginDownloadingContainer;
+  }
+
+  private List<String> getCommand() {
+    List<String> command = new ArrayList();
+    command.add("/bin/sh");
+    return command;
+  }
+
+  private List<String> getPluginDownloadingArgs(List<Manifest> manifests) {
+    StringBuilder sb = new StringBuilder("cd /opt/spinnaker/plugins/resources && ");
+    for (Manifest manifest : manifests) {
+      String manifestsList = String.join(" ", manifest.getResources().get(getCanonicalName()));
+      sb.append("mkdir -p ").append(manifest.getName()).append(" && ");
+      sb.append("wget ")
+          .append(manifestsList)
+          .append(" -P ")
+          .append(manifest.getName())
+          .append("&& ");
+    }
+    sb.append("chown -R www-data:www-data /opt/spinnaker/plugins/resources;");
+
+    List<String> pluginArgs = new ArrayList();
+    pluginArgs.add("-c");
+    pluginArgs.add(sb.toString());
+    return pluginArgs;
+  }
+
+  private List<Map> getVolumeMounts() {
+    List<Map> volumeMounts = new ArrayList();
+    Map initContainerVolumeMount = new HashMap();
+    initContainerVolumeMount.put("name", "downloaded-plugin-location");
+    initContainerVolumeMount.put("mountPath", "/opt/spinnaker/plugins/resources");
+    volumeMounts.add(initContainerVolumeMount);
+    return volumeMounts;
+  }
+
+  @Override
+  public List<ConfigSource> stageConfig(
+      KubernetesV2Executor executor,
+      AccountDeploymentDetails<KubernetesAccount> details,
+      GenerateService.ResolvedConfiguration resolvedConfiguration) {
+
+    List<ConfigSource> configSources =
+        KubernetesV2Service.super.stageConfig(executor, details, resolvedConfiguration);
+
+    Plugins plugins = details.getDeploymentConfiguration().getPlugins();
+    if (plugins.isEnabled() && plugins.isDownloadingEnabled()) {
+      configSources.add(
+          new ConfigSource()
+              .setId("downloaded-plugin-location")
+              .setMountPath("/opt/deck/html/plugins")
+              .setType(ConfigSource.Type.emptyDir));
+    }
+    return configSources;
   }
 
   @Override

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2ServiceTest.groovy
@@ -191,6 +191,7 @@ class KubernetesV2ServiceTest extends Specification {
         SidecarConfig.SecretVolumeMount svm = new SidecarConfig.SecretVolumeMount(secretName: "sMap", mountPath: "/secretMap")
         car.getSecretVolumeMounts().add(svm)
         sidecarConfigs.add(car)
+        AccountDeploymentDetails<KubernetesAccount> details = new AccountDeploymentDetails<>();
 
         when:
         List<String> volumes = testService.combineVolumes(configSources, settings, sidecarConfigs)


### PR DESCRIPTION
In order to provide a UI component for plugins, we need to place the required resources such that Deck has access to them. In a Kubernetes environment, this means the pod needs access to the necessary assets. Ideally those assets are available locally and Deck itself would not have to download them. Some Spinnaker operators may choose to build images with the plugins included, so the deployment of plugin resources should be decoupled with the running service itself. 

To solve this for Kubernetes environments, I am using init containers to download the required 
resources to a volume mount thats shared with the pod, in this case deck. 

I had previously solved this issue for Java services by having Kork download the resources upon startup, however I would like to move to this version of deploying plugin resources to decouple the deployment of resources from the loading of plugins. This also simplifies the deployment of plugin resources by providing a single method of deployment for both Java services and Deck.

This does change how a plugin’s manifest.yml is formatted, changing from:

```
    ...
    jars:
      - resourceA.jar
      - resourceB.jar
```
to

```
    ...
    resources:
      orca:
        - resourceA.jar
      deck:
        - resourceB.js
        - resourceC.png
```
Since the plugin manifest format was changed to allow for specifying which service each resources should be laid down upon, PluginProfileFactory was also updated to allow for specifying which service the plugins.yml file is needed for. 

There will be an accompanying Deck PR that updates settings.js to read the plugin binding. I’ve added another format for replacing keys in settings.js so we can replace values with objects. Previously, we were only able to replace keys as strings, for instance given a variable `foo="bar"` `'{%foo%}'` would be replaced with `'bar'`. The single quotes are necessary for having a valid JSON, but it ensures only strings are templatizable. This PR adds the ability to create objects for consumption by Deck by adding another templating format (double curly braces + percent sign), `'{{%key%}}'`. In this case, the single quotes are still required, however we replace them as well, which allows us to create valid JSON objects. 

I’ve also added manifests as a field to Plugin.java, since a manifest.yml belongs to a particular plugin. This also allows for only downloading the manifest once, rather than each time it is required. 