### PR TITLE
refactor(ci): Make AbstractAccountCommand reusable

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -3867,20 +3867,20 @@ hal config ci gcb account ACCOUNT [parameters] [subcommands]
 ```
 
 #### Parameters
-`ACCOUNT`: The name of the master to operate on.
+`ACCOUNT`: The name of the account to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 #### Subcommands
- * `add`: Add a Google Cloud Build account
+ * `add`: Add a Google Cloud Build account.
  * `delete`: Delete a Google Cloud Build account.
- * `edit`: Add a Google Cloud Build account
+ * `edit`: Edit a Google Cloud Build account.
  * `list`: List the Google Cloud Build accounts.
 
 ---
 ## hal config ci gcb account add
 
-Add a Google Cloud Build account
+Add a Google Cloud Build account.
 
 #### Usage
 ```
@@ -3888,12 +3888,12 @@ hal config ci gcb account add ACCOUNT [parameters]
 ```
 
 #### Parameters
-`ACCOUNT`: The name of the master to operate on.
+`ACCOUNT`: The name of the account to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--json-key`: The path to a JSON service account that Spinnaker will use as credentials
+ * `--json-key`: The path to a JSON service account that Spinnaker will use as credentials.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--project`: (*Required*) The name of the GCP project in which to trigger and monitor builds
- * `--subscription-name`: The name of the PubSub subscription on which to listen for build changes
+ * `--project`: (*Required*) The name of the GCP project in which to trigger and monitor builds.
+ * `--subscription-name`: The name of the PubSub subscription on which to listen for build changes.
 
 
 ---
@@ -3907,7 +3907,7 @@ hal config ci gcb account delete ACCOUNT [parameters]
 ```
 
 #### Parameters
-`ACCOUNT`: The name of the master to operate on.
+`ACCOUNT`: The name of the account to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
@@ -3915,7 +3915,7 @@ hal config ci gcb account delete ACCOUNT [parameters]
 ---
 ## hal config ci gcb account edit
 
-Add a Google Cloud Build account
+Edit a Google Cloud Build account.
 
 #### Usage
 ```
@@ -3923,12 +3923,12 @@ hal config ci gcb account edit ACCOUNT [parameters]
 ```
 
 #### Parameters
-`ACCOUNT`: The name of the master to operate on.
+`ACCOUNT`: The name of the account to operate on.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--json-key`: The path to a JSON service account that Spinnaker will use as credentials
+ * `--json-key`: The path to a JSON service account that Spinnaker will use as credentials.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--project`: The name of the GCP project in which to trigger and monitor builds
- * `--subscription-name`: The name of the PubSub subscription on which to listen for build changes
+ * `--project`: The name of the GCP project in which to trigger and monitor builds.
+ * `--subscription-name`: The name of the PubSub subscription on which to listen for build changes.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractAccountCommand.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.AbstractHasAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.DeleteAccountCommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.ListAccountsCommandBuilder;
+
+@Parameters(separators = "=")
+public abstract class AbstractAccountCommand extends AbstractHasAccountCommand {
+  @Override
+  public String getCommandName() {
+    return "account";
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Manage and view Spinnaker configuration for the "
+        + getCiFullName()
+        + " service account.";
+  }
+
+  protected AbstractAccountCommand() {
+    registerSubcommand(
+        new DeleteAccountCommandBuilder()
+            .setCiName(getCiName())
+            .setCiFullName(getCiFullName())
+            .build());
+
+    registerSubcommand(
+        new ListAccountsCommandBuilder()
+            .setCiName(getCiName())
+            .setCiFullName(getCiFullName())
+            .build());
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractAddAccountCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google, Inc.
+ * Copyright 2020 Amazon.com, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -12,49 +12,47 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
 
-/** Delete a specific Google Cloud Build account */
 @Parameters(separators = "=")
-public class GooglecloudBuildDeleteAccountCommand extends AbstractHasAccountCommand {
+public abstract class AbstractAddAccountCommand extends AbstractHasAccountCommand {
   @Getter(AccessLevel.PROTECTED)
   private Map<String, NestableCommand> subcommands = new HashMap<>();
 
   @Getter(AccessLevel.PUBLIC)
-  private String commandName = "delete";
+  private String commandName = "add";
 
-  protected String getCiName() {
-    return "gcb";
-  }
+  protected abstract CIAccount buildAccount(String accountName);
 
   public String getShortDescription() {
-    return "Delete a Google Cloud Build account.";
+    return "Add a " + getCiFullName() + " account.";
   }
 
   @Override
   protected void executeThis() {
     String accountName = getAccountName();
-    String currentDeployment = getCurrentDeployment();
+    CIAccount account = buildAccount(accountName);
     String ciName = getCiName();
+
+    String currentDeployment = getCurrentDeployment();
     new OperationHandler<Void>()
-        .setOperation(Daemon.deleteMaster(currentDeployment, ciName, accountName, !noValidate))
-        .setSuccessMessage(String.format("Deleted Google Cloud Build account %s.", accountName))
+        .setOperation(Daemon.addMaster(currentDeployment, ciName, !noValidate, account))
+        .setSuccessMessage(String.format("Added %s account %s.", getCiFullName(), accountName))
         .setFailureMesssage(
-            String.format("Failed to delete Google Cloud Build account %s.", accountName))
+            String.format("Failed to add %s account %s.", getCiFullName(), accountName))
         .get();
-    AnsiUi.success("Deleted " + accountName);
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractDeleteAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractDeleteAccountCommand.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+/** Delete a specific CI account */
+@Parameters(separators = "=")
+public abstract class AbstractDeleteAccountCommand extends AbstractHasAccountCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "delete";
+
+  public String getShortDescription() {
+    return "Delete a " + getCiFullName() + " account.";
+  }
+
+  @Override
+  protected void executeThis() {
+    deleteAccount(getAccountName());
+    AnsiUi.success("Deleted " + getAccountName());
+  }
+
+  private void deleteAccount(String accountName) {
+    String currentDeployment = getCurrentDeployment();
+    String ciName = getCiName();
+    new OperationHandler<Void>()
+        .setOperation(Daemon.deleteMaster(currentDeployment, ciName, accountName, !noValidate))
+        .setSuccessMessage(String.format("Deleted %s account %s.", getCiFullName(), accountName))
+        .setFailureMesssage(
+            String.format("Failed to delete %s account %s.", getCiFullName(), accountName))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractEditAccountCommand.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2020 Amazon, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public abstract class AbstractEditAccountCommand<T extends CIAccount>
+    extends AbstractHasAccountCommand {
+  @Getter(AccessLevel.PROTECTED)
+  private Map<String, NestableCommand> subcommands = new HashMap<>();
+
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  protected abstract CIAccount editAccount(T account);
+
+  public String getShortDescription() {
+    return "Edit a " + getCiFullName() + " account.";
+  }
+
+  @Override
+  protected void executeThis() {
+    String accountName = getAccountName();
+    String ciName = getCiName();
+    String currentDeployment = getCurrentDeployment();
+    // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
+    CIAccount account =
+        new OperationHandler<CIAccount>()
+            .setOperation(Daemon.getMaster(currentDeployment, ciName, accountName, false))
+            .setFailureMesssage(
+                String.format("Failed to edit %s account %s.", getCiFullName(), accountName))
+            .get();
+
+    int originalHash = account.hashCode();
+
+    account = editAccount((T) account);
+
+    if (originalHash == account.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+
+    new OperationHandler<Void>()
+        .setOperation(
+            Daemon.setMaster(currentDeployment, ciName, accountName, !noValidate, account))
+        .setSuccessMessage(String.format("Edited %s account %s.", getCiFullName(), accountName))
+        .setFailureMesssage(
+            String.format("Failed to edit %s account %s.", getCiFullName(), accountName))
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractHasAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractHasAccountCommand.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -25,7 +25,7 @@ import java.util.List;
 /** An abstract definition for commands that accept 'account' as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasAccountCommand extends AbstractCiCommand {
-  @Parameter(description = "The name of the master to operate on.", arity = 1)
+  @Parameter(description = "The name of the account to operate on.", arity = 1)
   List<String> accounts = new ArrayList<>();
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractListAccountsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractListAccountsCommand.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google, Inc.
+ * Copyright 2020 Amazon.com, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -12,9 +12,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractCiCommand;
@@ -27,14 +28,9 @@ import java.util.List;
 import lombok.Getter;
 
 @Parameters(separators = "=")
-class GoogleCloudBuildListAccountsCommand extends AbstractCiCommand {
+abstract class AbstractListAccountsCommand extends AbstractCiCommand {
   public String getShortDescription() {
-    return "List the Google Cloud Build accounts.";
-  }
-
-  @Override
-  protected String getCiName() {
-    return "gcb";
+    return "List the " + getCiFullName() + " accounts.";
   }
 
   @Getter private String commandName = "list";
@@ -44,7 +40,7 @@ class GoogleCloudBuildListAccountsCommand extends AbstractCiCommand {
     String ciName = getCiName();
     return new OperationHandler<Ci>()
         .setOperation(Daemon.getCi(currentDeployment, ciName, !noValidate))
-        .setFailureMesssage("Failed to get Google Cloud Build account.")
+        .setFailureMesssage("Failed to list " + getCiFullName() + " accounts.")
         .get();
   }
 
@@ -53,9 +49,9 @@ class GoogleCloudBuildListAccountsCommand extends AbstractCiCommand {
     Ci ci = getCi();
     List<CIAccount> account = ci.listAccounts();
     if (account.isEmpty()) {
-      AnsiUi.success("No configured Google Cloud Build accounts.");
+      AnsiUi.success("No configured " + getCiFullName() + " accounts.");
     } else {
-      AnsiUi.success("Google Cloud Build accounts:");
+      AnsiUi.success(getCiFullName() + " accounts:");
       account.forEach(master -> AnsiUi.listItem(master.getName()));
     }
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/DeleteAccountCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/DeleteAccountCommandBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class DeleteAccountCommandBuilder implements CommandBuilder {
+  @Setter String ciName;
+  @Setter String ciFullName;
+
+  @Override
+  public NestableCommand build() {
+    return new DeleteAccountCommandBuilder.DeleteAccountCommand(ciName, ciFullName);
+  }
+
+  @Parameters(separators = "=")
+  private static class DeleteAccountCommand extends AbstractDeleteAccountCommand {
+    private DeleteAccountCommand(String ciName, String ciFullName) {
+      this.ciName = ciName;
+      this.ciFullName = ciFullName == null ? ciName : ciFullName;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    private String ciName;
+
+    @Getter(AccessLevel.PROTECTED)
+    private String ciFullName;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/ListAccountsCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/ListAccountsCommandBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
+import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ListAccountsCommandBuilder implements CommandBuilder {
+  @Setter String ciName;
+  @Setter String ciFullName;
+
+  @Override
+  public NestableCommand build() {
+    return new ListAccountsCommand(ciName, ciFullName);
+  }
+
+  @Parameters(separators = "=")
+  private static class ListAccountsCommand extends AbstractListAccountsCommand {
+    private ListAccountsCommand(String ciName, String ciFullName) {
+      this.ciName = ciName;
+      this.ciFullName = ciFullName;
+    }
+
+    @Getter(AccessLevel.PROTECTED)
+    private String ciName;
+
+    @Getter(AccessLevel.PROTECTED)
+    private String ciFullName;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAccountCommand.java
@@ -17,13 +17,18 @@
 package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
 
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractAccountCommand;
 
 /** Interact with Google Cloud Build accounts */
 @Parameters(separators = "=")
-public class GoogleCloudBuildAccountCommand extends AbstractHasAccountCommand {
+public class GoogleCloudBuildAccountCommand extends AbstractAccountCommand {
   protected String getCiName() {
     return "gcb";
+  }
+
+  @Override
+  protected String getCiFullName() {
+    return "Google Cloud Build";
   }
 
   @Override
@@ -33,19 +38,7 @@ public class GoogleCloudBuildAccountCommand extends AbstractHasAccountCommand {
 
   public GoogleCloudBuildAccountCommand() {
     super();
-    registerSubcommand(new GoogleCloudBuildListAccountsCommand());
     registerSubcommand(new GoogleCloudBuildAddAccountCommand());
     registerSubcommand(new GoogleCloudBuildEditAccountCommand());
-    registerSubcommand(new GooglecloudBuildDeleteAccountCommand());
-  }
-
-  @Override
-  public String getShortDescription() {
-    return "Manage and view Spinnaker configuration for the Google Cloud Build service account.";
-  }
-
-  @Override
-  protected void executeThis() {
-    showHelp();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildAddAccountCommand.java
@@ -18,69 +18,42 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master.AbstractHasAccountCommand;
-import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.AbstractAddAccountCommand;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuildAccount;
-import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
-import java.util.HashMap;
-import java.util.Map;
-import lombok.AccessLevel;
-import lombok.Getter;
 
 @Parameters(separators = "=")
-public class GoogleCloudBuildAddAccountCommand extends AbstractHasAccountCommand {
-  @Getter(AccessLevel.PROTECTED)
-  private Map<String, NestableCommand> subcommands = new HashMap<>();
-
+public class GoogleCloudBuildAddAccountCommand extends AbstractAddAccountCommand {
   protected String getCiName() {
     return "gcb";
   }
 
-  public String getShortDescription() {
-    return "Add a Google Cloud Build account";
+  @Override
+  protected String getCiFullName() {
+    return "Google Cloud Build";
   }
-
-  @Getter(AccessLevel.PUBLIC)
-  private String commandName = "add";
 
   @Parameter(
       names = "--project",
       required = true,
-      description = "The name of the GCP project in which to trigger and monitor builds")
+      description = GoogleCloudBuildCommandProperties.PROJECT_DESCRIPTION)
   private String project;
 
   @Parameter(
       names = "--subscription-name",
-      description = "The name of the PubSub subscription on which to listen for build changes")
+      description = GoogleCloudBuildCommandProperties.SUBSCRIPTION_NAME_DESCRIPTION)
   private String subscriptionName;
 
   @Parameter(
       names = "--json-key",
-      description = "The path to a JSON service account that Spinnaker will use as credentials")
+      description = GoogleCloudBuildCommandProperties.JSON_KEY_DESCRIPTION)
   private String jsonKey;
 
+  @Override
   protected GoogleCloudBuildAccount buildAccount(String accountName) {
     return new GoogleCloudBuildAccount()
         .setName(accountName)
         .setProject(project)
         .setSubscriptionName(subscriptionName)
         .setJsonKey(jsonKey);
-  }
-
-  @Override
-  protected void executeThis() {
-    String accountName = getAccountName();
-    CIAccount account = buildAccount(accountName);
-    String ciName = getCiName();
-
-    String currentDeployment = getCurrentDeployment();
-    new OperationHandler<Void>()
-        .setOperation(Daemon.addMaster(currentDeployment, ciName, !noValidate, account))
-        .setSuccessMessage(String.format("Added Google Cloud Build account %s.", accountName))
-        .setFailureMesssage(
-            String.format("Failed to add Google Cloud Build account %s.", accountName))
-        .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/gcb/GoogleCloudBuildCommandProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 Google, Inc.
+ * Copyright 2020 Amazon.com, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License")
  * you may not use this file except in compliance with the License.
@@ -15,16 +15,15 @@
  *
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.ci;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb;
 
-import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
+public class GoogleCloudBuildCommandProperties {
+  static final String PROJECT_DESCRIPTION =
+      "The name of the GCP project in which to trigger and monitor builds.";
 
-@Parameters(separators = "=")
-public abstract class AbstractCiCommand extends AbstractConfigCommand {
-  protected abstract String getCiName();
+  static final String JSON_KEY_DESCRIPTION =
+      "The path to a JSON service account that Spinnaker will use as credentials.";
 
-  protected String getCiFullName() {
-    return getCiName();
-  }
+  static final String SUBSCRIPTION_NAME_DESCRIPTION =
+      "The name of the PubSub subscription on which to listen for build changes.";
 }


### PR DESCRIPTION
GoogleCloudBuildAccountCommand directly implements AbstractHasAccountCommand. This is ok currently since Google Cloud Build is the only CI service that uses account instead of master. However, it blocks adding new account-based CI service to halyard since a lot of logics need to be duplicated across packages. This commit is aimming to abstract some common parts for account-based commands which makes adding a new CI service much easier.