### PR TITLE
config(core): Revert "fix(flags): Revert "config(core): Remove MPTV2 …

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6342,7 +6342,6 @@ hal config features edit [parameters]
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--gremlin`: Enable Gremlin fault-injection support.
  * `--infrastructure-stages`: Enable infrastructure stages. Allows for creating Load Balancers as part of pipelines.
- * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--pipeline-templates`: Enable pipeline template support. Read more at [https://github.com/spinnaker/dcd-spec](https://github.com/spinnaker/dcd-spec).

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -91,12 +91,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   private Boolean wercker = null;
 
   @Parameter(
-      names = "--managed-pipeline-templates-v2-ui",
-      description = "Enable managed pipeline templates v2 UI support.",
-      arity = 1)
-  private Boolean managedPipelineTemplatesV2UI = null;
-
-  @Parameter(
       names = "--gremlin",
       description = "Enable Gremlin fault-injection support.",
       arity = 1)
@@ -129,10 +123,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
             : features.getAppengineContainerImageUrlDeployments());
     features.setTravis(travis != null ? travis : features.getTravis());
     features.setWercker(wercker != null ? wercker : features.getWercker());
-    features.setManagedPipelineTemplatesV2UI(
-        managedPipelineTemplatesV2UI != null
-            ? managedPipelineTemplatesV2UI
-            : features.getManagedPipelineTemplatesV2UI());
     features.setGremlin(gremlin != null ? gremlin : features.getGremlin());
 
     if (originalHash == features.hashCode()) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -22,7 +22,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@JsonIgnoreProperties({"jobs"})
+@JsonIgnoreProperties({"jobs", "managedPipelineTemplatesV2UI"})
 public class Features extends Node {
   @Override
   public String getNodeName() {
@@ -86,11 +86,6 @@ public class Features extends Node {
       lowerBound = "1.9.0",
       tooLowMessage = "Wercker stage is not available prior to this release.")
   private Boolean wercker;
-
-  @ValidForSpinnakerVersion(
-      lowerBound = "1.13.0",
-      tooLowMessage = "Managed Pipeline Templates v2 UI is not available prior to this release.")
-  private Boolean managedPipelineTemplatesV2UI;
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.13.0",

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -140,12 +140,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
         "features.wercker",
         Boolean.toString(features.getWercker() != null ? features.getWercker() : false));
     bindings.put(
-        "features.managedPipelineTemplatesV2UI",
-        Boolean.toString(
-            features.getManagedPipelineTemplatesV2UI() != null
-                ? features.getManagedPipelineTemplatesV2UI()
-                : false));
-    bindings.put(
         "features.gremlin",
         Boolean.toString(features.getGremlin() != null ? features.getGremlin() : false));
     bindings.put(


### PR DESCRIPTION
…UI feature flag (#1510)" (#1530)"

The feature flag for the MPTV2 UI was removed from halyard but had to be reverted since 1.19 had yet to be released. This reverts that revert and will go out with 1.19.