### PR TITLE
feat(stats): Adds Telemetry validator, which prints a new Info level …

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/ResponseUnwrapper.java
@@ -235,6 +235,9 @@ public class ResponseUnwrapper {
         List<String> options = problem.getOptions();
 
         switch (severity) {
+          case INFO:
+            AnsiUi.info(message);
+            break;
           case FATAL:
           case ERROR:
             AnsiUi.error(message);

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiUi.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/ui/v1/AnsiUi.java
@@ -37,13 +37,27 @@ public class AnsiUi {
     AnsiParagraphBuilder builder =
         new AnsiParagraphBuilder().setIndentFirstLine(false).setIndentWidth(2);
 
-    builder.addSnippet("Problems in ");
+    builder.addSnippet("Validation in ");
 
     builder.addSnippet(message).addStyle(AnsiStyle.BOLD);
 
     builder.addSnippet(":");
 
     AnsiPrinter.err.println(builder.toString());
+  }
+
+  public static void info(String message) {
+    AnsiParagraphBuilder builder =
+        new AnsiParagraphBuilder().setIndentFirstLine(false).setIndentWidth(2);
+
+    builder
+        .addSnippet("- INFO ")
+        .setForegroundColor(AnsiForegroundColor.GREEN)
+        .addStyle(AnsiStyle.BOLD);
+
+    builder.addSnippet(message);
+
+    AnsiPrinter.out.println(builder.toString());
   }
 
   public static void warning(String message) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
@@ -31,7 +31,11 @@ public class Telemetry extends Node {
     return "telemetry";
   }
 
+  @ValidForSpinnakerVersion(
+      lowerBound = "1.18.0",
+      tooLowMessage = "Telemetry is not available prior to this release.")
   private Boolean enabled = false;
+
   private String endpoint = DEFAULT_TELEMETRY_ENDPOINT;
   private String instanceId = new ULID().nextULID();
   private String spinnakerVersion;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/DeploymentService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/DeploymentService.java
@@ -154,7 +154,8 @@ public class DeploymentService {
             .withAnyProvider()
             .withAnyAccount()
             .setFeatures()
-            .setSecurity();
+            .setSecurity()
+            .setTelemetry();
 
     if (storage.getPersistentStoreType() != null) {
       filter.setPersistentStore(storage.getPersistentStoreType().getId());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/TelemetryValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/TelemetryValidator.java
@@ -1,0 +1,33 @@
+package com.netflix.spinnaker.halyard.config.validate.v1;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
+import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
+import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class TelemetryValidator extends Validator<Telemetry> {
+
+  @Override
+  public void validate(ConfigProblemSetBuilder p, Telemetry t) {
+    StringBuilder msg = new StringBuilder();
+    msg.append("Telemetry is currently ");
+    if (t.getEnabled()) {
+      msg.append("ENABLED. Usage statistics are being collected—Thank you! ");
+      msg.append("These stats inform improvements to the product, and that helps the community. ");
+      msg.append("To disable, run `hal config telemetry disable`. ");
+    } else {
+      msg.append("DISABLED. Usage statistics are not being collected. ");
+      msg.append("Please consider enabling statistic collection. ");
+      msg.append("These stats inform improvements to the product, and that helps the community. ");
+      msg.append("To enable, run `hal config telemetry enable`. ");
+    }
+
+    msg.append("To learn more about what and how telemetry data is used, please see ");
+    msg.append("https://www.spinnaker.io/community/stats.");
+    p.addProblem(Severity.INFO, msg.toString());
+  }
+}

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/Problem.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/problem/v1/Problem.java
@@ -30,6 +30,9 @@ public class Problem {
      */
     NONE,
 
+    /** Indicates no problem at all, just information that should be shared with the user. */
+    INFO,
+
     /**
      * Indicates the deployment of Spinnaker is going against our preferred/recommended practices.
      * For example: using an unauthenticated docker registry.


### PR DESCRIPTION
…message that will get printed during all `hal config telemetry enable|disable` and `hal deploy apply` invocations. Samples below:

```
$ hal config telemetry enable
+ Get current deployment
  Success
+ Enable or disable telemetry
  Success
Validation in default.telemetry:
- INFO Telemetry is currently ENABLED. Usage statistics are being
  collected—Thank you!These stats inform improvements to the product, and that
  helps the community.To disable, run `hal config telemetry disable`.To learn more
  about what and how telemetry data is used, please see
  https://www.spinnaker.io/community/stats

+ Successfully enabled telemetry settings.

```

```
$ hal config telemetry disable
+ Get current deployment
  Success
+ Enable or disable telemetry
  Success
Validation in default.telemetry:
- INFO Telemetry is currently DISABLED. Usage statistics are not
  being collected. Please consider enabling statistic collection. These stats
  inform improvements to the product, and that helps the community. To enable, run
  `hal config telemetry enable`. To learn more about what and how telemetry data
  is used, please see https://www.spinnaker.io/community/stats.

+ Successfully disabled telemetry settings.

```

I realize this kind of repurposes the `Problem` and `ProblemSet` classes to print an info message, but the infrastructure is super useful for this kind of task, i.e. only print a message during specific commands. Renaming all instances of Problem and ProblemSet would blow up this PR and mask what is actually trying to be accomplished.