### PR TITLE
fix(halyard/macos): Catalina compability

### DIFF
--- a/startup/macos/hal
+++ b/startup/macos/hal
@@ -12,8 +12,8 @@ function start_daemon() {
     printf "The halyard daemon isn't running yet... starting it manually"
 
     /opt/halyard/bin/halyard \
-      2> /var/log/spinnaker/halyard/halyard.err \
-      > /var/log/spinnaker/halyard/halyard.log &
+      2> ~/dev/spinnaker/logs/halyard/halyard.err \
+      > ~/dev/spinnaker/logs/halyard/halyard.log &
 
     echo $! > $HALYARD_DAEMON_PID_FILE 
 


### PR DESCRIPTION
Halyard will not start on macOS Catalina because it can't write logs to `/var`. Changing the log directory to the user directory fixes the problem.