### PR TITLE
feat(kubernetes): Enable TCP probe for containers

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -36,6 +36,7 @@ public class KubernetesSettings {
   String serviceType = "ClusterIP";
   String nodePort = null;
   Boolean useExecHealthCheck = true;
+  Boolean useTcpProbe = false;
   KubernetesSecurityContext securityContext = null;
   DeploymentStrategy deploymentStrategy = null;
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -423,7 +423,8 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
 
   default TemplatedResource getProbe(ServiceSettings settings, Integer initialDelaySeconds) {
     TemplatedResource probe;
-    if (StringUtils.isNotEmpty(settings.getHealthEndpoint())) {
+    if (StringUtils.isNotEmpty(settings.getHealthEndpoint())
+        && !settings.getKubernetes().getUseTcpProbe()) {
       if (settings.getKubernetes().getUseExecHealthCheck()) {
         probe = new JinjaJarResource("/kubernetes/manifests/execProbe.yml");
         probe.addBinding("command", getReadinessExecCommand(settings));

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -423,20 +423,18 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
 
   default TemplatedResource getProbe(ServiceSettings settings, Integer initialDelaySeconds) {
     TemplatedResource probe;
-    if (StringUtils.isNotEmpty(settings.getHealthEndpoint())
-        && !settings.getKubernetes().getUseTcpProbe()) {
-      if (settings.getKubernetes().getUseExecHealthCheck()) {
-        probe = new JinjaJarResource("/kubernetes/manifests/execProbe.yml");
-        probe.addBinding("command", getReadinessExecCommand(settings));
-      } else {
-        probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
-        probe.addBinding("port", settings.getPort());
-        probe.addBinding("path", settings.getHealthEndpoint());
-        probe.addBinding("scheme", settings.getScheme().toUpperCase());
-      }
-    } else {
+    if (!StringUtils.isNotEmpty(settings.getHealthEndpoint())
+        || settings.getKubernetes().getUseTcpProbe()) {
       probe = new JinjaJarResource("/kubernetes/manifests/tcpSocketProbe.yml");
       probe.addBinding("port", settings.getPort());
+    } else if (settings.getKubernetes().getUseExecHealthCheck()) {
+      probe = new JinjaJarResource("/kubernetes/manifests/execProbe.yml");
+      probe.addBinding("command", getReadinessExecCommand(settings));
+    } else {
+      probe = new JinjaJarResource("/kubernetes/manifests/httpProbe.yml");
+      probe.addBinding("port", settings.getPort());
+      probe.addBinding("path", settings.getHealthEndpoint());
+      probe.addBinding("scheme", settings.getScheme().toUpperCase());
     }
     probe.addBinding("initialDelaySeconds", initialDelaySeconds);
     return probe;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -423,7 +423,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
 
   default TemplatedResource getProbe(ServiceSettings settings, Integer initialDelaySeconds) {
     TemplatedResource probe;
-    if (!StringUtils.isNotEmpty(settings.getHealthEndpoint())
+    if (StringUtils.isEmpty(settings.getHealthEndpoint())
         || settings.getKubernetes().getUseTcpProbe()) {
       probe = new JinjaJarResource("/kubernetes/manifests/tcpSocketProbe.yml");
       probe.addBinding("port", settings.getPort());


### PR DESCRIPTION
Adding a flag to switch readiness to TCP probe. The reason for that is to enable deployments with mTLS where the `wget` readiness probe won't work. We could also allow users to provide their own `exec` command to use a valid client certificate but that's not covered by this PR :)

To enable the TCP probe, add the following to service-settings/<service>.yml:
```
kubernetes:
  useTcpProbe: true
```