### PR TITLE
feat(stats): Make stats collection opt-out

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/HalconfigParser.java
@@ -229,6 +229,20 @@ public class HalconfigParser {
               .build());
     }
 
+    // Added for the the opt-in/opt-out switch for release 1.19
+    // This ensures that telemetry.enabled reflects the enabled/disabled state truthfully in the
+    // written halconfig. Without it, one would see this, yet telemetry would actually be enabled:
+    //   telemetry:
+    //     enabled: false
+    //     explicitlySet: false
+    local.getDeploymentConfigurations().stream()
+        .forEach(
+            dc -> {
+              if (!dc.getTelemetry().getExplicitlySet()) {
+                dc.getTelemetry().setEnabled(true);
+              }
+            });
+
     AtomicFileWriter writer = null;
     try {
       writer = new AtomicFileWriter(path);

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
@@ -34,7 +34,12 @@ public class Telemetry extends Node {
   @ValidForSpinnakerVersion(
       lowerBound = "1.18.0",
       tooLowMessage = "Telemetry is not available prior to this release.")
-  private Boolean enabled = false;
+  private Boolean enabled = true;
+
+  @ValidForSpinnakerVersion(
+      lowerBound = "1.19.0",
+      tooLowMessage = "Will enable telemetry when not explicitly disabled.")
+  private Boolean explicitlySet = false;
 
   private String endpoint = DEFAULT_TELEMETRY_ENDPOINT;
   private String instanceId = new ULID().nextULID();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/TelemetryService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/TelemetryService.java
@@ -48,6 +48,7 @@ public class TelemetryService {
         deploymentService.getDeploymentConfiguration(deploymentName);
     Telemetry telemetry = deploymentConfiguration.getTelemetry();
     telemetry.setEnabled(enable);
+    telemetry.setExplicitlySet(true);
   }
 
   public ProblemSet validateTelemetry(String deploymentName) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/TelemetryValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/TelemetryValidator.java
@@ -14,11 +14,17 @@ public class TelemetryValidator extends Validator<Telemetry> {
   @Override
   public void validate(ConfigProblemSetBuilder p, Telemetry t) {
     StringBuilder msg = new StringBuilder();
-    msg.append("Telemetry is currently ");
-    if (t.getEnabled()) {
+    msg.append("Telemetry is now opt-out. Your telemetry preference is currently ");
+    if (t.getExplicitlySet()) {
+      msg.append("set to ");
+    } else {
+      msg.append("unset, so it is ");
+    }
+    if (t.getEnabled() || !t.getExplicitlySet()) {
       msg.append("ENABLED. Usage statistics are being collected—Thank you! ");
       msg.append("These stats inform improvements to the product, and that helps the community. ");
       msg.append("To disable, run `hal config telemetry disable`. ");
+      t.setEnabled(true);
     } else {
       msg.append("DISABLED. Usage statistics are not being collected. ");
       msg.append("Please consider enabling statistic collection. ");


### PR DESCRIPTION
Here's the experience:

1. Beginning state of the config:
    ````
    telemetry:
      enabled: false
    ````
1. User updates to new Halyard
1. User runs read-only operation, like `hal config`
    ```
    - INFO Telemetry is now opt-out. Your telemetry preference is
    currently unset, so it is ENABLED....
    ```
    ```
    telemetry:
      enabled: false
    ```
1. User runs a mutating operation, like `hal config version edit --version 1.19.0`. This flips the `enabled` field and adds the `explicitlySet` field. When `explicitlySet` is false, telemetry is enabled, regardless of the `enabled` field's value (hence opt-out). Flipping it in config is meant to reflect this.
    ```
    telemetry:
      enabled: true
      explicitlySet: false
    ```
1. User runs a deploy operation:
    ```
    - INFO Telemetry is now opt-out. Your telemetry preference is
    currently unset, so it is ENABLED.
    ```
1. User runs `hal config telemetry disable`:
    ```
    - INFO Telemetry is now opt-out. Your telemetry preference is
    currently set to DISABLED.... 
    ```
    ```
    telemetry:
      enabled: false
      explicitlySet: true
    ```
1. User runs `hal config telemetry enable`:
    ```
    - INFO Telemetry is now opt-out. Your telemetry preference is
    currently set to ENABLED.
    ```
    ```
    telemetry:
      enabled: true
      explicitlySet: true
    ```

cc @imosquera @ncknt 