### PR TITLE
fix(gate): apply the JVM flags to gate

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2DeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2DeckService.java
@@ -25,7 +25,6 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.deck.DeckDocker
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.DeckService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedService.DeployPriority;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesSharedServiceSettings;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -81,14 +80,7 @@ public class KubernetesV2DeckService extends DeckService
   }
 
   @Override
-  public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
-    KubernetesSharedServiceSettings kubernetesSharedServiceSettings =
-        new KubernetesSharedServiceSettings(deploymentConfiguration);
-    ServiceSettings settings = defaultServiceSettings(deploymentConfiguration);
-    settings
-        .setArtifactId(getArtifactId(deploymentConfiguration))
-        .setLocation(kubernetesSharedServiceSettings.getDeployLocation())
-        .setEnabled(true);
-    return settings;
+  public Optional<String> buildAddress(String namespace) {
+    return Optional.empty();
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2GateService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2GateService.java
@@ -25,11 +25,11 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.GateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.DistributedService.DeployPriority;
-import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesSharedServiceSettings;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -53,15 +53,8 @@ public class KubernetesV2GateService extends GateService
   }
 
   @Override
-  public ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
-    KubernetesSharedServiceSettings kubernetesSharedServiceSettings =
-        new KubernetesSharedServiceSettings(deploymentConfiguration);
-    ServiceSettings settings = defaultServiceSettings(deploymentConfiguration);
-    settings
-        .setArtifactId(getArtifactId(deploymentConfiguration))
-        .setLocation(kubernetesSharedServiceSettings.getDeployLocation())
-        .setEnabled(true);
-    return settings;
+  public Optional<String> buildAddress(String namespace) {
+    return Optional.empty();
   }
 
   @Override

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -57,6 +57,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -751,8 +752,8 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     return result;
   }
 
-  default String buildAddress(String namespace) {
-    return Strings.join(".", getServiceName(), namespace);
+  default Optional<String> buildAddress(String namespace) {
+    return Optional.of(Strings.join(".", getServiceName(), namespace));
   }
 
   default ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {
@@ -761,10 +762,10 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     ServiceSettings settings = defaultServiceSettings(deploymentConfiguration);
     String location = kubernetesSharedServiceSettings.getDeployLocation();
     settings
-        .setAddress(buildAddress(location))
         .setArtifactId(getArtifactId(deploymentConfiguration))
         .setLocation(location)
         .setEnabled(isEnabled(deploymentConfiguration));
+    buildAddress(location).ifPresent(settings::setAddress);
     if (runsOnJvm()) {
       // Use half the available memory allocated to the container for the JVM heap
       settings.getEnv().put("JAVA_OPTS", "-XX:MaxRAMPercentage=50.0");


### PR DESCRIPTION
It looks like gate and deck were overriding `buildServiceSettings` just to avoid calling `setAddress`. But then when the JVM flags got added to that `buildServiceSettings`, they both missed that functionality. Since `deck` doesn't use a JVM, that's no big deal, but for `gate` it's an issue.

Held my nose and went for a minimally invasive change rather than a more holistic cleanup.

Fixes spinnaker/spinnaker#5483