### PR TITLE
Switch kubectl release from 1.14.10 to 1.14.6 to match AWS release

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -2,7 +2,7 @@ FROM alpine:3.11
 LABEL maintainer="delivery-engineering@netflix.com"
 COPY --from=halyard.compile /compiled_sources/halyard-web/build/install/halyard /opt/halyard
 
-ENV KUBECTL_RELEASE=1.14.10
+ENV KUBECTL_RELEASE=1.14.6
 ENV AWS_BINARY_RELEASE_DATE=2019-08-22
 ENV AWS_CLI_VERSION=1.17.9
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 LABEL maintainer="delivery-engineering@netflix.com"
 COPY --from=halyard.compile /compiled_sources/halyard-web/build/install/halyard /opt/halyard
 
-ENV KUBECTL_RELEASE=1.14.10
+ENV KUBECTL_RELEASE=1.14.6
 ENV AWS_BINARY_RELEASE_DATE=2019-08-22
 ENV AWS_CLI_VERSION=1.17.9
 


### PR DESCRIPTION
I'm not sure what happened but there is no 1.14.10 in the S3 bucket being used for `aws-iam-authenticator` anymore.
```
aws s3 ls amazon-eks
                           PRE 1.10.11/
                           PRE 1.10.13/
                           PRE 1.10.3/
                           PRE 1.11.10/
                           PRE 1.11.5/
                           PRE 1.11.8/
                           PRE 1.11.9/
                           PRE 1.12.10/
                           PRE 1.12.7/
                           PRE 1.12.9/
                           PRE 1.13.11/
                           PRE 1.13.12/
                           PRE 1.13.7/
                           PRE 1.13.8/
                           PRE 1.14.6/
                           PRE 1.14.7/
                           PRE 1.14.8/
                           PRE 1.14.9/
                           PRE 1.15.10/
                           PRE cloudformation/
                           PRE manifests/

aws s3 ls amazon-eks/1.14.6/
                           PRE 2019-08-22/
```

Rather than using 1.14.9 I thought it'd be a good idea to use `1.14.6` to match what AWS docs point to for 1.14.x as it's more likely to exist long-term.
https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/install-aws-iam-authenticator.md

This is my first PR here so let me know if this extends further than assumed. Ryan Thompson (thanks!) just mentioned this on Slack and it seemed like an easy win to try.