### PR TITLE
fix(halyard/installer): Add support for Java version 13

### DIFF
--- a/install/macos/InstallHalyard.sh
+++ b/install/macos/InstallHalyard.sh
@@ -154,6 +154,7 @@ function install_java() {
      [[ "$java_version" == *"10.0"* ]] || \
      [[ "$java_version" == *"11"* ]] || \
      [[ "$java_version" == *"12"* ]] || \
+     [[ "$java_version" == *"13"* ]] || \
      [[ "$java_version" == "java version \"10\""* ]]; then
     echo "Java is already installed & at the right version"
     return 0;


### PR DESCRIPTION
My java version:
```bash
java --version 
$ openjdk
$ OpenJDK Runtime Environment (build 13+33)
$OpenJDK 64-Bit Server VM (build 13+33, mixed mode, sharing)
```

My Halyard version:
```bash
hal -v
$ 1.24.0-20191002142815
```