### PR TITLE
feat(telemetry): add ability to report deploy method

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
@@ -39,6 +39,16 @@ public class Telemetry extends Node {
   private String endpoint = DEFAULT_TELEMETRY_ENDPOINT;
   private String instanceId = new ULID().nextULID();
   private String spinnakerVersion;
+  private DeploymentMethod deploymentMethod = new DeploymentMethod();
   private int connectionTimeoutMillis = 3000;
   private int readTimeoutMillis = 5000;
+
+  @Data
+  public static class DeploymentMethod {
+
+    public static String HALYARD = "halyard";
+
+    private String type;
+    private String version;
+  }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -116,15 +116,15 @@ public class EchoProfileFactory extends SpringProfileFactory {
     profile.appendContents(profile.getBaseContents()).setRequiredFiles(files);
   }
 
-  private Telemetry.DeploymentMethod deploymentMethod(){
+  private Telemetry.DeploymentMethod deploymentMethod() {
     return new Telemetry.DeploymentMethod()
-            .setType(Telemetry.DeploymentMethod.HALYARD)
-            .setVersion(halyardVersion());
+        .setType(Telemetry.DeploymentMethod.HALYARD)
+        .setVersion(halyardVersion());
   }
 
   private String halyardVersion() {
     return Optional.ofNullable(EchoProfileFactory.class.getPackage().getImplementationVersion())
-            .orElse("Unknown");
+        .orElse("Unknown");
   }
 
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -18,12 +18,18 @@ package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile;
 
 import com.netflix.spinnaker.halyard.config.config.v1.ResourceConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
-import com.netflix.spinnaker.halyard.config.model.v1.node.*;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Artifacts;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Cis;
+import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Notifications;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsubs;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService.Type;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import lombok.Data;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -101,12 +107,24 @@ public class EchoProfileFactory extends SpringProfileFactory {
         telemetryVersion = deploymentConfiguration.getVersion();
       }
       telemetry.setSpinnakerVersion(telemetryVersion);
+      telemetry.setDeploymentMethod(deploymentMethod());
       profile.appendContents(
           yamlToString(
               deploymentConfiguration.getName(), profile, new TelemetryWrapper(telemetry)));
     }
 
     profile.appendContents(profile.getBaseContents()).setRequiredFiles(files);
+  }
+
+  private Telemetry.DeploymentMethod deploymentMethod(){
+    return new Telemetry.DeploymentMethod()
+            .setType(Telemetry.DeploymentMethod.HALYARD)
+            .setVersion(halyardVersion());
+  }
+
+  private String halyardVersion() {
+    return Optional.ofNullable(EchoProfileFactory.class.getPackage().getImplementationVersion())
+            .orElse("Unknown");
   }
 
   @Data


### PR DESCRIPTION
This is a follow-up to spinnaker/kork#503 and /spinnaker/echo#770 where we added deploy method and version. 
This change in halyard allows sending the telemetry information with the deployment method and version.