### PR TITLE
fix(backup): support wildcard truststore: skip backup

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Node.java
@@ -486,7 +486,7 @@ public abstract class Node implements Validatable {
                               }
                             }
 
-                            if (fPath == null) {
+                            if (fPath == null || fPath.equals("*")) {
                               return null;
                             }
 


### PR DESCRIPTION
This skips the backup of `*` files as found in Igor's `truststore`: https://github.com/spinnaker/igor/pull/363

This should fix https://github.com/spinnaker/spinnaker/issues/5096