### PR TITLE
feat(deployment): Overwrite deploy command's timeout value

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -11442,6 +11442,7 @@ This guarantees that no configuration will be generated for this deployment. Thi
  * `--prep-only`: (*Default*: `false`) This does just the prep work, and not the actual deployment. Only useful at the moment if you want to just clone the repositories for a localgit setup.
  * `--service-names`: (*Default*: `[]`) When supplied, only install or update the specified Spinnaker services.
  * `--wait-for-completion`: (*Default*: `false`) When supplied, wait for all containers to be ready before returning (only applies to Kubernetes V2 provider).
+ * `--wait-for-completion-timeout-minutes`: Specify timeout for deploy apply command.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/ApplyDeployCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/deploy/ApplyDeployCommand.java
@@ -97,6 +97,11 @@ public class ApplyDeployCommand extends AbstractRemoteActionCommand {
           "When supplied, wait for all containers to be ready before returning (only applies to Kubernetes V2 provider).")
   boolean waitForCompletion;
 
+  @Parameter(
+      names = "--wait-for-completion-timeout-minutes",
+      description = "Specify timeout for deploy apply command.")
+  Integer waitForCompletionTimeoutMinutes;
+
   @Override
   protected OperationHandler<RemoteAction> getRemoteAction() {
     List<DeployOption> deployOptions = new ArrayList<>();
@@ -131,7 +136,12 @@ public class ApplyDeployCommand extends AbstractRemoteActionCommand {
           .setSuccessMessage("Run `hal deploy connect` to connect to Spinnaker.")
           .setOperation(
               Daemon.deployDeployment(
-                  getCurrentDeployment(), false, deployOptions, serviceNames, excludeServiceNames));
+                  getCurrentDeployment(),
+                  false,
+                  deployOptions,
+                  serviceNames,
+                  excludeServiceNames,
+                  waitForCompletionTimeoutMinutes));
     }
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -830,7 +830,8 @@ public class Daemon {
       boolean validate,
       List<DeployOption> deployOptions,
       List<String> serviceNames,
-      List<String> excludeServiceNames) {
+      List<String> excludeServiceNames,
+      Integer waitForCompletionTimeoutMinutes) {
     return () -> {
       Object rawDeployResult =
           ResponseUnwrapper.get(
@@ -841,6 +842,7 @@ public class Daemon {
                       deployOptions,
                       serviceNames,
                       excludeServiceNames,
+                      waitForCompletionTimeoutMinutes,
                       ""));
       return getObjectMapper().convertValue(rawDeployResult, RemoteAction.class);
     };

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -100,6 +100,7 @@ public interface DaemonService {
       @Query("deployOptions") List<DeployOption> deployOptions,
       @Query("serviceNames") List<String> serviceNames,
       @Query("excludeServiceNames") List<String> excludeServiceNames,
+      @Query("waitForCompletionTimeoutMinutes") Integer waitForCompletionTimeoutMinutes,
       @Body String _ignore);
 
   @POST("/v1/config/deployments/{deploymentName}/prep/")

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/BakeDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/BakeDeployer.java
@@ -26,10 +26,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.BakeService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.BakeServiceProvider;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
@@ -41,7 +38,8 @@ public class BakeDeployer implements Deployer<BakeServiceProvider, DeploymentDet
       DeploymentDetails deploymentDetails,
       GenerateService.ResolvedConfiguration resolvedConfiguration,
       List<SpinnakerService.Type> serviceTypes,
-      boolean waitForCompletion) {
+      boolean waitForCompletion,
+      Optional<Integer> waitForCompletionTimeoutMinutes) {
     List<BakeService> enabledServices =
         serviceProvider.getPrioritizedBakeableServices(serviceTypes).stream()
             .filter(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/Deployer.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSetting
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerServiceProvider;
 import java.util.List;
+import java.util.Optional;
 
 public interface Deployer<S extends SpinnakerServiceProvider<D>, D extends DeploymentDetails> {
   RemoteAction deploy(
@@ -30,7 +31,8 @@ public interface Deployer<S extends SpinnakerServiceProvider<D>, D extends Deplo
       D deploymentDetails,
       ResolvedConfiguration resolvedConfiguration,
       List<SpinnakerService.Type> serviceTypes,
-      boolean waitForCompletion);
+      boolean waitForCompletion,
+      Optional<Integer> waitForCompletionTimeoutMinutes);
 
   void rollback(
       S serviceProvider,

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/DistributedDeployer.java
@@ -35,13 +35,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedServiceProvider;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
@@ -200,7 +194,8 @@ public class DistributedDeployer<T extends Account>
       AccountDeploymentDetails<T> deploymentDetails,
       ResolvedConfiguration resolvedConfiguration,
       List<SpinnakerService.Type> serviceTypes,
-      boolean waitForCompletion) {
+      boolean waitForCompletion,
+      Optional<Integer> waitForCompletionTimeoutMinutes) {
     SpinnakerRuntimeSettings runtimeSettings = resolvedConfiguration.getRuntimeSettings();
 
     DaemonTaskHandler.newStage("Deploying Spinnaker");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/KubectlDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/KubectlDeployer.java
@@ -34,6 +34,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kub
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2.KubernetesV2Service;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2.KubernetesV2Utils;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -50,7 +51,8 @@ public class KubectlDeployer
       AccountDeploymentDetails<KubernetesAccount> deploymentDetails,
       GenerateService.ResolvedConfiguration resolvedConfiguration,
       List<SpinnakerService.Type> serviceTypes,
-      boolean waitForCompletion) {
+      boolean waitForCompletion,
+      Optional<Integer> waitForCompletionTimeoutMinutes) {
     List<KubernetesV2Service> services = serviceProvider.getServicesByPriority(serviceTypes);
     services.stream()
         .forEach(
@@ -122,7 +124,7 @@ public class KubectlDeployer
               DaemonTaskHandler.submitTask(
                   builder::build,
                   "Deploy " + service.getServiceName(),
-                  TimeUnit.MINUTES.toMillis(10));
+                  TimeUnit.MINUTES.toMillis(waitForCompletionTimeoutMinutes.orElse(10)));
             });
 
     DaemonTaskHandler.message("Waiting on deployments to complete");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalDeployer.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/LocalDeployer.java
@@ -30,6 +30,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalServ
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -44,7 +45,8 @@ public class LocalDeployer implements Deployer<LocalServiceProvider, DeploymentD
       DeploymentDetails deploymentDetails,
       GenerateService.ResolvedConfiguration resolvedConfiguration,
       List<SpinnakerService.Type> serviceTypes,
-      boolean waitForCompletion) {
+      boolean waitForCompletion,
+      Optional<Integer> waitForCompletionTimeoutMinutes) {
     List<LocalService> enabledServices =
         serviceProvider.getLocalServices(serviceTypes).stream()
             .filter(i -> resolvedConfiguration.getServiceSettings(i.getService()) != null)

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
@@ -50,6 +50,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerServic
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
@@ -251,7 +252,8 @@ public class DeployService {
       String deploymentName,
       List<DeployOption> deployOptions,
       List<String> serviceNames,
-      List<String> excludeServiceNames) {
+      List<String> excludeServiceNames,
+      Optional<Integer> waitForCompletionTimeoutMinutes) {
     if (deployOptions.contains(DeployOption.DELETE_ORPHANED_SERVICES) && !serviceNames.isEmpty()) {
       throw new IllegalArgumentException(
           "Cannot delete orphaned services when services to include are explicitly supplied.");
@@ -310,7 +312,8 @@ public class DeployService {
             deploymentDetails,
             resolvedConfiguration,
             serviceTypes,
-            waitForCompletion);
+            waitForCompletion,
+            waitForCompletionTimeoutMinutes);
     halconfigParser.backupConfig();
 
     if (deployOptions.contains(DeployOption.FLUSH_INFRASTRUCTURE_CACHES)) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/DeploymentController.java
@@ -43,6 +43,7 @@ import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -216,7 +217,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase {
       @ModelAttribute ValidationSettings validationSettings,
       @RequestParam(required = false) List<DeployOption> deployOptions,
       @RequestParam(required = false) List<String> serviceNames,
-      @RequestParam(required = false) List<String> excludeServiceNames) {
+      @RequestParam(required = false) List<String> excludeServiceNames,
+      @RequestParam Optional<Integer> waitForCompletionTimeoutMinutes) {
     List<DeployOption> finalDeployOptions =
         deployOptions != null ? deployOptions : Collections.emptyList();
     List<String> finalServiceNames = serviceNames != null ? serviceNames : Collections.emptyList();
@@ -229,7 +231,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase {
                     deploymentName,
                     finalDeployOptions,
                     finalServiceNames,
-                    finalExcludeServiceNames));
+                    finalExcludeServiceNames,
+                    waitForCompletionTimeoutMinutes));
     builder.setSeverity(validationSettings.getSeverity());
 
     if (validationSettings.isValidate()) {
@@ -250,7 +253,8 @@ public class DeploymentController extends DeploymentsGrpc.DeploymentsImplBase {
                     request.getName(),
                     Collections.emptyList(),
                     Collections.emptyList(),
-                    Collections.emptyList()));
+                    Collections.emptyList(),
+                    Optional.empty()));
     builder.setValidateResponse(() -> deploymentService.validateDeployment(request.getName()));
     builder.setSeverity(Severity.WARNING);
     builder.setSetup(


### PR DESCRIPTION
This PR introduces `--wait-for-completion-timeout-minutes` option for `hal deploy apply` command and allows us to overwrite its 10 minutes default timeout value. The issue is reported in https://github.com/spinnaker/spinnaker/issues/5185.