### PR TITLE
chore(vulnerabilities): resolve CVE issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 
 buildscript {
   ext {
-    clouddriverVersion = "5.47.1"
+    clouddriverVersion = "5.55.1"
     front50Version = "2.15.0"
     fiatVersion = "1.13.1"
   }

--- a/halyard-backup/halyard-backup.gradle
+++ b/halyard-backup/halyard-backup.gradle
@@ -10,7 +10,7 @@ dependencies {
   implementation 'com.google.auth:google-auth-library-oauth2-http'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io:2.6'
-  implementation 'org.apache.commons:commons-compress:1.14'
+  implementation 'org.apache.commons:commons-compress:1.20'
   implementation 'io.fabric8:kubernetes-client:4.1.1'
   implementation 'org.codehaus.groovy:groovy'
 

--- a/halyard-core/halyard-core.gradle
+++ b/halyard-core/halyard-core.gradle
@@ -13,7 +13,7 @@ dependencies {
   implementation 'com.google.api.grpc:grpc-google-common-protos:1.0.5'
   implementation 'com.google.auth:google-auth-library-oauth2-http'
   implementation 'org.apache.commons:commons-exec'
-  implementation 'org.apache.commons:commons-compress:1.14'
+  implementation 'org.apache.commons:commons-compress:1.20'
   implementation 'commons-io:commons-io:2.6'
   implementation 'io.reactivex:rxjava'
   implementation 'com.hubspot.jinjava:jinjava:2.2.3'

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation 'com.google.apis:google-api-services-storage'
   implementation 'com.google.apis:google-api-services-compute'
   implementation 'com.amazonaws:aws-java-sdk-core:1.11.534'
-  implementation 'org.apache.commons:commons-compress:1.2'
+  implementation 'org.apache.commons:commons-compress:1.20'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io:2.6'
   implementation 'com.squareup.retrofit:retrofit'


### PR DESCRIPTION
fix CVE-2019-12402 caused by commons-compress.

- Upgrade Cloud Driver version
- Upgrade commons-compress version 