### PR TITLE
fix(java11): remove deprecated JVM flags

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -768,11 +768,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
         .setEnabled(isEnabled(deploymentConfiguration));
     if (runsOnJvm()) {
       // Use half the available memory allocated to the container for the JVM heap
-      settings
-          .getEnv()
-          .put(
-              "JAVA_OPTS",
-              "-XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=2");
+      settings.getEnv().put("JAVA_OPTS", "-XX:MaxRAMPercentage=50.0");
     }
     return settings;
   }


### PR DESCRIPTION
`-XX:UseCGroupMemoryLimitForHeap` was deprecated in Java 8u191. It's functionality is now enabled by default. `-XX:MaxRAMFraction` was also replaced by the (more flexible) `-XX:MaxRAMPercentage`.

https://www.oracle.com/technetwork/java/javase/8u191-relnotes-5032181.html

Java 8 will still launch with the old flags, but ≥10 will not, so we need this for the move to Java 11.

We've been using Java ≥8u191 in every service since Spinnaker 1.14.0. So this version of Halyard will still successfully deploy 1.14.0, but not 1.13.0 or earlier. (Because we we're hardcoding the version of the JDK in Echo to 8u111 until then, probably accidentally.)

Probably this setting belongs in the `Dockerfile`for each service, not in Halyard, but that's a battle for another day.