### PR TITLE
feat(config): HalconfigDirStruct source of truth, allow override

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ResourceConfig.java
@@ -52,12 +52,8 @@ public class ResourceConfig {
   }
 
   @Bean
-  String halconfigPath(@Value("${halyard.halconfig.directory:~/.hal}") String path) {
-    return normalizePath(Paths.get(path, "config").toString());
-  }
-
-  @Bean
   String localBomPath(@Value("${halyard.halconfig.directory:~/.hal}") String path) {
+
     return normalizePath(Paths.get(path, ".boms").toString());
   }
 

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/HalconfigParserMocker.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/HalconfigParserMocker.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.services.v1
 
+import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser
 import com.netflix.spinnaker.halyard.config.config.v1.StrictObjectMapper
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig
@@ -30,7 +31,7 @@ class HalconfigParserMocker extends Specification {
     def parserStub = new HalconfigParser()
     parserStub.objectMapper = new StrictObjectMapper()
     parserStub.yamlParser = new Yaml(new SafeConstructor())
-    parserStub.halconfigPath = "/some/nonsense/file"
+    parserStub.halconfigDirectoryStructure = new HalconfigDirectoryStructure();
 
     def stream = new ByteArrayInputStream(config.getBytes(StandardCharsets.UTF_8))
     Halconfig halconfig = parserStub.parseHalconfig(stream)

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/GenerateService.java
@@ -57,8 +57,6 @@ public class GenerateService {
 
   @Autowired private ServiceProviderFactory serviceProviderFactory;
 
-  @Autowired private String halconfigPath;
-
   @Autowired private HalconfigDirectoryStructure halconfigDirectoryStructure;
 
   @Autowired private List<SpinnakerService> spinnakerServices = new ArrayList<>();
@@ -99,7 +97,7 @@ public class GenerateService {
     DaemonTaskHandler.newStage("Generating all Spinnaker profile files and endpoints");
     log.info(
         "Generating config from \""
-            + halconfigPath
+            + halconfigDirectoryStructure.getHalconfigPath()
             + "\" with deploymentName \""
             + deploymentName
             + "\"");


### PR DESCRIPTION
Halyard uses `halyard.halconfig.directory` for both `halconfigDirectory` and `halconfigPath`. With this PR:
- Halyard only uses `HalconfigDirectoryStructure` to build the correct path.
- We can override the directory used. The goal is to be able to temporarily point Halyard to a separate directory to read the user's configuration.

Note after that `localBomPath` still uses the same property but it's in `halyard-core` so without an easy way to refactor.

