### PR TITLE
feat(build): Enable local Maven repo when detecting SNAPSHOT dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@
 
 buildscript {
   ext {
-    clouddriverVersion = "5.8.0"
-    front50Version = "2.1.0"
-    fiatVersion = "1.0.5"
+    clouddriverVersion = "5.47.1"
+    front50Version = "2.15.0"
+    fiatVersion = "1.13.1"
   }
   repositories {
     jcenter()

--- a/build.gradle
+++ b/build.gradle
@@ -79,3 +79,12 @@ def createScript(project, mainClass, name) {
     }
   }
 }
+
+subprojects { project ->
+  if ([korkVersion, fiatVersion, clouddriverVersion, front50Version].any { it.endsWith("-SNAPSHOT") }) {
+    logger.info("Enabling mavenLocal")
+    repositories {
+      mavenLocal()
+    }
+  }
+}

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -4,7 +4,7 @@ dependencies {
 
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-docker:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes:$clouddriverVersion"
+  implementation "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes-v1:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-appengine:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-azure:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-cloudfoundry:$clouddriverVersion"

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -6,6 +6,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-core:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes:$clouddriverVersion"
+  implementation "com.netflix.spinnaker.clouddriver:clouddriver-kubernetes-v1:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
   implementation "com.netflix.spinnaker.clouddriver:clouddriver-security:$clouddriverVersion"
   implementation "com.netflix.spinnaker.kork:kork-secrets"


### PR DESCRIPTION
Also updating dependencies: `clouddriver`, `front50` and `fiat` so they are use the same latest Spring Boot version (2.2.4)