### PR TITLE
feat(codebuild): Add support for manipulating AWS CodeBuild accounts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -176,6 +176,15 @@
  * [**hal config canary signalfx disable**](#hal-config-canary-signalfx-disable)
  * [**hal config canary signalfx enable**](#hal-config-canary-signalfx-enable)
  * [**hal config ci**](#hal-config-ci)
+ * [**hal config ci codebuild**](#hal-config-ci-codebuild)
+ * [**hal config ci codebuild account**](#hal-config-ci-codebuild-account)
+ * [**hal config ci codebuild account add**](#hal-config-ci-codebuild-account-add)
+ * [**hal config ci codebuild account delete**](#hal-config-ci-codebuild-account-delete)
+ * [**hal config ci codebuild account edit**](#hal-config-ci-codebuild-account-edit)
+ * [**hal config ci codebuild account get**](#hal-config-ci-codebuild-account-get)
+ * [**hal config ci codebuild account list**](#hal-config-ci-codebuild-account-list)
+ * [**hal config ci codebuild disable**](#hal-config-ci-codebuild-disable)
+ * [**hal config ci codebuild enable**](#hal-config-ci-codebuild-enable)
  * [**hal config ci concourse**](#hal-config-ci-concourse)
  * [**hal config ci concourse disable**](#hal-config-ci-concourse-disable)
  * [**hal config ci concourse enable**](#hal-config-ci-concourse-enable)
@@ -3667,11 +3676,172 @@ hal config ci [subcommands]
 ```
 
 #### Subcommands
+ * `codebuild`: Manage and view Spinnaker configuration for AWS CodeBuild
  * `concourse`: Manage and view Spinnaker configuration for the concourse ci
  * `gcb`: Manage and view Spinnaker configuration for Google Cloud Build
  * `jenkins`: Manage and view Spinnaker configuration for the jenkins ci
  * `travis`: Manage and view Spinnaker configuration for the travis ci
  * `wercker`: Manage and view Spinnaker configuration for the wercker ci
+
+---
+## hal config ci codebuild
+
+Manage and view Spinnaker configuration for AWS CodeBuild
+
+#### Usage
+```
+hal config ci codebuild [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `account`: Manage and view Spinnaker configuration for AWS CodeBuild service account.
+ * `disable`: Set the codebuild ci as disabled
+ * `enable`: Set the codebuild ci as enabled
+
+---
+## hal config ci codebuild account
+
+Manage and view Spinnaker configuration for AWS CodeBuild service account.
+
+#### Usage
+```
+hal config ci codebuild account ACCOUNT [parameters] [subcommands]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `add`: Add a AWS CodeBuild account.
+ * `delete`: Delete a AWS CodeBuild account.
+ * `edit`: Edit a AWS CodeBuild account.
+ * `get`: Get the account details for AWS CodeBuild.
+ * `list`: List the AWS CodeBuild accounts.
+
+---
+## hal config ci codebuild account add
+
+Add a AWS CodeBuild account.
+
+#### Usage
+```
+hal config ci codebuild account add ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--account-id`: (*Required*) The AWS account ID that will be used to trigger CodeBuild build.
+ * `--assume-role`: (*Required*) If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
+
+Example: "user/spinnaker" or "role/spinnakerManaged"
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--region`: (*Required*) The AWS region in which your CodeBuild projects live.
+
+
+---
+## hal config ci codebuild account delete
+
+Delete a AWS CodeBuild account.
+
+#### Usage
+```
+hal config ci codebuild account delete ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci codebuild account edit
+
+Edit a AWS CodeBuild account.
+
+#### Usage
+```
+hal config ci codebuild account edit ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--account-id`: The AWS account ID that will be used to trigger CodeBuild build.
+ * `--assume-role`: If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
+
+Example: "user/spinnaker" or "role/spinnakerManaged"
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--region`: The AWS region in which your CodeBuild projects live.
+
+
+---
+## hal config ci codebuild account get
+
+Get the account details for AWS CodeBuild.
+
+#### Usage
+```
+hal config ci codebuild account get ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci codebuild account list
+
+List the AWS CodeBuild accounts.
+
+#### Usage
+```
+hal config ci codebuild account list [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci codebuild disable
+
+Set the codebuild ci as disabled
+
+#### Usage
+```
+hal config ci codebuild disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci codebuild enable
+
+Set the codebuild ci as enabled
+
+#### Usage
+```
+hal config ci codebuild enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
 
 ---
 ## hal config ci concourse

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/CiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/CiCommand.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.ci;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild.AwsCodeBuildCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.concourse.ConcourseCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.gcb.GoogleCloudBuildCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.jenkins.JenkinsCommand;
@@ -42,6 +43,7 @@ public class CiCommand extends NestableCommand {
       "Configure, validate, and view the specified Continuous Integration service.";
 
   public CiCommand() {
+    registerSubcommand(new AwsCodeBuildCommand());
     registerSubcommand(new ConcourseCommand());
     registerSubcommand(new GoogleCloudBuildCommand());
     registerSubcommand(new JenkinsCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractGetAccountCommand.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Amazon, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import lombok.Getter;
+
+@Parameters(separators = "=")
+public abstract class AbstractGetAccountCommand<T extends CIAccount>
+    extends AbstractHasAccountCommand {
+  @Getter private String commandName = "get";
+
+  public String getShortDescription() {
+    return "Get the account details for " + getCiFullName() + ".";
+  }
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    String masterName = getAccountName();
+    String ciName = getCiName();
+    new OperationHandler<CIAccount>()
+        .setOperation(Daemon.getMaster(currentDeployment, ciName, masterName, !noValidate))
+        .setFailureMesssage(String.format("Failed to get %s account.", getCiFullName()))
+        .setFormat(AnsiFormatUtils.Format.STRING)
+        .setUserFormatted(true)
+        .get();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildAccountCommand.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractAccountCommand;
+
+/** Interact with AWS CodeBuild's accounts */
+@Parameters(separators = "=")
+public class AwsCodeBuildAccountCommand extends AbstractAccountCommand {
+  protected String getCiName() {
+    return "codebuild";
+  }
+
+  @Override
+  protected String getCiFullName() {
+    return "AWS CodeBuild";
+  }
+
+  @Override
+  public String getCommandName() {
+    return "account";
+  }
+
+  public AwsCodeBuildAccountCommand() {
+    super();
+    registerSubcommand(new AwsCodeBuildAddAccountCommand());
+    registerSubcommand(new AwsCodeBuildEditAccountCommand());
+    registerSubcommand(new AwsCodeBuildGetAccountCommand());
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Manage and view Spinnaker configuration for AWS CodeBuild service account.";
+  }
+
+  @Override
+  protected void executeThis() {
+    showHelp();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildAddAccountCommand.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.AbstractAddAccountCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
+
+@Parameters(separators = "=")
+public class AwsCodeBuildAddAccountCommand extends AbstractAddAccountCommand {
+  protected String getCiName() {
+    return "codebuild";
+  }
+
+  @Override
+  protected String getCiFullName() {
+    return "AWS CodeBuild";
+  }
+
+  @Parameter(
+      names = "--account-id",
+      required = true,
+      description = AwsCodeBuildCommandProperties.ACCOUNT_ID_DESCRIPTION)
+  private String accountId;
+
+  @Parameter(
+      names = "--assume-role",
+      required = true,
+      description = AwsCodeBuildCommandProperties.ASSUME_ROLE_DESCRIPTION)
+  private String assumeRole;
+
+  @Parameter(
+      names = "--region",
+      required = true,
+      description = AwsCodeBuildCommandProperties.REGION_DESCRIPTION)
+  private String region;
+
+  @Override
+  protected AwsCodeBuildAccount buildAccount(String accountName) {
+    return new AwsCodeBuildAccount()
+        .setName(accountName)
+        .setAccountId(accountId)
+        .setAssumeRole(assumeRole)
+        .setRegion(region);
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommand.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractNamedCiCommand;
+
+/** Interact with AWS CodeBuild */
+@Parameters(separators = "=")
+public class AwsCodeBuildCommand extends AbstractNamedCiCommand {
+  protected String getCiName() {
+    return "codebuild";
+  }
+
+  @Override
+  public String getCommandName() {
+    return "codebuild";
+  }
+
+  public AwsCodeBuildCommand() {
+    super();
+    registerSubcommand(new AwsCodeBuildAccountCommand());
+  }
+
+  @Override
+  public String getShortDescription() {
+    return "Manage and view Spinnaker configuration for AWS CodeBuild";
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommandProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
+
+public class AwsCodeBuildCommandProperties {
+  static final String ACCOUNT_ID_DESCRIPTION =
+      "The AWS account ID that will be used to trigger CodeBuild build.";
+  static final String REGION_DESCRIPTION = "The AWS region in which your CodeBuild projects live.";
+  static final String ASSUME_ROLE_DESCRIPTION =
+      "If set, Halyard will configure a credentials provider that uses AWS "
+          + "Security Token Service to assume the specified role.\n\n"
+          + "Example: \"user/spinnaker\" or \"role/spinnakerManaged\"";
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildEditAccountCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.AbstractEditAccountCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
+
+@Parameters(separators = "=")
+public class AwsCodeBuildEditAccountCommand
+    extends AbstractEditAccountCommand<AwsCodeBuildAccount> {
+  protected String getCiName() {
+    return "codebuild";
+  }
+
+  @Override
+  protected String getCiFullName() {
+    return "AWS CodeBuild";
+  }
+
+  @Parameter(
+      names = "--account-id",
+      description = AwsCodeBuildCommandProperties.ACCOUNT_ID_DESCRIPTION)
+  private String accountId;
+
+  @Parameter(
+      names = "--assume-role",
+      description = AwsCodeBuildCommandProperties.ASSUME_ROLE_DESCRIPTION)
+  private String assumeRole;
+
+  @Parameter(names = "--region", description = AwsCodeBuildCommandProperties.REGION_DESCRIPTION)
+  private String region;
+
+  @Override
+  protected AwsCodeBuildAccount editAccount(AwsCodeBuildAccount account) {
+    if (isSet(accountId)) {
+      account.setAccountId(accountId);
+    }
+
+    if (isSet(assumeRole)) {
+      account.setAssumeRole(assumeRole);
+    }
+
+    if (isSet(region)) {
+      account.setRegion(region);
+    }
+
+    return account;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildGetAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildGetAccountCommand.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.AbstractGetAccountCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
+
+@Parameters(separators = "=")
+public class AwsCodeBuildGetAccountCommand extends AbstractGetAccountCommand<AwsCodeBuildAccount> {
+  protected String getCiName() {
+    return "codebuild";
+  }
+
+  @Override
+  protected String getCiFullName() {
+    return "AWS CodeBuild";
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/CiType.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/CiType.java
@@ -16,6 +16,8 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.ci;
 
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseMaster;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
@@ -34,7 +36,8 @@ public enum CiType {
   travis(TravisCi.class, TravisMaster.class),
   wercker(WerckerCi.class, WerckerMaster.class),
   concourse(ConcourseCi.class, ConcourseMaster.class),
-  gcb(GoogleCloudBuild.class, GoogleCloudBuildAccount.class);
+  gcb(GoogleCloudBuild.class, GoogleCloudBuildAccount.class),
+  codebuild(AwsCodeBuild.class, AwsCodeBuildAccount.class);
 
   public final Class<? extends Ci> ciClass;
   public final Class<? extends CIAccount> accountClass;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuild.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuild.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class AwsCodeBuild extends Ci<AwsCodeBuildAccount> {
+  private boolean enabled;
+  private List<AwsCodeBuildAccount> accounts = new ArrayList<>();
+
+  public List<AwsCodeBuildAccount> listAccounts() {
+    return accounts;
+  }
+
+  @Override
+  public String getNodeName() {
+    return "codebuild";
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuildAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuildAccount.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class AwsCodeBuildAccount extends CIAccount {
+  private String name;
+  private String accountId;
+  private String assumeRole;
+  private String region;
+
+  public String getNodeName() {
+    return name;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.concourse.ConcourseCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsCi;
@@ -32,6 +33,7 @@ public class Cis extends Node implements Cloneable {
   WerckerCi wercker = new WerckerCi();
   ConcourseCi concourse = new ConcourseCi();
   GoogleCloudBuild gcb = new GoogleCloudBuild();
+  AwsCodeBuild codebuild = new AwsCodeBuild();
 
   public boolean ciEnabled() {
     NodeIterator iterator = getChildren();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/AwsCodeBuildService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ci/AwsCodeBuildService.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.services.v1.ci;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AwsCodeBuildService extends CiService<AwsCodeBuildAccount, AwsCodeBuild> {
+  public AwsCodeBuildService(CiService.Members members) {
+    super(members);
+  }
+
+  public String ciName() {
+    return "codebuild";
+  }
+
+  protected List<AwsCodeBuild> getMatchingCiNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, AwsCodeBuild.class);
+  }
+
+  protected List<AwsCodeBuildAccount> getMatchingAccountNodes(NodeFilter filter) {
+    return lookupService.getMatchingNodesOfType(filter, AwsCodeBuildAccount.class);
+  }
+
+  @Override
+  public AwsCodeBuildAccount convertToAccount(Object object) {
+    return objectMapper.convertValue(object, AwsCodeBuildAccount.class);
+  }
+}

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/AwsCodeBuildController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/ci/AwsCodeBuildController.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.controllers.v1.ci;
+
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuild;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
+import com.netflix.spinnaker.halyard.config.services.v1.ci.AwsCodeBuildService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/ci/codebuild")
+public class AwsCodeBuildController extends CiController<AwsCodeBuildAccount, AwsCodeBuild> {
+  public AwsCodeBuildController(
+      CiController.Members members, AwsCodeBuildService awsCodeBuildService) {
+    super(members, awsCodeBuildService);
+  }
+}


### PR DESCRIPTION
Igor configuration for AWS CodeBuild is already merged https://github.com/spinnaker/igor/commit/8422a0a08275e1ef15cbb9863b10b245339fbd4a
This PR allows users to configure AWS CodeBuild accounts through halyard command line tool.

Test steps:
1. `cd` into halyard root directory
2. Run `./gradlew` to start halyard daemon
3. Run `./halyard-cli/build/install/halyard-cli/bin/halyard-cli config ci codebuild account add <ACCOUNT> --account-id <ACCOUNT_ID> --assume-role <ROLE> --region <REGION>` to test adding account
4. Run `./halyard-cli/build/install/halyard-cli/bin/halyard-cli config ci codebuild account get <ACCOUNT>` to test getting account
5. Run `./halyard-cli/build/install/halyard-cli/bin/halyard-cli config ci codebuild account list` to test listing accounts
6. Run `./halyard-cli/build/install/halyard-cli/bin/halyard-cli config ci codebuild account edit <ACCOUNT> --region <ANOTHER_REGION>` to test updating account
7. Run `./halyard-cli/build/install/halyard-cli/bin/halyard-cli config ci codebuild account delete <ACCOUNT>` to test deleting account
8. Run `./halyard-cli/build/install/halyard-cli/bin/halyard-cli config ci codebuild enable` to test enable and disable codebuild