### PR TITLE
chore(java11): Switch the containers to use Java 11.

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -9,7 +9,7 @@ ENV AWS_CLI_VERSION=1.17.9
 RUN apk --no-cache add --update \
   bash \
   curl \
-  openjdk8-jre \
+  openjdk11-jre \
   py-pip \
   python
 RUN pip install --upgrade awscli==${AWS_CLI_VERSION}

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -9,7 +9,7 @@ ENV AWS_CLI_VERSION=1.17.9
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-      openjdk-8-jre-headless \
+      openjdk-11-jre-headless \
       curl \
       python-pip && \
     pip install awscli==${AWS_CLI_VERSION} --upgrade


### PR DESCRIPTION
Halyard was accidentally forgotten the [the Java 11 RFC](https://github.com/spinnaker/governance/blob/master/rfc/java11.md). Unlike the other containers, I'm not going to provide Java 8 fallback containers for Halyard, since users can just use 1.30 if they have issues with Java 11. If there's a lot of demand for a Java 8 container, I'll look into providing them.