### PR TITLE
fix(halyard): Change deployment to support new Kubernetes API (…

### DIFF
--- a/halyard-deploy/src/main/resources/kubernetes/manifests/clouddriver.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/clouddriver.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # As of Kubernetes 1.16, apps/v1beta2 has been deprecated
 kind: Deployment
 metadata:
   name: spin-clouddriver

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/deployment.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2 # for versions before 1.9.0 use apps/v1beta2
+apiVersion: apps/v1 # As of Kubernetes 1.16, apps/v1beta2 has been deprecated
 kind: Deployment
 metadata:
   name: spin-{{ name }}


### PR DESCRIPTION
…1beta2 has been deprecated and replaced with apps/v1)

As of Kubernetes 1.16, the apps/v1beta2 deployment object has been deprecated.

I'm assuming the commit will be squashed, so I'm ignoring the typo in the commit message.