### PR TITLE
fix(artifacts/gitrepo): use Boolean class instead of primitive

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/gitrepo/GitRepoAddArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/gitrepo/GitRepoAddArtifactAccountCommand.java
@@ -69,7 +69,7 @@ public class GitRepoAddArtifactAccountCommand extends AbstractAddArtifactAccount
   @Parameter(
       names = "--ssh-trust-unknown-hosts",
       description = "Setting this to true allows Spinnaker to authenticate with unknown hosts")
-  private Boolean sshTrustUnknownHosts = null;
+  private Boolean sshTrustUnknownHosts;
 
   @Override
   protected ArtifactAccount buildArtifactAccount(String accountName) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/gitrepo/GitRepoEditArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/gitrepo/GitRepoEditArtifactAccountCommand.java
@@ -70,7 +70,7 @@ public class GitRepoEditArtifactAccountCommand
   @Parameter(
       names = "--ssh-trust-unknown-hosts",
       description = "Setting this to true allows Spinnaker to authenticate with unknown hosts")
-  private Boolean sshTrustUnknownHosts = null;
+  private Boolean sshTrustUnknownHosts;
 
   @Override
   protected ArtifactAccount editArtifactAccount(GitRepoArtifactAccount account) {
@@ -89,7 +89,7 @@ public class GitRepoEditArtifactAccountCommand
     account.setSshKnownHostsFilePath(
         isSet(sshKnownHostsFilePath) ? sshKnownHostsFilePath : account.getSshKnownHostsFilePath());
     account.setSshTrustUnknownHosts(
-        isSet(sshTrustUnknownHosts) ? sshTrustUnknownHosts : account.isSshTrustUnknownHosts());
+        isSet(sshTrustUnknownHosts) ? sshTrustUnknownHosts : account.getSshTrustUnknownHosts());
     return account;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/gitrepo/GitRepoArtifactAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/artifacts/gitrepo/GitRepoArtifactAccount.java
@@ -37,5 +37,5 @@ public class GitRepoArtifactAccount extends ArtifactAccount {
   @LocalFile @SecretFile String sshPrivateKeyFilePath;
   @Secret String sshPrivateKeyPassphrase;
   @LocalFile @SecretFile String sshKnownHostsFilePath;
-  boolean sshTrustUnknownHosts;
+  Boolean sshTrustUnknownHosts = false;
 }


### PR DESCRIPTION
Adding a new git repo account from a hal command will fail if you don't explicitly specify the `--ssh-trust-known-hosts` parameter, because the field is a boolean primitive type in the `GitRepoArtifactAccount` class. With the change to `Boolean`, this bug is fixed.