### PR TITLE
chore(core): remove unused jobs feature flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5952,7 +5952,6 @@ hal config features edit [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--gremlin`: Enable Gremlin fault-injection support.
  * `--infrastructure-stages`: Enable infrastructure stages. Allows for creating Load Balancers as part of pipelines.
- * `--jobs`: Allow Spinnaker to run containers in Kubernetes and Titus as Job stages in pipelines.
  * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -43,13 +43,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   private Boolean chaos = null;
 
   @Parameter(
-      names = "--jobs",
-      description =
-          "Allow Spinnaker to run containers in Kubernetes and Titus as Job stages in pipelines.",
-      arity = 1)
-  private Boolean jobs = null;
-
-  @Parameter(
       names = "--pipeline-templates",
       description =
           "Enable pipeline template support. Read more at https://github.com/spinnaker/dcd-spec.",
@@ -122,7 +115,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     int originalHash = features.hashCode();
 
     features.setChaos(chaos != null ? chaos : features.isChaos());
-    features.setJobs(jobs != null ? jobs : features.isJobs());
     features.setPipelineTemplates(
         pipelineTemplates != null ? pipelineTemplates : features.getPipelineTemplates());
     features.setArtifacts(artifacts != null ? artifacts : features.getArtifacts());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -16,11 +16,13 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
+@JsonIgnoreProperties({"jobs"})
 public class Features extends Node {
   @Override
   public String getNodeName() {
@@ -36,7 +38,6 @@ public class Features extends Node {
   private boolean fiat;
   private boolean chaos;
   private boolean entityTags;
-  private boolean jobs;
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.2.0",

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -106,7 +106,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     // Configure feature-flags
     bindings.put("features.auth", Boolean.toString(features.isAuth(deploymentConfiguration)));
     bindings.put("features.chaos", Boolean.toString(features.isChaos()));
-    bindings.put("features.jobs", Boolean.toString(features.isJobs()));
     bindings.put(
         "features.fiat",
         Boolean.toString(deploymentConfiguration.getSecurity().getAuthz().isEnabled()));


### PR DESCRIPTION
Let's delete some code from Halyard!

@christopherthielen determined that we no longer use the `jobs` feature flag (added way back in 2016 in [this commit](https://github.com/spinnaker/deck/commit/826d9e17c0d3e8236e591f34f6d8e3b823ca299f)) and removed all references to it in [this PR](https://github.com/spinnaker/deck/pull/7553). This PR removes all Halyard references to the jobs feature flag, and adds a `JsonIgnoreProperties` annotation to the `Feature` class so that deserializing existing hal configs will not cause errors.