### PR TITLE
feat(stats): Rename telemetry to stats, enable by default

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -590,6 +590,10 @@
  * [**hal config security ui ssl disable**](#hal-config-security-ui-ssl-disable)
  * [**hal config security ui ssl edit**](#hal-config-security-ui-ssl-edit)
  * [**hal config security ui ssl enable**](#hal-config-security-ui-ssl-enable)
+ * [**hal config stats**](#hal-config-stats)
+ * [**hal config stats disable**](#hal-config-stats-disable)
+ * [**hal config stats edit**](#hal-config-stats-edit)
+ * [**hal config stats enable**](#hal-config-stats-enable)
  * [**hal config storage**](#hal-config-storage)
  * [**hal config storage azs**](#hal-config-storage-azs)
  * [**hal config storage azs edit**](#hal-config-storage-azs-edit)
@@ -600,10 +604,6 @@
  * [**hal config storage oracle edit**](#hal-config-storage-oracle-edit)
  * [**hal config storage s3**](#hal-config-storage-s3)
  * [**hal config storage s3 edit**](#hal-config-storage-s3-edit)
- * [**hal config telemetry**](#hal-config-telemetry)
- * [**hal config telemetry disable**](#hal-config-telemetry-disable)
- * [**hal config telemetry edit**](#hal-config-telemetry-edit)
- * [**hal config telemetry enable**](#hal-config-telemetry-enable)
  * [**hal config version**](#hal-config-version)
  * [**hal config version edit**](#hal-config-version-edit)
  * [**hal config webhook**](#hal-config-webhook)
@@ -891,8 +891,8 @@ hal config [parameters] [subcommands]
  * `pubsub`: Configure, validate, and view the specified pubsub.
  * `repository`: Configure, validate, and view the specified repository.
  * `security`: Configure Spinnaker's security. This includes external SSL, authentication mechanisms, and authorization policies.
+ * `stats`: Show Spinnaker's stats settings.
  * `storage`: Show Spinnaker's persistent storage configuration.
- * `telemetry`: Show Spinnaker's telemetry settings.
  * `version`: Configure & view the current deployment of Spinnaker's version.
  * `webhook`: Show Spinnaker's webhook configuration.
 
@@ -11581,6 +11581,71 @@ hal config security ui ssl enable [parameters]
 
 
 ---
+## hal config stats
+
+Show Spinnaker's stats settings.
+
+#### Usage
+```
+hal config stats [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `disable`: Set Spinnaker's stats settings to disabled.
+ * `edit`: Edit Spinnaker's stats settings.
+ * `enable`: Set Spinnaker's stats settings to enabled.
+
+---
+## hal config stats disable
+
+Set Spinnaker's stats settings to disabled.
+
+#### Usage
+```
+hal config stats disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config stats edit
+
+Edit Spinnaker's stats settings.
+
+#### Usage
+```
+hal config stats edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--endpoint`: Set the endpoint for stats metrics.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config stats enable
+
+Set Spinnaker's stats settings to enabled.
+
+#### Usage
+```
+hal config stats enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
 ## hal config storage
 
 Show Spinnaker's persistent storage configuration.
@@ -11771,71 +11836,6 @@ Example: "user/spinnaker" or "role/spinnakerManaged"
  * `--root-folder`: The root folder in the chosen bucket to place all of Spinnaker's persistent data in.
  * `--secret-access-key`: (*Sensitive data* - user will be prompted on standard input) Your AWS Secret Key.
  * `--server-side-encryption`: Use Amazon Server-Side Encryption ('x-amz-server-side-encryption' header). Supports 'AES256' (for Amazon S3-managed encryption keys, equivalent to a header value of 'AES256') and 'AWSKMS' (for AWS KMS-managed encryption keys, equivalent to a header value of 'aws:kms'.
-
-
----
-## hal config telemetry
-
-Show Spinnaker's telemetry settings.
-
-#### Usage
-```
-hal config telemetry [parameters] [subcommands]
-```
-
-#### Parameters
- * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--no-validate`: (*Default*: `false`) Skip validation.
-
-#### Subcommands
- * `disable`: Set Spinnaker's telemetry settings to disabled.
- * `edit`: Edit Spinnaker's telemetry settings.
- * `enable`: Set Spinnaker's telemetry settings to enabled.
-
----
-## hal config telemetry disable
-
-Set Spinnaker's telemetry settings to disabled.
-
-#### Usage
-```
-hal config telemetry disable [parameters]
-```
-
-#### Parameters
- * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--no-validate`: (*Default*: `false`) Skip validation.
-
-
----
-## hal config telemetry edit
-
-Edit Spinnaker's telemetry settings.
-
-#### Usage
-```
-hal config telemetry edit [parameters]
-```
-
-#### Parameters
- * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--endpoint`: Set the endpoint for telemetry metrics.
- * `--no-validate`: (*Default*: `false`) Skip validation.
-
-
----
-## hal config telemetry enable
-
-Set Spinnaker's telemetry settings to enabled.
-
-#### Usage
-```
-hal config telemetry enable [parameters]
-```
-
-#### Parameters
- * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--no-validate`: (*Default*: `false`) Skip validation.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/ConfigCommand.java
@@ -25,7 +25,7 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.CiCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.ProviderCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.pubsubs.PubsubCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.repository.RepositoryCommand;
-import com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry.TelemetryCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.stats.StatsCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.webhook.WebhookCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
@@ -71,7 +71,7 @@ public class ConfigCommand extends AbstractConfigCommand {
     registerSubcommand(new CiCommand());
     registerSubcommand(new ListCommand());
     registerSubcommand(new RepositoryCommand());
-    registerSubcommand(new TelemetryCommand());
+    registerSubcommand(new StatsCommand());
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/AbstractEnableDisableStatsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/AbstractEnableDisableStatsCommand.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.stats;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
@@ -27,7 +27,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 
 @Parameters(separators = "=")
-public abstract class AbstractEnableDisableTelemetryCommand extends AbstractConfigCommand {
+public abstract class AbstractEnableDisableStatsCommand extends AbstractConfigCommand {
   @Override
   public String getCommandName() {
     return isEnable() ? "enable" : "disable";
@@ -48,7 +48,7 @@ public abstract class AbstractEnableDisableTelemetryCommand extends AbstractConf
 
   @Override
   public String getShortDescription() {
-    return "Set Spinnaker's telemetry settings to " + subjunctivePerfectAction() + ".";
+    return "Set Spinnaker's stats settings to " + subjunctivePerfectAction() + ".";
   }
 
   @Override
@@ -56,9 +56,9 @@ public abstract class AbstractEnableDisableTelemetryCommand extends AbstractConf
     String currentDeployment = getCurrentDeployment();
     boolean enable = isEnable();
     new OperationHandler<Void>()
-        .setOperation(Daemon.setTelemetryEnableDisable(currentDeployment, !noValidate, enable))
-        .setFailureMesssage("Failed to " + getCommandName() + " telemetry settings.")
-        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " telemetry settings.")
+        .setOperation(Daemon.setStatsEnableDisable(currentDeployment, !noValidate, enable))
+        .setFailureMesssage("Failed to " + getCommandName() + " stats settings.")
+        .setSuccessMessage("Successfully " + indicativePastPerfectAction() + " stats settings.")
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/StatsCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/StatsCommand.java
@@ -14,39 +14,40 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.stats;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Stats;
 import lombok.AccessLevel;
 import lombok.Getter;
 
 @Parameters(separators = "=")
-public class TelemetryCommand extends AbstractConfigCommand {
-  @Getter(AccessLevel.PUBLIC)
-  private String commandName = "telemetry";
+public class StatsCommand extends AbstractConfigCommand {
 
   @Getter(AccessLevel.PUBLIC)
-  private String shortDescription = "Show Spinnaker's telemetry settings.";
+  private String commandName = "stats";
 
-  public TelemetryCommand() {
-    registerSubcommand(new TelemetryEditCommand());
-    registerSubcommand(new TelemetryEnableDisableCommandBuilder().setEnable(true).build());
-    registerSubcommand(new TelemetryEnableDisableCommandBuilder().setEnable(false).build());
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Show Spinnaker's stats settings.";
+
+  public StatsCommand() {
+    registerSubcommand(new StatsEditCommand());
+    registerSubcommand(new StatsEnableDisableCommandBuilder().setEnable(true).build());
+    registerSubcommand(new StatsEnableDisableCommandBuilder().setEnable(false).build());
   }
 
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
 
-    new OperationHandler<Telemetry>()
-        .setOperation(Daemon.getTelemetry(currentDeployment, !noValidate))
-        .setFailureMesssage("Failed to load telemetry.")
-        .setSuccessMessage("Configured telemetry: ")
+    new OperationHandler<Stats>()
+        .setOperation(Daemon.getStats(currentDeployment, !noValidate))
+        .setFailureMesssage("Failed to load stats.")
+        .setSuccessMessage("Configured stats: ")
         .setFormat(AnsiFormatUtils.Format.STRING)
         .setUserFormatted(true)
         .get();

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/StatsEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/StatsEditCommand.java
@@ -14,45 +14,45 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.stats;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Stats;
 import lombok.AccessLevel;
 import lombok.Getter;
 
 @Parameters(separators = "=")
-public class TelemetryEditCommand extends AbstractConfigCommand {
+public class StatsEditCommand extends AbstractConfigCommand {
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "edit";
 
   @Getter(AccessLevel.PUBLIC)
-  private String shortDescription = "Edit Spinnaker's telemetry settings.";
+  private String shortDescription = "Edit Spinnaker's stats settings.";
 
-  @Parameter(names = "--endpoint", description = "Set the endpoint for telemetry metrics.")
+  @Parameter(names = "--endpoint", description = "Set the endpoint for stats metrics.")
   private String endpoint;
 
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
-    Telemetry telemetry =
-        new OperationHandler<Telemetry>()
-            .setOperation(Daemon.getTelemetry(currentDeployment, false))
-            .setFailureMesssage("Failed to load telemetry settings.")
+    Stats stats =
+        new OperationHandler<Stats>()
+            .setOperation(Daemon.getStats(currentDeployment, false))
+            .setFailureMesssage("Failed to load stats settings.")
             .get();
 
     if (isSet(endpoint)) {
-      telemetry.setEndpoint(endpoint);
+      stats.setEndpoint(endpoint);
     }
 
     new OperationHandler<Void>()
-        .setOperation(Daemon.setTelemetry(currentDeployment, !noValidate, telemetry))
-        .setFailureMesssage("Failed to edit telemetry settings.")
-        .setSuccessMessage("Successfully edited telemetry settings.")
+        .setOperation(Daemon.setStats(currentDeployment, !noValidate, stats))
+        .setFailureMesssage("Failed to edit stats settings.")
+        .setSuccessMessage("Successfully edited stats settings.")
         .get();
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/StatsEnableDisableCommandBuilder.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/stats/StatsEnableDisableCommandBuilder.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry;
+package com.netflix.spinnaker.halyard.cli.command.v1.config.stats;
 
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.CommandBuilder;
@@ -23,17 +23,17 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 
-public class TelemetryEnableDisableCommandBuilder implements CommandBuilder {
+public class StatsEnableDisableCommandBuilder implements CommandBuilder {
   @Setter boolean enable;
 
   @Override
   public NestableCommand build() {
-    return new TelemetryEnableDisableCommand(enable);
+    return new StatsEnableDisableCommand(enable);
   }
 
   @Parameters(separators = "=")
-  private static class TelemetryEnableDisableCommand extends AbstractEnableDisableTelemetryCommand {
-    private TelemetryEnableDisableCommand(boolean enable) {
+  private static class StatsEnableDisableCommand extends AbstractEnableDisableStatsCommand {
+    private StatsEnableDisableCommand(boolean enable) {
       this.enable = enable;
     }
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -1432,26 +1432,24 @@ public class Daemon {
     };
   }
 
-  public static Supplier<Telemetry> getTelemetry(String deploymentName, boolean validate) {
+  public static Supplier<Stats> getStats(String deploymentName, boolean validate) {
     return () -> {
-      Object rawTelemetry =
-          ResponseUnwrapper.get(getService().getTelemetry(deploymentName, validate));
-      return getObjectMapper().convertValue(rawTelemetry, new TypeReference<Telemetry>() {});
+      Object rawStats = ResponseUnwrapper.get(getService().getStats(deploymentName, validate));
+      return getObjectMapper().convertValue(rawStats, new TypeReference<Stats>() {});
     };
   }
 
-  public static Supplier<Void> setTelemetryEnableDisable(
+  public static Supplier<Void> setStatsEnableDisable(
       String deploymentName, boolean validate, boolean enable) {
     return () -> {
-      ResponseUnwrapper.get(getService().setTelemetryEnabled(deploymentName, validate, enable));
+      ResponseUnwrapper.get(getService().setStatsEnabled(deploymentName, validate, enable));
       return null;
     };
   }
 
-  public static Supplier<Void> setTelemetry(
-      String deploymentName, boolean validate, Telemetry telemetry) {
+  public static Supplier<Void> setStats(String deploymentName, boolean validate, Stats stats) {
     return () -> {
-      ResponseUnwrapper.get(getService().setTelemetry(deploymentName, validate, telemetry));
+      ResponseUnwrapper.get(getService().setStats(deploymentName, validate, stats));
       return null;
     };
   }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -965,18 +965,18 @@ public interface DaemonService {
       @Path("repositoryName") String pluginRepositoryName,
       @Query("validate") boolean validate);
 
-  @GET("/v1/config/deployments/{deploymentName}/telemetry/")
-  DaemonTask<Halconfig, Object> getTelemetry(
+  @GET("/v1/config/deployments/{deploymentName}/stats/")
+  DaemonTask<Halconfig, Object> getStats(
       @Path("deploymentName") String deploymentName, @Query("validate") boolean validate);
 
-  @PUT("/v1/config/deployments/{deploymentName}/telemetry/")
-  DaemonTask<Halconfig, Void> setTelemetry(
+  @PUT("/v1/config/deployments/{deploymentName}/stats/")
+  DaemonTask<Halconfig, Void> setStats(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
-      @Body Telemetry telemetry);
+      @Body Stats stats);
 
-  @PUT("/v1/config/deployments/{deploymentName}/telemetry/enabled/")
-  DaemonTask<Halconfig, Void> setTelemetryEnabled(
+  @PUT("/v1/config/deployments/{deploymentName}/stats/enabled/")
+  DaemonTask<Halconfig, Void> setStatsEnabled(
       @Path("deploymentName") String deploymentName,
       @Query("validate") boolean validate,
       @Body boolean enabled);

--- a/halyard-cli/src/test/groovy/com/netflix/spinnaker/halyard/cli/command/v1/CommandTreeSpec.groovy
+++ b/halyard-cli/src/test/groovy/com/netflix/spinnaker/halyard/cli/command/v1/CommandTreeSpec.groovy
@@ -37,8 +37,8 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.saml.S
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authn.x509.X509Command
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.authz.AuthzCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.config.security.ui.UiSecurityCommand
-import com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry.TelemetryCommand
-import com.netflix.spinnaker.halyard.cli.command.v1.config.telemetry.TelemetryEnableDisableCommandBuilder
+import com.netflix.spinnaker.halyard.cli.command.v1.config.stats.StatsCommand
+import com.netflix.spinnaker.halyard.cli.command.v1.config.stats.StatsEnableDisableCommandBuilder
 import com.netflix.spinnaker.halyard.cli.command.v1.plugins.AddPluginCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.plugins.DeletePluginCommand
 import com.netflix.spinnaker.halyard.cli.command.v1.plugins.EditPluginCommand
@@ -101,7 +101,7 @@ class CommandTreeSpec extends Specification {
     ConfigCommand   | "security"      | SecurityCommand
     ConfigCommand   | "version"       | VersionConfigCommand
     ConfigCommand   | "ci"            | CiCommand
-    ConfigCommand   | "telemetry"     | TelemetryCommand
+    ConfigCommand   | "stats"         | StatsCommand
 
     SecurityCommand | "api"           | ApiSecurityCommand
     SecurityCommand | "authn"         | AuthnCommand

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
 import com.netflix.spinnaker.halyard.config.model.v1.security.Security;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
@@ -90,7 +91,10 @@ public class DeploymentConfiguration extends Node {
 
   Webhook webhook = new Webhook();
 
-  Telemetry telemetry = new Telemetry();
+  // Remove after 2021-03-01 in favor of Stats.
+  @JsonIgnore Telemetry telemetry = new Telemetry();
+
+  Stats stats = new Stats();
 
   @Override
   public String getNodeName() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/NodeFilter.java
@@ -361,8 +361,8 @@ public class NodeFilter implements Cloneable {
     return this;
   }
 
-  public NodeFilter setTelemetry() {
-    matchers.add(Node.thisNodeAcceptor(Telemetry.class));
+  public NodeFilter setStats() {
+    matchers.add(Node.thisNodeAcceptor(Stats.class));
     return this;
   }
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Stats.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Stats.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.config.model.v1.node;
+
+import de.huxhorn.sulky.ulid.ULID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = false)
+public class Stats extends Node {
+
+  public static String DEFAULT_STATS_ENDPOINT = "https://stats.spinnaker.io";
+
+  @Override
+  public String getNodeName() {
+    return "stats";
+  }
+
+  @ValidForSpinnakerVersion(
+      lowerBound = "1.18.0",
+      tooLowMessage = "Stats are not available prior to this release.")
+  private Boolean enabled = true;
+
+  private String endpoint = DEFAULT_STATS_ENDPOINT;
+  private String instanceId = new ULID().nextULID();
+  private String spinnakerVersion;
+  private DeploymentMethod deploymentMethod = new DeploymentMethod();
+  private int connectionTimeoutMillis = 3000;
+  private int readTimeoutMillis = 5000;
+
+  @Data
+  public static class DeploymentMethod {
+
+    public static String HALYARD = "halyard";
+
+    private String type;
+    private String version;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Telemetry.java
@@ -16,39 +16,13 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
-import de.huxhorn.sulky.ulid.ULID;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
+/** @deprecated Use {@link Stats} instead. */
 @Data
 @EqualsAndHashCode(callSuper = false)
+@Deprecated
 public class Telemetry extends Node {
-
-  public static String DEFAULT_TELEMETRY_ENDPOINT = "https://stats.spinnaker.io";
-
-  @Override
-  public String getNodeName() {
-    return "telemetry";
-  }
-
-  @ValidForSpinnakerVersion(
-      lowerBound = "1.18.0",
-      tooLowMessage = "Telemetry is not available prior to this release.")
-  private Boolean enabled = false;
-
-  private String endpoint = DEFAULT_TELEMETRY_ENDPOINT;
-  private String instanceId = new ULID().nextULID();
-  private String spinnakerVersion;
-  private DeploymentMethod deploymentMethod = new DeploymentMethod();
-  private int connectionTimeoutMillis = 3000;
-  private int readTimeoutMillis = 5000;
-
-  @Data
-  public static class DeploymentMethod {
-
-    public static String HALYARD = "halyard";
-
-    private String type;
-    private String version;
-  }
+  private final String nodeName = "telemetry";
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/DeploymentService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/DeploymentService.java
@@ -155,7 +155,7 @@ public class DeploymentService {
             .withAnyAccount()
             .setFeatures()
             .setSecurity()
-            .setTelemetry();
+            .setStats();
 
     if (storage.getPersistentStoreType() != null) {
       filter.setPersistentStore(storage.getPersistentStoreType().getId());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/StatsService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/StatsService.java
@@ -18,40 +18,40 @@ package com.netflix.spinnaker.halyard.config.services.v1;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeFilter;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Stats;
 import com.netflix.spinnaker.halyard.core.problem.v1.ProblemSet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class TelemetryService {
+public class StatsService {
   private final LookupService lookupService;
   private final ValidateService validateService;
   private final DeploymentService deploymentService;
 
-  public Telemetry getTelemetry(String deploymentName) {
-    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setTelemetry();
+  public Stats getStats(String deploymentName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setStats();
 
     return lookupService.getSingularNodeOrDefault(
-        filter, Telemetry.class, Telemetry::new, n -> setTelemetry(deploymentName, n));
+        filter, Stats.class, Stats::new, n -> setStats(deploymentName, n));
   }
 
-  public void setTelemetry(String deploymentName, Telemetry telemetry) {
+  public void setStats(String deploymentName, Stats stats) {
     DeploymentConfiguration deploymentConfiguration =
         deploymentService.getDeploymentConfiguration(deploymentName);
-    deploymentConfiguration.setTelemetry(telemetry);
+    deploymentConfiguration.setStats(stats);
   }
 
-  public void setTelemetryEnabled(String deploymentName, boolean validate, boolean enable) {
+  public void setStatsEnabled(String deploymentName, boolean validate, boolean enable) {
     DeploymentConfiguration deploymentConfiguration =
         deploymentService.getDeploymentConfiguration(deploymentName);
-    Telemetry telemetry = deploymentConfiguration.getTelemetry();
-    telemetry.setEnabled(enable);
+    Stats stats = deploymentConfiguration.getStats();
+    stats.setEnabled(enable);
   }
 
-  public ProblemSet validateTelemetry(String deploymentName) {
-    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setTelemetry();
+  public ProblemSet validateStats(String deploymentName) {
+    NodeFilter filter = new NodeFilter().setDeployment(deploymentName).setStats();
     return validateService.validateMatchingFilter(filter);
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/StatsValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/StatsValidator.java
@@ -1,6 +1,6 @@
 package com.netflix.spinnaker.halyard.config.validate.v1;
 
-import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Stats;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
 import com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity;
@@ -9,24 +9,24 @@ import org.springframework.stereotype.Component;
 
 @Component
 @Slf4j
-public class TelemetryValidator extends Validator<Telemetry> {
+public class StatsValidator extends Validator<Stats> {
 
   @Override
-  public void validate(ConfigProblemSetBuilder p, Telemetry t) {
+  public void validate(ConfigProblemSetBuilder p, Stats t) {
     StringBuilder msg = new StringBuilder();
-    msg.append("Telemetry is currently ");
+    msg.append("Stats are currently ");
     if (t.getEnabled()) {
       msg.append("ENABLED. Usage statistics are being collected—Thank you! ");
       msg.append("These stats inform improvements to the product, and that helps the community. ");
-      msg.append("To disable, run `hal config telemetry disable`. ");
+      msg.append("To disable, run `hal config stats disable`. ");
     } else {
       msg.append("DISABLED. Usage statistics are not being collected. ");
       msg.append("Please consider enabling statistic collection. ");
       msg.append("These stats inform improvements to the product, and that helps the community. ");
-      msg.append("To enable, run `hal config telemetry enable`. ");
+      msg.append("To enable, run `hal config stats enable`. ");
     }
 
-    msg.append("To learn more about what and how telemetry data is used, please see ");
+    msg.append("To learn more about what and how stats data is used, please see ");
     msg.append("https://www.spinnaker.io/community/stats.");
     p.addProblem(Severity.INFO, msg.toString());
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -108,7 +108,7 @@ public class EchoProfileFactory extends SpringProfileFactory {
       stats.setSpinnakerVersion(statsVersion);
       stats.setDeploymentMethod(deploymentMethod());
       profile.appendContents(
-          yamlToString(deploymentConfiguration.getName(), profile, new TelemetryWrapper(stats)));
+          yamlToString(deploymentConfiguration.getName(), profile, new StatsWrapper(stats)));
     }
 
     profile.appendContents(profile.getBaseContents()).setRequiredFiles(files);
@@ -152,13 +152,12 @@ public class EchoProfileFactory extends SpringProfileFactory {
     }
   }
 
-  /** Translates Halyard's `Stats` class to Echo's `Telemetry` class */
   @Data
-  private static class TelemetryWrapper {
-    private Stats telemetry;
+  private static class StatsWrapper {
+    private Stats stats;
 
-    TelemetryWrapper(Stats stats) {
-      this.telemetry = stats;
+    StatsWrapper(Stats stats) {
+      this.stats = stats;
     }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/EchoProfileFactory.java
@@ -23,7 +23,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Cis;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Notifications;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Pubsubs;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Stats;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService.Type;
@@ -94,31 +94,29 @@ public class EchoProfileFactory extends SpringProfileFactory {
             yamlToString(deploymentConfiguration.getName(), profile, new GCBWrapper(gcb)));
       }
     }
-
-    Telemetry telemetry = deploymentConfiguration.getTelemetry();
-    if (telemetry != null) {
+    Stats stats = deploymentConfiguration.getStats();
+    if (stats != null) {
 
       // We don't want to accidentally log any PII that may be stuffed into custom BOM bucket names,
       // so we should only log the version if using our public releases (as indicated by using our
       // public GCS bucket).
-      String telemetryVersion = "custom";
+      String statsVersion = "custom";
       if (gcsEnabled
           && spinconfigBucket.equalsIgnoreCase(ResourceConfig.DEFAULT_HALCONFIG_BUCKET)) {
-        telemetryVersion = deploymentConfiguration.getVersion();
+        statsVersion = deploymentConfiguration.getVersion();
       }
-      telemetry.setSpinnakerVersion(telemetryVersion);
-      telemetry.setDeploymentMethod(deploymentMethod());
+      stats.setSpinnakerVersion(statsVersion);
+      stats.setDeploymentMethod(deploymentMethod());
       profile.appendContents(
-          yamlToString(
-              deploymentConfiguration.getName(), profile, new TelemetryWrapper(telemetry)));
+          yamlToString(deploymentConfiguration.getName(), profile, new TelemetryWrapper(stats)));
     }
 
     profile.appendContents(profile.getBaseContents()).setRequiredFiles(files);
   }
 
-  private Telemetry.DeploymentMethod deploymentMethod() {
-    return new Telemetry.DeploymentMethod()
-        .setType(Telemetry.DeploymentMethod.HALYARD)
+  private Stats.DeploymentMethod deploymentMethod() {
+    return new Stats.DeploymentMethod()
+        .setType(Stats.DeploymentMethod.HALYARD)
         .setVersion(halyardVersion());
   }
 
@@ -154,12 +152,13 @@ public class EchoProfileFactory extends SpringProfileFactory {
     }
   }
 
+  /** Translates Halyard's `Stats` class to Echo's `Telemetry` class */
   @Data
   private static class TelemetryWrapper {
-    private Telemetry telemetry;
+    private Stats telemetry;
 
-    TelemetryWrapper(Telemetry telemetry) {
-      this.telemetry = telemetry;
+    TelemetryWrapper(Stats stats) {
+      this.telemetry = stats;
     }
   }
 }

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/StatsController.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/controllers/v1/StatsController.java
@@ -19,8 +19,8 @@ package com.netflix.spinnaker.halyard.controllers.v1;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigParser;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Halconfig;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Telemetry;
-import com.netflix.spinnaker.halyard.config.services.v1.TelemetryService;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Stats;
+import com.netflix.spinnaker.halyard.config.services.v1.StatsService;
 import com.netflix.spinnaker.halyard.core.tasks.v1.DaemonTask;
 import com.netflix.spinnaker.halyard.models.v1.ValidationSettings;
 import com.netflix.spinnaker.halyard.util.v1.GenericEnableDisableRequest;
@@ -30,48 +30,48 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/v1/config/deployments/{deploymentName:.+}/telemetry")
+@RequestMapping("/v1/config/deployments/{deploymentName:.+}/stats")
 @RequiredArgsConstructor
-public class TelemetryController {
-  private final TelemetryService telemetryService;
+public class StatsController {
+  private final StatsService statsService;
   private final HalconfigDirectoryStructure halconfigDirectoryStructure;
   private final HalconfigParser halconfigParser;
 
   @RequestMapping(value = "/", method = RequestMethod.GET)
-  DaemonTask<Halconfig, Telemetry> getTelemetry(
+  DaemonTask<Halconfig, Stats> getStats(
       @PathVariable String deploymentName, @ModelAttribute ValidationSettings validationSettings) {
-    return GenericGetRequest.<Telemetry>builder()
-        .getter(() -> telemetryService.getTelemetry(deploymentName))
-        .validator(() -> telemetryService.validateTelemetry(deploymentName))
-        .description("Get telemetry")
+    return GenericGetRequest.<Stats>builder()
+        .getter(() -> statsService.getStats(deploymentName))
+        .validator(() -> statsService.validateStats(deploymentName))
+        .description("Get stats")
         .build()
         .execute(validationSettings);
   }
 
   @RequestMapping(value = "/enabled", method = RequestMethod.PUT)
-  DaemonTask<Halconfig, Void> setTelemetryEnabled(
+  DaemonTask<Halconfig, Void> setStatsEnabled(
       @PathVariable String deploymentName,
       @ModelAttribute ValidationSettings validationSettings,
       @RequestBody Boolean enabled) {
     return GenericEnableDisableRequest.builder(halconfigParser)
-        .updater(t -> telemetryService.setTelemetryEnabled(deploymentName, false, enabled))
-        .validator(() -> telemetryService.validateTelemetry(deploymentName))
-        .description("Enable or disable telemetry")
+        .updater(t -> statsService.setStatsEnabled(deploymentName, false, enabled))
+        .validator(() -> statsService.validateStats(deploymentName))
+        .description("Enable or disable stats")
         .build()
         .execute(validationSettings, enabled);
   }
 
   @RequestMapping(value = "/", method = RequestMethod.PUT)
-  DaemonTask<Halconfig, Void> setTelemetry(
+  DaemonTask<Halconfig, Void> setStats(
       @PathVariable String deploymentName,
       @ModelAttribute ValidationSettings validationSettings,
-      @RequestBody Telemetry telemetry) {
-    return GenericUpdateRequest.<Telemetry>builder(halconfigParser)
+      @RequestBody Stats stats) {
+    return GenericUpdateRequest.<Stats>builder(halconfigParser)
         .stagePath(halconfigDirectoryStructure.getStagingPath(deploymentName))
-        .updater(t -> telemetryService.setTelemetry(deploymentName, t))
-        .validator(() -> telemetryService.validateTelemetry(deploymentName))
-        .description("Edit telemetry settings")
+        .updater(t -> statsService.setStats(deploymentName, t))
+        .validator(() -> statsService.validateStats(deploymentName))
+        .description("Edit stats settings")
         .build()
-        .execute(validationSettings, telemetry);
+        .execute(validationSettings, stats);
   }
 }


### PR DESCRIPTION
This is largely a `s/telemetry/stats/g` change, with some minor tweaks to ignore the old `telemetry` block (see `DeploymentConfiguration.java`). This change enables telemetry stats by default, and makes https://github.com/spinnaker/halyard/pull/1550 obsolete.

One known effect of this will be that all existing instance IDs will be regenerated. This may show a bump in unique instance counts as users upgrade their Halyard instances. Since there is only 118 28-day-active instances anyway, I think it'll largely be swallowed by the expected increase of newly enabled instances reporting metrics.

@ezimanyi Once this is in and Halyard is released, we'll need to indicate that the newly released Halyard version is required for 1.19.0.