### PR TITLE
fix(saml): get saml file path instead of file contents in saml validator

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HaEchoValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/HaEchoValidator.java
@@ -38,7 +38,7 @@ public class HaEchoValidator extends Validator<DeploymentEnvironment> {
       p.addProblem(
           Problem.Severity.WARNING,
           "High Availability (HA) is enabled for echo, but found custom sizing for the main service (this setting will be ignored). "
-              + "With HA enabled, the service is split into multiple sub-services (echo-scheduler, echo-scheduler). You need to update the component sizing for each sub-service, individually.");
+              + "With HA enabled, the service is split into multiple sub-services (spin-echo-scheduler, spin-echo-worker). You need to update the component sizing for each sub-service, individually.");
     }
 
     if (!haEchoEnabled

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Saml;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
+import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
@@ -30,10 +31,13 @@ import lombok.val;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SamlValidator extends Validator<Saml> {
+  @Autowired SecretSessionManager secretSessionManager;
+
   @Override
   public void validate(ConfigProblemSetBuilder p, Saml saml) {
     if (!saml.isEnabled()) {
@@ -47,7 +51,7 @@ public class SamlValidator extends Validator<Saml> {
 
     if (StringUtils.isNotEmpty(saml.getMetadataLocal())) {
       try {
-        new File(new URI("file:" + validatingFileDecrypt(p, saml.getMetadataLocal())));
+        new File(new URI("file:" + secretSessionManager.decryptAsFile(saml.getMetadataLocal())));
       } catch (Exception f) {
         p.addProblem(Problem.Severity.ERROR, f.getMessage());
       }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/security/SamlValidator.java
@@ -20,24 +20,21 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Saml;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem;
-import com.netflix.spinnaker.halyard.core.secrets.v1.SecretSessionManager;
+import lombok.val;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.stereotype.Component;
+
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.security.KeyStore;
 import java.util.Collections;
-import lombok.val;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.HttpClientBuilder;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 @Component
 public class SamlValidator extends Validator<Saml> {
-  @Autowired SecretSessionManager secretSessionManager;
-
   @Override
   public void validate(ConfigProblemSetBuilder p, Saml saml) {
     if (!saml.isEnabled()) {


### PR DESCRIPTION
The SAML validator currently is getting the file contents of the metadata file instead of the file path, which causes the validator to fail. This PR fixes that bug.