### PR TITLE
docs(documentation): Add notice to user that hal deploy clean destroys enclosing namespace

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11447,7 +11447,7 @@ This guarantees that no configuration will be generated for this deployment. Thi
 ---
 ## hal deploy clean
 
-This command destroys all Spinnaker artifacts in your target deployment environment. This cannot be undone, so use with care. This does not delete Halyard nor any of the configuration.
+This command destroys all Spinnaker artifacts in your target deployment environment, including the namespace that contains spinnaker. This cannot be undone, so use with care. This does not delete Halyard nor any of the configuration.
 
 #### Usage
 ```


### PR DESCRIPTION
I was just bit by the namespace deletion today, as per https://github.com/spinnaker/spinnaker/issues/2432, it seems like this would be a good addition to the docs. It would also warn people not to install spinnaker in important namespaces that shouldn't be managed by halyard.

Adding into master as that's the documentation users will hit by default (hopefully that's ok).