### PR TITLE
fix(container): set the spinnaker user to uid 1000

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -34,7 +34,8 @@ RUN apk --purge del \
   py-pip
 RUN rm -rf /var/cache/apk
 
-RUN adduser -D -S spinnaker
+RUN addgroup -S -g 1000 spinnaker
+RUN adduser -D -S -G spinnaker -u 1000 spinnaker
 USER spinnaker
 
 CMD ["/opt/halyard/bin/halyard"]


### PR DESCRIPTION
You can't specify a username in a k8s securityContext, only a uid. So
the uid 1000 is special and we need to keep the `spinnaker` user with
that ID.