### PR TITLE
feat(plugins): enable plugin config overrides

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Plugins.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Plugins.java
@@ -18,7 +18,9 @@ package com.netflix.spinnaker.halyard.config.model.v1.node;
 
 import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -26,6 +28,9 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Plugins extends Node {
+  private List<Plugin> plugins = new ArrayList<>();
+  private boolean enabled;
+  private boolean downloadingEnabled;
 
   @Override
   public String getNodeName() {
@@ -38,7 +43,15 @@ public class Plugins extends Node {
         plugins.stream().map(a -> (Node) a).collect(Collectors.toList()));
   }
 
-  private List<Plugin> plugins = new ArrayList<>();
-  private boolean enabled;
-  private boolean downloadingEnabled;
+  public Map<String, Object> getPluginConfigurations() {
+    Map<String, Object> fullyRenderedYaml = new LinkedHashMap<>();
+    Map<String, Object> pluginMetadata =
+        plugins.stream()
+            .filter(p -> p.getEnabled())
+            .filter(p -> !p.getManifestLocation().isEmpty())
+            .collect(Collectors.toMap(p -> p.getName(), p -> p.getCombinedOptions()));
+
+    fullyRenderedYaml.put("plugins", pluginMetadata);
+    return fullyRenderedYaml;
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
@@ -111,4 +111,8 @@ public class Plugin extends Node {
     }
     return original;
   }
+
+  public Map<String, Object> getCombinedOptions() {
+    return Plugin.merge(generateManifest().getOptions(), options);
+  }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
@@ -24,6 +24,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.yaml.snakeyaml.Yaml;
@@ -36,6 +39,7 @@ public class Plugin extends Node {
   public String name;
   public Boolean enabled;
   public String manifestLocation;
+  public Map<String, Object> options = new HashMap<>();
 
   @Override
   public String getNodeName() {
@@ -71,5 +75,40 @@ public class Plugin extends Node {
                       + e.getMessage())
               .build());
     }
+  }
+
+  /**
+   * Used to merge plugin options passed in through the hal config to overwrite the default plugin
+   * options, as necessary. Since options can be a nested map, if a hal config overwrites a
+   * particular piece of the default plugin options, we want to preserve the other options.
+   *
+   * <p>If a key is present on both the original and new options, the types match, and are of type
+   * Map or List, then we merge the two values. Otherwise, we overwrite the keys with the values in
+   * the newMap.
+   *
+   * @param original
+   * @param newMap
+   * @return
+   */
+  public static Map<String, Object> merge(
+      Map<String, Object> original, Map<String, Object> newMap) {
+    for (String key : newMap.keySet()) {
+      if (newMap.get(key) instanceof Map && original.get(key) instanceof Map) {
+        Map originalChild = (Map) original.get(key);
+        Map newChild = (Map) newMap.get(key);
+        original.put(key, Plugin.merge(originalChild, newChild));
+      } else if (newMap.get(key) instanceof List && original.get(key) instanceof List) {
+        List originalChild = (List) original.get(key);
+        List newChild = (List) newMap.get(key);
+        for (Object each : newChild) {
+          if (!originalChild.contains(each)) {
+            originalChild.add(each);
+          }
+        }
+      } else {
+        original.put(key, newMap.get(key));
+      }
+    }
+    return original;
   }
 }

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/ManifestSpec.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Bol.com
+ * Copyright 2019 Armory, Inc
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/PluginSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/plugins/PluginSpec.groovy
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 Armory, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.plugins
+
+import com.netflix.spinnaker.halyard.config.error.v1.IllegalConfigException
+import org.springframework.boot.liquibase.SpringPackageScanClassResolver
+import org.springframework.core.SpringProperties
+import spock.lang.Specification
+
+class PluginSpec extends Specification {
+
+    void "plugin merge works correctly"() {
+        setup:
+        def originalOptions = [
+                example: [
+                        url: 'host',
+                        port: 1000,
+                        nested: [
+                                foo: 'bar',
+                                key: 'value'
+                        ],
+                        list: [
+                                'first',
+                                'second'
+                        ],
+                        changeMe: [
+                                'change',
+                                'to',
+                                'integer'
+                        ],
+                        doNot: 'change'
+                ]
+        ]
+
+        def newOptions = [
+                example: [
+                        url: 'new.host',
+                        port: 2000,
+                        nested: [
+                                foo: 'baz',
+                                cat: 'dog'
+                        ],
+                        list: [
+                                'new',
+                                'list'
+                        ],
+                        changeMe: 200
+                ]
+        ]
+
+        when:
+        def subject = Plugin.merge(originalOptions, newOptions)
+
+        then:
+        def expectedOptions = [
+                example: [
+                        url: 'new.host',
+                        port: 2000,
+                        nested: [
+                                foo: 'baz',
+                                cat: 'dog',
+                                key: 'value'
+                        ],
+                        list: [
+                                'first',
+                                'second',
+                                'new',
+                                'list'
+                        ],
+                        changeMe: 200,
+                        doNot: 'change'
+                ]
+        ]
+        subject == expectedOptions
+    }
+}

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/PluginServiceSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/PluginServiceSpec.groovy
@@ -49,6 +49,10 @@ deploymentConfigurations:
     plugins:
     - name: test-plugin
       manifestLocation: /home/user/test-plugin.yaml
+      options:
+        foo: bar
+        nested:
+          key: value
 """
     def pluginService = makePluginService(config)
 
@@ -60,6 +64,8 @@ deploymentConfigurations:
     result.size() == 1
     result[0].getName() == "test-plugin"
     result[0].getManifestLocation() == "/home/user/test-plugin.yaml"
+    result[0].getOptions().get("foo") == "bar"
+    result[0].getOptions().get("nested").get("key") == "value"
 
     when:
     result = pluginService.getPlugin(DEPLOYMENT, "test-plugin")

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -19,16 +19,12 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Features;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Webhook;
-import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.integrations.IntegrationsConfigWrapper;
-import java.util.AbstractMap;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -81,23 +77,9 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     // For backward compatibility
     profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
 
-    // Plugins
-    final List<Plugin> plugins = deploymentConfiguration.getPlugins().getPlugins();
-    Map<String, Object> fullyRenderedYaml = new LinkedHashMap<>();
-    Map<String, Object> pluginMetadata =
-        plugins.stream()
-            .filter(p -> p.getEnabled())
-            .filter(p -> !p.getManifestLocation().isEmpty())
-            .map(p -> new AbstractMap.SimpleEntry<>(p, p.generateManifest()))
-            .collect(
-                Collectors.toMap(
-                    m -> m.getValue().getName(),
-                    m -> Plugin.merge(m.getValue().getOptions(), m.getKey().getOptions())));
-
-    fullyRenderedYaml.put("plugins", pluginMetadata);
-
-    profile.appendContents(
-        yamlToString(deploymentConfiguration.getName(), profile, fullyRenderedYaml));
+    Map<String, Object> pluginsYaml =
+        deploymentConfiguration.getPlugins().getPluginConfigurations();
+    profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, pluginsYaml));
   }
 
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/PluginProfileFactory.java
@@ -60,7 +60,6 @@ public class PluginProfileFactory extends StringBackedProfileFactory {
     metadata.put("enabled", plugin.getEnabled());
     metadata.put("name", manifest.getName());
     metadata.put("jars", manifest.getJars());
-    metadata.put("manifestVersion", manifest.getManifestVersion());
     return metadata;
   }
 


### PR DESCRIPTION
Spinnaker operators should be able to override default plugin config values. This PR enables Spinnaker operators to configure plugin overrides via the hal config file. 

A hal config could contain the following in order to override the options for a particular plugin:
```
  plugins:
    plugins:
    - name: test
      enabled: true
      manifestLocation: https://github.com/armory/stage-plugin/blob/master/manifest.yml
      options:
        example:
          url: blah
          port: 2000
          nested:
            list:
            - last
            - first
```

I am also correcting the copy+paste error for Manifest.java's copyright. 