### PR TITLE
feat(kubernetes): prepare for upcoming removal of V1 provider

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7149,7 +7149,6 @@ hal config provider appengine account add ACCOUNT [parameters]
  * `--omit-services`: A list of regular expressions. Any service matching one of these regexes will be ignored by Spinnaker.
  * `--omit-versions`: A list of regular expressions. Any version matching one of these regexes will be ignored by Spinnaker.
  * `--project`: (*Required*) The Google Cloud Platform project this Spinnaker account will manage.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--services`: A list of regular expressions. Any service matching one of these regexes will be indexed by Spinnaker.
@@ -7205,7 +7204,6 @@ hal config provider appengine account edit ACCOUNT [parameters]
  * `--omit-services`: A list of regular expressions. Any service matching one of these regexes will be ignored by Spinnaker.
  * `--omit-versions`: A list of regular expressions. Any version matching one of these regexes will be ignored by Spinnaker.
  * `--project`: The Google Cloud Platform project this Spinnaker account will manage.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
@@ -7373,7 +7371,6 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
 
  * `--launching-lifecycle-hook-role-arn`: The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target, for example, an Amazon SNS topic or an Amazon SQS queue.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: (*Default*: `[]`) The AWS regions this Spinnaker account will manage.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -7438,7 +7435,6 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
 
  * `--launching-lifecycle-hook-role-arn`: The ARN of the IAM role that allows the Auto Scaling group to publish to the specified notification target, for example, an Amazon SNS topic or an Amazon SQS queue.
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: The AWS regions this Spinnaker account will manage.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
@@ -7669,7 +7665,6 @@ hal config provider azure account add ACCOUNT [parameters]
  * `--object-id`: The objectId of your service principal. This is only required if using Packer to bake Windows images.
  * `--packer-resource-group`: The resource group to use if baking images with Packer.
  * `--packer-storage-account`: The storage account to use if baking images with Packer.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: (*Default*: `[westus, eastus]`) The Azure regions this Spinnaker account will manage.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -7720,7 +7715,6 @@ hal config provider azure account edit ACCOUNT [parameters]
  * `--object-id`: The objectId of your service principal. This is only required if using Packer to bake Windows images.
  * `--packer-resource-group`: The resource group to use if baking images with Packer.
  * `--packer-storage-account`: The storage account to use if baking images with Packer.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: The Azure regions this Spinnaker account will manage.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
@@ -8004,7 +7998,6 @@ hal config provider cloudfoundry account add ACCOUNT [parameters]
  * `--metrics-url, --metrics-uri, --metricsUri`: HTTP(S) URL of the metrics application for the CloudFoundry Foundation ie. `[https://metrics.sys.somesystem.com](https://metrics.sys.somesystem.com)`
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: (*Required*) Password for the account to use on for this CloudFoundry Foundation
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--skip-ssl-validation`: (*Default*: `false`) Skip SSL server certificate validation of the API endpoint
@@ -8050,7 +8043,6 @@ hal config provider cloudfoundry account edit ACCOUNT [parameters]
  * `--metrics-url, --metrics-uri, --metricsUri`: HTTP(S) URL of the metrics application for the CloudFoundry Foundation ie. `[https://metrics.sys.somesystem.com](https://metrics.sys.somesystem.com)`
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: Password for the account to use on for this CloudFoundry Foundation
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
@@ -8182,7 +8174,6 @@ hal config provider dcos account add ACCOUNT [parameters]
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: Password for a user account
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--service-key-file`: Path to a file containing the secret key for service account authentication
@@ -8226,7 +8217,6 @@ hal config provider dcos account edit ACCOUNT [parameters]
  * `--docker-registries`: (*Default*: `[]`) Provide the list of docker registries to use with this DC/OS account
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-credential`: (*Default*: `[]`) Provide the cluster name and uid of credentials to remove: --remove-credential my-cluster my-user
  * `--remove-docker-registry`: Remove this docker registry from the list of docker registries to use as a source of images.
@@ -8486,7 +8476,6 @@ hal config provider docker-registry account add ACCOUNT [parameters]
  * `--password`: (*Sensitive data* - user will be prompted on standard input) Your docker registry password
  * `--password-command`: Command to retrieve docker token/password, commands must be available in environment
  * `--password-file`: The path to a file containing your docker password in plaintext (not a docker/config.json file)
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--repositories`: (*Default*: `[]`) An optional list of repositories to cache images from. If not provided, Spinnaker will attempt to read accessible repositories from the registries _catalog endpoint
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -8547,7 +8536,6 @@ hal config provider docker-registry account edit ACCOUNT [parameters]
  * `--password`: (*Sensitive data* - user will be prompted on standard input) Your docker registry password
  * `--password-command`: Command to retrieve docker token/password, commands must be available in environment
  * `--password-file`: The path to a file containing your docker password in plaintext (not a docker/config.json file)
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
  * `--remove-repository`: Remove this repository to the list of repositories to cache images from.
@@ -8679,7 +8667,6 @@ hal config provider ecs account add ACCOUNT [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -8720,7 +8707,6 @@ hal config provider ecs account edit ACCOUNT [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
@@ -8852,7 +8838,6 @@ hal config provider google account add ACCOUNT [parameters]
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: (*Required*) The Google Cloud Platform project this Spinnaker account will manage.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: A list of regions for caching and mutating calls. This overwrites any default-regions set on the provider.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -8899,7 +8884,6 @@ hal config provider google account edit ACCOUNT [parameters]
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: The Google Cloud Platform project this Spinnaker account will manage.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: A list of regions for caching and mutating calls. This overwrites any default-regions set on the provider.
  * `--remove-image-project`: Remove this image project from the list of image projects to cache and deploy images from.
@@ -9208,7 +9192,6 @@ hal config provider huaweicloud account add ACCOUNT [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: (*Required*) (*Sensitive data* - user will be prompted on standard input) (Sensitive data - user will be prompted on standard input) The password used to access cloud.
  * `--project-name`: (*Required*) The name of the project within the cloud.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: (*Default*: `[]`) (*Required*) The region(s) of the cloud.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -9257,7 +9240,6 @@ hal config provider huaweicloud account edit ACCOUNT [parameters]
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--password`: (*Sensitive data* - user will be prompted on standard input) (Sensitive data - user will be prompted on standard input) The password used to access cloud.
  * `--project-name`: The name of the project within the cloud.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: (*Default*: `[]`) The region(s) of the cloud.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
@@ -9574,7 +9556,7 @@ This can only be set when --kinds is empty or not set.
 This can only be set when --namespaces is empty or not set.
  * `--only-spinnaker-managed`: (*Default*: `false`) (V2 Only) When true, Spinnaker will only cache/display applications that have been
 created by Spinnaker; as opposed to attempting to configure applications for resources already present in Kubernetes.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
+ * `--provider-version`: There are currently two versions of the Kubernetes Provider: V1 and V2. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.V1 is scheduled for removal in Spinnaker 1.21; we recommend using V2 only.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--service-account`: When true, Spinnaker attempt to authenticate against Kubernetes using a Kubernetes service account. This only works when Halyard & Spinnaker are deployed in Kubernetes. Read more about service accounts here: [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).
@@ -9644,7 +9626,7 @@ This can only be set when --kinds is empty or not set.
 This can only be set when --namespaces is empty or not set.
  * `--only-spinnaker-managed`: (V2 Only) When true, Spinnaker will only cache/display applications that have been
 created by Spinnaker; as opposed to attempting to configure applications for resources already present in Kubernetes.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
+ * `--provider-version`: There are currently two versions of the Kubernetes Provider: V1 and V2. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.V1 is scheduled for removal in Spinnaker 1.21; we recommend using V2 only.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--remove-custom-resource`: Remove this Kubernetes custom resource by name from the list of custom resources to manage.
  * `--remove-docker-registry`: Remove this docker registry from the list of docker registries to use as a source of images.
@@ -9798,7 +9780,6 @@ hal config provider oracle account add ACCOUNT [parameters]
  * `--fingerprint`: (*Required*) Fingerprint of the public key
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--private-key-passphrase`: (*Sensitive data* - user will be prompted on standard input) Passphrase used for the private key, if it is encrypted
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--region`: (*Required*) An Oracle region (e.g., us-phoenix-1)
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -9845,7 +9826,6 @@ hal config provider oracle account edit ACCOUNT [parameters]
  * `--fingerprint`: Fingerprint of the public key
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--private-key-passphrase`: (*Sensitive data* - user will be prompted on standard input) Passphrase used for the private key, if it is encrypted
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--region`: An Oracle region (e.g., us-phoenix-1)
  * `--remove-read-permission`: Remove this permission from the list of read permissions.
@@ -10126,7 +10106,6 @@ hal config provider tencentcloud account add ACCOUNT [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: The Tencent CLoud regions this Spinnaker account will manage.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
@@ -10170,7 +10149,6 @@ hal config provider tencentcloud account edit ACCOUNT [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--no-validate`: (*Default*: `false`) Skip validation.
- * `--provider-version`: Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: The Tencent CLoud regions this Spinnaker account will manage.
  * `--remove-read-permission`: Remove this permission from the list of read permissions.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9556,7 +9556,7 @@ This can only be set when --kinds is empty or not set.
 This can only be set when --namespaces is empty or not set.
  * `--only-spinnaker-managed`: (*Default*: `false`) (V2 Only) When true, Spinnaker will only cache/display applications that have been
 created by Spinnaker; as opposed to attempting to configure applications for resources already present in Kubernetes.
- * `--provider-version`: There are currently two versions of the Kubernetes Provider: V1 and V2. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.V1 is scheduled for removal in Spinnaker 1.21; we recommend using V2 only.
+ * `--provider-version`: (*Default*: `v2`) There are currently two versions of the Kubernetes Provider: V1 and V2. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.V1 is scheduled for removal in Spinnaker 1.21; we recommend using V2 only.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
  * `--service-account`: When true, Spinnaker attempt to authenticate against Kubernetes using a Kubernetes service account. This only works when Halyard & Spinnaker are deployed in Kubernetes. Read more about service accounts here: [https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/).

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractAddAccountCommand.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,11 +57,6 @@ public abstract class AbstractAddAccountCommand extends AbstractHasAccountComman
       names = "--write-permissions",
       description = AccountCommandProperties.WRITE_PERMISSION_DESCRIPTION)
   private List<String> writePermissions = new ArrayList<>();
-
-  @Parameter(
-      names = "--provider-version",
-      description = AccountCommandProperties.PROVIDER_VERSION_DESCRIPTION)
-  private Provider.ProviderVersion providerVersion;
 
   @Parameter(
       names = "--environment",
@@ -99,7 +93,6 @@ public abstract class AbstractAddAccountCommand extends AbstractHasAccountComman
     account.setRequiredGroupMembership(requiredGroupMembership);
     account.getPermissions().add(Authorization.READ, readPermissions);
     account.getPermissions().add(Authorization.WRITE, writePermissions);
-    account.setProviderVersion(providerVersion);
     account.setEnvironment(isSet(environment) ? environment : account.getEnvironment());
     String providerName = getProviderName();
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractEditAccountCommand.java
@@ -24,7 +24,6 @@ import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -92,11 +91,6 @@ public abstract class AbstractEditAccountCommand<T extends Account>
   private List<String> writePermissions;
 
   @Parameter(
-      names = "--provider-version",
-      description = AccountCommandProperties.PROVIDER_VERSION_DESCRIPTION)
-  private Provider.ProviderVersion providerVersion;
-
-  @Parameter(
       names = "--environment",
       arity = 1,
       description = AccountCommandProperties.ENVIRONMENT_DESCRIPTION)
@@ -154,9 +148,6 @@ public abstract class AbstractEditAccountCommand<T extends Account>
         writePermissions,
         addWritePermission,
         removeWritePermission);
-
-    account.setProviderVersion(
-        isSet(providerVersion) ? providerVersion : account.getProviderVersion());
 
     account.setEnvironment(isSet(environment) ? environment : account.getEnvironment());
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AccountCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AccountCommandProperties.java
@@ -21,9 +21,6 @@ public class AccountCommandProperties {
   public static final String REQUIRED_GROUP_MEMBERSHIP_DESCRIPTION =
       "A user must be a member of at least one specified group in order to make changes to this account's cloud resources.";
 
-  public static final String PROVIDER_VERSION_DESCRIPTION =
-      "Some providers support multiple versions/release tracks. This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker.";
-
   public static final String READ_PERMISSION_DESCRIPTION =
       "A user must have at least one of these roles in order to view this account's cloud resources.";
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider.ProviderVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 import java.util.ArrayList;
@@ -119,6 +120,11 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
       description = KubernetesCommandProperties.CACHE_THREADS)
   private int cacheThreads = 1;
 
+  @Parameter(
+      names = "--provider-version",
+      description = KubernetesCommandProperties.PROVIDER_VERSION_DESCRIPTION)
+  private ProviderVersion providerVersion;
+
   @Override
   protected Account buildAccount(String accountName) {
     KubernetesAccount account = (KubernetesAccount) new KubernetesAccount().setName(accountName);
@@ -143,6 +149,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     account.setLiveManifestCalls(liveManifestCalls);
     account.setCacheThreads(cacheThreads);
+    account.setProviderVersion(providerVersion);
 
     return account;
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -123,7 +123,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
   @Parameter(
       names = "--provider-version",
       description = KubernetesCommandProperties.PROVIDER_VERSION_DESCRIPTION)
-  private ProviderVersion providerVersion;
+  private ProviderVersion providerVersion = ProviderVersion.V2;
 
   @Override
   protected Account buildAccount(String accountName) {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -72,4 +72,9 @@ public class KubernetesCommandProperties {
   static final String CUSTOM_RESOURCES =
       "(V2 Only) Add Kubernetes custom resource to the list of custom resources to managed by clouddriver and made available for use in patch and delete manifest stages. "
           + "Fields besides the Kubernetes Kind (resource name) can be set using the flags \"--spinnaker-kind\" and \"--versioned\"";
+
+  static final String PROVIDER_VERSION_DESCRIPTION =
+      "There are currently two versions of the Kubernetes Provider: V1 and V2. "
+          + "This allows you to pick the version of the provider (not the resources it manages) to run within Spinnaker."
+          + "V1 is scheduled for removal in Spinnaker 1.21; we recommend using V2 only.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -21,6 +21,7 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
 import java.util.ArrayList;
@@ -218,6 +219,11 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
       description = KubernetesCommandProperties.CACHE_THREADS)
   private Integer cacheThreads;
 
+  @Parameter(
+      names = "--provider-version",
+      description = KubernetesCommandProperties.PROVIDER_VERSION_DESCRIPTION)
+  private Provider.ProviderVersion providerVersion;
+
   @Override
   protected Account editAccount(KubernetesAccount account) {
     boolean contextSet = context != null && !context.isEmpty();
@@ -337,6 +343,11 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
     account.setLiveManifestCalls(
         isSet(liveManifestCalls) ? liveManifestCalls : account.getLiveManifestCalls());
     account.setCacheThreads(isSet(cacheThreads) ? cacheThreads : account.getCacheThreads());
+
+    if (isSet(providerVersion)) {
+      account.setProviderVersion(providerVersion);
+    }
+
     return account;
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider.ProviderVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ValidForSpinnakerVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
@@ -32,6 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class KubernetesAccount extends ContainerAccount implements Cloneable {
+  ProviderVersion providerVersion = ProviderVersion.V2;
   String context;
   String cluster;
   String user;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -55,39 +55,52 @@ import org.springframework.stereotype.Component;
 public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
   @Override
   public void validate(ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
-    DeploymentConfiguration deploymentConfiguration;
+    switch (account.getProviderVersion()) {
+        // TODO(mneterval): remove all V1-only validators after 1.21 is released
+      case V1:
+        validateV1KindConfig(psBuilder, account);
+        validateCacheThreads(psBuilder, account);
+        validateV1DockerRegistries(psBuilder, account);
+        validateKubeconfig(psBuilder, account);
+        validateOnlySpinnakerConfig(psBuilder, account);
+      case V2:
+        validateKindConfig(psBuilder, account);
+        validateCacheThreads(psBuilder, account);
+      default:
+        throw new IllegalStateException("Unknown provider version " + account.getProviderVersion());
+    }
+  }
 
-    // TODO(lwander) this is still a little messy - I should use the filters to get the necessary
-    // docker account
+  private void validateV1DockerRegistries(
+      ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
     Node parent = account.getParent();
     while (!(parent instanceof DeploymentConfiguration)) {
       // Note this will crash in the above check if the halconfig representation is corrupted
       // (that's ok, because it indicates a more serious error than we want to validate).
       parent = parent.getParent();
     }
-    deploymentConfiguration = (DeploymentConfiguration) parent;
+    DeploymentConfiguration deploymentConfiguration = (DeploymentConfiguration) parent;
 
-    validateKindConfig(psBuilder, account);
-    validateCacheThreads(psBuilder, account);
+    List<String> dockerRegistryNames =
+        account.getDockerRegistries().stream()
+            .map(DockerRegistryReference::getAccountName)
+            .collect(Collectors.toList());
 
-    // TODO(lwander) validate all config with clouddriver's v2 creds
-    switch (account.getProviderVersion()) {
-      case V1:
-        final List<String> dockerRegistryNames =
-            account.getDockerRegistries().stream()
-                .map(DockerRegistryReference::getAccountName)
-                .collect(Collectors.toList());
-        validateDockerRegistries(
-            psBuilder,
-            deploymentConfiguration,
-            dockerRegistryNames,
-            Provider.ProviderType.KUBERNETES);
-        validateKubeconfig(psBuilder, account);
-        validateOnlySpinnakerConfig(psBuilder, account);
-      case V2:
-        break;
-      default:
-        throw new IllegalStateException("Unknown provider version " + account.getProviderVersion());
+    validateDockerRegistries(
+        psBuilder, deploymentConfiguration, dockerRegistryNames, Provider.ProviderType.KUBERNETES);
+  }
+
+  private void validateV1KindConfig(ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
+    List<String> kinds = account.getKinds();
+    List<String> omitKinds = account.getOmitKinds();
+    List<KubernetesAccount.CustomKubernetesResource> customResources = account.getCustomResources();
+
+    if (CollectionUtils.isNotEmpty(kinds)
+        || CollectionUtils.isNotEmpty(omitKinds)
+        || CollectionUtils.isNotEmpty(customResources)) {
+      psBuilder.addProblem(
+          WARNING,
+          "Kubernetes accounts at V1 do no support configuring caching behavior for kinds or custom resources.");
     }
   }
 
@@ -95,18 +108,6 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
     List<String> kinds = account.getKinds();
     List<String> omitKinds = account.getOmitKinds();
     List<KubernetesAccount.CustomKubernetesResource> customResources = account.getCustomResources();
-
-    if (account.getProviderVersion() == Provider.ProviderVersion.V1) {
-      if (CollectionUtils.isNotEmpty(kinds)
-          || CollectionUtils.isNotEmpty(omitKinds)
-          || CollectionUtils.isNotEmpty(customResources)) {
-        psBuilder.addProblem(
-            WARNING,
-            "Kubernetes accounts at V1 do no support configuring caching behavior for kinds or custom resources.");
-      }
-
-      return;
-    }
 
     if (CollectionUtils.isNotEmpty(kinds) && CollectionUtils.isNotEmpty(omitKinds)) {
       psBuilder.addProblem(ERROR, "At most one of \"kinds\" and \"omitKinds\" may be specified.");
@@ -164,12 +165,10 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
       ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
     Boolean onlySpinnakerManaged = account.getOnlySpinnakerManaged();
 
-    if (account.getProviderVersion() == Provider.ProviderVersion.V1) {
-      if (onlySpinnakerManaged) {
-        psBuilder.addProblem(
-            WARNING,
-            "Kubernetes accounts at V1 does not support configuring caching behavior for a only spinnaker managed resources.");
-      }
+    if (onlySpinnakerManaged) {
+      psBuilder.addProblem(
+          WARNING,
+          "Kubernetes accounts at V1 does not support configuring caching behavior for a only spinnaker managed resources.");
     }
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -58,6 +58,7 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
     switch (account.getProviderVersion()) {
         // TODO(mneterval): remove all V1-only validators after 1.21 is released
       case V1:
+        addV1RemovalWarning(psBuilder, account);
         validateV1KindConfig(psBuilder, account);
         validateCacheThreads(psBuilder, account);
         validateV1DockerRegistries(psBuilder, account);
@@ -69,6 +70,16 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
       default:
         throw new IllegalStateException("Unknown provider version " + account.getProviderVersion());
     }
+  }
+
+  private void addV1RemovalWarning(ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
+    psBuilder.addProblem(
+        WARNING,
+        String.format(
+            "Account %s is using Spinnaker’s legacy Kubernetes provider (V1), which is scheduled for removal in Spinnaker 1.21. "
+                + "Please migrate to the manifest-based provider (V2). Check out this RFC for more information: "
+                + "https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md.",
+            account.getName()));
   }
 
   private void validateV1DockerRegistries(


### PR DESCRIPTION
Related to: https://github.com/spinnaker/governance/blob/master/rfc/eol_kubernetes_v1.md

- **refactor(kubernetes): separate v1 and v2 account validators**

  The goal of this small refactor is to make it easier to reason about which validators in `KubernetesAccountValidator` apply to V1 vs. V2 accounts, so that we can easily remove the V1 validators after the release of 1.21. Previously, we applied some validators to both types of accounts and had in-validator checks against `providerVersion`. Instead, let's extract the V1-only validation logic into its own methods, also containing the logic to derive `DeploymentConfiguration` into a V1-only Docker Registry validator.

- **feat(kubernetes): add warning for v1 accounts**

  Adds a warning linking to the Kubernetes V1 Provider EOL RFC so that operators running `hal deploy apply` with one or more V1 Kubernetes accounts will be notified.

- **feat(cli): only expose providerVersion for kubernetes accounts**

  We currently expose a `--provider-version` command for every provider account command. Based on the description of this [Clouddriver PR](https://github.com/spinnaker/clouddriver/pull/1820), it seems that we thought more providers would implement multiple versions. However, only the Kubernetes provider implements more than one version (and will soon implement only one version). To reduce user confusion, let's stop exposing `--provider-version` on all provider accounts except Kubernetes. Pushing the configuration of `providerVersion` down to the provider-specific command logic will also allow us to set provider-specific `providerVersion` defaults, which we will do in the next commit. At this point, all provider accounts' `providerVersion` still [defaults to `V1`](https://github.com/spinnaker/halyard/blob/master/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java#L32).

- **feat(kubernetes): default new and unspecified accounts to V2**

  When adding a new Kubernetes account without specifying `--provider-version`, its `providerVersion` will now default to `V2`. Any existing Kubernetes accounts with an unspecified `providerVersion` will also now default to `V2`. This is a breaking change, so I'll be sure to communicate it along with re-sharing the news of the upcoming V1 removal when we release 1.19 and a new version of Halyard.