### PR TITLE
fix(kubernetes): Only load kubeconfig if it's a local file

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/FileService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/FileService.java
@@ -91,6 +91,18 @@ public class FileService {
     return readFromLocalFilesystem(fileReference);
   }
 
+  /**
+   * Indicates if the given file reference is for a remote (secret reference, config server) or
+   * local file.
+   *
+   * @param fileReference to be checked.
+   * @return true if it's a remote file.
+   */
+  public boolean isRemoteFile(String fileReference) {
+    return CloudConfigResourceService.isCloudConfigResource(fileReference)
+        || EncryptedSecret.isEncryptedFile(fileReference);
+  }
+
   private byte[] readFromLocalFilesystem(String path) throws IOException {
     Path absolutePath = absolutePath(path);
     if (absolutePath == null) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KubernetesV2ClouddriverProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KubernetesV2ClouddriverProfileFactory.java
@@ -63,7 +63,13 @@ public class KubernetesV2ClouddriverProfileFactory extends ClouddriverProfileFac
       return;
     }
 
+    // If kubeconfigFile is remote, clouddriver will download it at runtime instead of using a
+    // halyard-generated version
     String kubeconfigFile = account.getKubeconfigFile();
+    if (StringUtils.isEmpty(kubeconfigFile) || fileService.isRemoteFile(kubeconfigFile)) {
+      return;
+    }
+
     String kubeconfigContents = getKubconfigFileContents(kubeconfigFile);
     String context = account.getContext();
 


### PR DESCRIPTION
Closes https://github.com/spinnaker/spinnaker/issues/5305

When kubeconfig is stored remotely, Halyard shouldn't try to modify it in place because clouddriver will download it from remote source anyway.