### PR TITLE
feat(codebuild): Add support for static credentials

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -184,6 +184,7 @@
  * [**hal config ci codebuild account get**](#hal-config-ci-codebuild-account-get)
  * [**hal config ci codebuild account list**](#hal-config-ci-codebuild-account-list)
  * [**hal config ci codebuild disable**](#hal-config-ci-codebuild-disable)
+ * [**hal config ci codebuild edit**](#hal-config-ci-codebuild-edit)
  * [**hal config ci codebuild enable**](#hal-config-ci-codebuild-enable)
  * [**hal config ci concourse**](#hal-config-ci-concourse)
  * [**hal config ci concourse disable**](#hal-config-ci-concourse-disable)
@@ -3702,6 +3703,7 @@ hal config ci codebuild [parameters] [subcommands]
 #### Subcommands
  * `account`: Manage and view Spinnaker configuration for AWS CodeBuild service account.
  * `disable`: Set the codebuild ci as disabled
+ * `edit`: Set CI provider-wide properties for AWS CodeBuild
  * `enable`: Set the codebuild ci as enabled
 
 ---
@@ -3738,8 +3740,8 @@ hal config ci codebuild account add ACCOUNT [parameters]
 
 #### Parameters
 `ACCOUNT`: The name of the account to operate on.
- * `--account-id`: (*Required*) The AWS account ID that will be used to trigger CodeBuild build.
- * `--assume-role`: (*Required*) If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
+ * `--account-id`: The AWS account ID that will be used to trigger CodeBuild build.
+ * `--assume-role`: If set, Halyard will configure a credentials provider that uses AWS Security Token Service to assume the specified role.
 
 Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
@@ -3828,6 +3830,23 @@ hal config ci codebuild disable [parameters]
 #### Parameters
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config ci codebuild edit
+
+Set CI provider-wide properties for AWS CodeBuild
+
+#### Usage
+```
+hal config ci codebuild edit [parameters]
+```
+
+#### Parameters
+ * `--access-key-id`: Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials as described at [http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default](http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default)
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractEditCiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/AbstractEditCiCommand.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2020 Amazon.com, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.ci;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.CIAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@Parameters(separators = "=")
+@EqualsAndHashCode(callSuper = false)
+public abstract class AbstractEditCiCommand<A extends CIAccount, C extends Ci<A>>
+    extends AbstractCiCommand {
+  String commandName = "edit";
+
+  @Override
+  protected void executeThis() {
+    String ciName = getCiName();
+    String currentDeployment = getCurrentDeployment();
+
+    Ci ci =
+        new OperationHandler<Ci>()
+            .setFailureMesssage("Failed to get ci provider " + ciName + ".")
+            .setOperation(Daemon.getCi(currentDeployment, ciName, false))
+            .get();
+
+    int originalHash = ci.hashCode();
+
+    ci = editCi((C) ci);
+
+    if (originalHash == ci.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to edit ci provider " + ci + ".")
+        .setSuccessMessage("Successfully edited ci provider " + ci + ".")
+        .setOperation(Daemon.setCi(currentDeployment, ciName, !noValidate, ci))
+        .get();
+  }
+
+  protected abstract Ci editCi(C ci);
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommand.java
@@ -35,6 +35,7 @@ public class AwsCodeBuildCommand extends AbstractNamedCiCommand {
   public AwsCodeBuildCommand() {
     super();
     registerSubcommand(new AwsCodeBuildAccountCommand());
+    registerSubcommand(new AwsCodeBuildEditCiCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildCommandProperties.java
@@ -25,4 +25,9 @@ public class AwsCodeBuildCommandProperties {
       "If set, Halyard will configure a credentials provider that uses AWS "
           + "Security Token Service to assume the specified role.\n\n"
           + "Example: \"user/spinnaker\" or \"role/spinnakerManaged\"";
+  static final String ACCESS_KEY_ID_DESCRIPTION =
+      "Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials "
+          + "as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default";
+
+  static final String SECRET_KEY_DESCRIPTION = "Your AWS Secret Key.";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildEditCiCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/codebuild/AwsCodeBuildEditCiCommand.java
@@ -18,11 +18,15 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.codebuild;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account.AbstractAddAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractEditCiCommand;
+import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild.AwsCodeBuildAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import lombok.Getter;
 
 @Parameters(separators = "=")
-public class AwsCodeBuildAddAccountCommand extends AbstractAddAccountCommand {
+public class AwsCodeBuildEditCiCommand
+    extends AbstractEditCiCommand<AwsCodeBuildAccount, AwsCodeBuild> {
   protected String getCiName() {
     return "codebuild";
   }
@@ -32,28 +36,23 @@ public class AwsCodeBuildAddAccountCommand extends AbstractAddAccountCommand {
     return "AWS CodeBuild";
   }
 
-  @Parameter(
-      names = "--account-id",
-      description = AwsCodeBuildCommandProperties.ACCOUNT_ID_DESCRIPTION)
-  private String accountId;
+  @Getter String shortDescription = "Set CI provider-wide properties for " + getCiFullName();
 
   @Parameter(
-      names = "--assume-role",
-      description = AwsCodeBuildCommandProperties.ASSUME_ROLE_DESCRIPTION)
-  private String assumeRole;
+      names = "--access-key-id",
+      description = AwsCodeBuildCommandProperties.ACCESS_KEY_ID_DESCRIPTION)
+  private String accessKeyId;
 
   @Parameter(
-      names = "--region",
-      required = true,
-      description = AwsCodeBuildCommandProperties.REGION_DESCRIPTION)
-  private String region;
+      names = "--secret-access-key",
+      description = AwsCodeBuildCommandProperties.SECRET_KEY_DESCRIPTION,
+      password = true)
+  private String secretAccessKey;
 
   @Override
-  protected AwsCodeBuildAccount buildAccount(String accountName) {
-    return new AwsCodeBuildAccount()
-        .setName(accountName)
-        .setAccountId(accountId)
-        .setAssumeRole(assumeRole)
-        .setRegion(region);
+  protected Ci editCi(AwsCodeBuild ci) {
+    ci.setAccessKeyId(isSet(accessKeyId) ? accessKeyId : ci.getAccessKeyId());
+    ci.setSecretAccessKey(isSet(secretAccessKey) ? secretAccessKey : ci.getSecretAccessKey());
+    return ci;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -726,6 +726,14 @@ public class Daemon {
     };
   }
 
+  public static Supplier<Void> setCi(
+      String deploymentName, String ciName, boolean validate, Ci ci) {
+    return () -> {
+      ResponseUnwrapper.get(getService().setCi(deploymentName, ciName, validate, ci));
+      return null;
+    };
+  }
+
   public static Supplier<Void> setCiEnableDisable(
       String deploymentName, String ciName, boolean validate, boolean enable) {
     return () -> {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -718,6 +718,13 @@ public interface DaemonService {
       @Path("ciName") String ciName,
       @Query("validate") boolean validate);
 
+  @PUT("/v1/config/deployments/{deploymentName}/ci/{ciName}/")
+  DaemonTask<Halconfig, Void> setCi(
+      @Path("deploymentName") String deploymentName,
+      @Path("ciName") String ciName,
+      @Query("validate") boolean validate,
+      @Body Ci ci);
+
   @PUT("/v1/config/deployments/{deploymentName}/ci/{ciName}/enabled/")
   DaemonTask<Halconfig, Void> setCiEnabled(
       @Path("deploymentName") String deploymentName,

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuild.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuild.java
@@ -26,6 +26,8 @@ import lombok.EqualsAndHashCode;
 @EqualsAndHashCode(callSuper = false)
 public class AwsCodeBuild extends Ci<AwsCodeBuildAccount> {
   private boolean enabled;
+  private String accessKeyId;
+  private String secretAccessKey;
   private List<AwsCodeBuildAccount> accounts = new ArrayList<>();
 
   public List<AwsCodeBuildAccount> listAccounts() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Cis.java
@@ -22,6 +22,9 @@ import com.netflix.spinnaker.halyard.config.model.v1.ci.gcb.GoogleCloudBuild;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.jenkins.JenkinsCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.travis.TravisCi;
 import com.netflix.spinnaker.halyard.config.model.v1.ci.wercker.WerckerCi;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Optional;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -52,5 +55,19 @@ public class Cis extends Node implements Cloneable {
   @Override
   public String getNodeName() {
     return "ci";
+  }
+
+  public static Class<? extends Ci> translateCiType(String ciName) {
+    Optional<? extends Class<?>> res =
+        Arrays.stream(Cis.class.getDeclaredFields())
+            .filter(f -> f.getName().equals(ciName))
+            .map(Field::getType)
+            .findFirst();
+
+    if (res.isPresent()) {
+      return (Class<? extends Ci>) res.get();
+    } else {
+      throw new IllegalArgumentException("No ci with name \"" + ciName + "\" handled by halyard");
+    }
   }
 }


### PR DESCRIPTION
1. Add an AbstractEditCiCommand class that could be inherited from. For now only codebuild account
command extends this class. There could be more in the future.
2. Mark assume-role and account-id as not required so that the static credentials could be used directly
3. Add an API in halyard daemon to set custom fields for CI providers

Example:
```
codebuild:
  enabled: true
  accessKeyId: 'access-key-id'
  secretAccessKey: 'secret-access-key'
  accounts:
  - name: my-codebuild-account
    accountId: '123456789012'
    assumeRole: role/spinnakerManaged
    region: us-west-2
  - name: my-codebuild-eu-central-1
    accountId: '123456789012'
    assumeRole: role/spinnakerManaged
    region: eu-central-1
  - name: my-codebuild-no-assume-role
    region: us-west-2
```
In the config above, `my-codebuild-account` will use static credentials to assume role `spinnakerManaged` in us-west-2. `my-codebuild-eu-central-1` will use static credentials to assume role `spinnakerManaged` in eu-central-1. `my-codebuild-no-assume-role` will directly use static credentials to call CodeBuild in us-west-2