### PR TITLE
fix(config): Ignore any existing `plugins` stanzas.

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentConfiguration.java
@@ -87,6 +87,9 @@ public class DeploymentConfiguration extends Node {
 
   Canary canary = new Canary();
 
+  // For backwards compatibility, removed in spinnaker/halyard#1520
+  @JsonIgnore String plugins = "";
+
   Spinnaker spinnaker = new Spinnaker();
 
   Webhook webhook = new Webhook();


### PR DESCRIPTION
Slack is littered with people having this issue. It looks like this field was added in halyard 1.23 on 8/27/2019. So anyone with a config after that will have this issue. Perhaps worth a 1.32.1 release?

FYI Cameron: because of the weird way Halyard works, it writes default values for everything into the Halyard config file. Which means basically every single person has a `plugins` stanza in their Halyard config and when you delete that `plugins` field, they'll get parsing errors. So it's basically not safe to ever completely remove a field from a Halyard `Node` class. :sob: 

Fixes spinnaker/spinnaker#5606