### PR TITLE
feat(plugins): add plugins to all services

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerServic
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,6 +50,11 @@ public class Front50ProfileFactory extends SpringProfileFactory {
   }
 
   @Override
+  protected boolean addExtensibilityConfigs(DeploymentConfiguration deploymentConfiguration) {
+    return false;
+  }
+
+  @Override
   public void setProfile(
       Profile profile,
       DeploymentConfiguration deploymentConfiguration,
@@ -59,8 +65,11 @@ public class Front50ProfileFactory extends SpringProfileFactory {
       throw new HalException(Problem.Severity.FATAL, "No persistent storage type was configured.");
     }
 
+    Map<String, Object> spinnakerYaml =
+        spinnakerVersionSupportsPlugins(deploymentConfiguration)
+            ? getSpinnakerYaml(deploymentConfiguration)
+            : new LinkedHashMap<>();
     List<String> files = backupRequiredFiles(persistentStorage, deploymentConfiguration.getName());
-    Map<String, Map<String, Object>> persistentStorageMap = new HashMap<>();
 
     NodeIterator children = persistentStorage.getChildren();
     Node child = children.getNext();
@@ -87,14 +96,14 @@ public class Front50ProfileFactory extends SpringProfileFactory {
         persistentStoreMap.put(
             "enabled", persistentStoreType.equals(persistentStorage.getPersistentStoreType()));
 
-        persistentStorageMap.put(persistentStoreType.getId(), persistentStoreMap);
+        spinnakerYaml.put(persistentStoreType.getId(), persistentStoreMap);
       }
 
       child = children.getNext();
     }
 
     Map<String, Object> spinnakerObjectMap = new HashMap<>();
-    spinnakerObjectMap.put("spinnaker", persistentStorageMap);
+    spinnakerObjectMap.put("spinnaker", spinnakerYaml);
 
     super.setProfile(profile, deploymentConfiguration, endpoints);
     profile

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/Front50ProfileFactory.java
@@ -66,7 +66,7 @@ public class Front50ProfileFactory extends SpringProfileFactory {
     }
 
     Map<String, Object> spinnakerYaml =
-        spinnakerVersionSupportsPlugins(deploymentConfiguration)
+        spinnakerVersionSupportsPlugins(deploymentConfiguration.getVersion())
             ? getSpinnakerYaml(deploymentConfiguration)
             : new LinkedHashMap<>();
     List<String> files = backupRequiredFiles(persistentStorage, deploymentConfiguration.getName());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KayentaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/KayentaProfileFactory.java
@@ -75,6 +75,16 @@ public class KayentaProfileFactory extends SpringProfileFactory {
     }
   }
 
+  @Override
+  protected String baseReleaseWithPlugins() {
+    return "1.20.0";
+  }
+
+  @Override
+  protected String concreteReleaseWithPlugins() {
+    return "1.20.0";
+  }
+
   @EqualsAndHashCode(callSuper = true)
   @Data
   private static class KayentaConfigWrapper extends SpringProfileConfig {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -23,9 +23,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.integrations.IntegrationsConfigWrapper;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -77,11 +75,6 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     profile.appendContents("pipelineTemplates.enabled: " + pipelineTemplates);
     // For backward compatibility
     profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
-
-    // TODO(link108): need to apply this to all services, must take into account duplicate keys
-    Map<String, Object> spinnakerYaml = new LinkedHashMap<>();
-    spinnakerYaml.put("spinnaker", deploymentConfiguration.getSpinnaker().toMap());
-    profile.appendContents(yamlToString(deploymentConfiguration.getName(), profile, spinnakerYaml));
   }
 
   @Data

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/OrcaProfileFactory.java
@@ -77,6 +77,11 @@ public class OrcaProfileFactory extends SpringProfileFactory {
     profile.appendContents("pipelineTemplate.enabled: " + pipelineTemplates);
   }
 
+  @Override
+  protected String concreteReleaseWithPlugins() {
+    return "1.19.0";
+  }
+
   @Data
   @RequiredArgsConstructor
   private static class WebhookWrapper {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringProfileFactory.java
@@ -74,15 +74,23 @@ public class SpringProfileFactory extends RegistryBackedProfileFactory {
   protected boolean spinnakerVersionSupportsPlugins(String version) {
     String[] versionParts = version.split("-");
     if (versionParts.length == 1) {
-      return Versions.greaterThanEqual(version, "1.19.4");
+      return Versions.greaterThanEqual(version, concreteReleaseWithPlugins());
     } else if (versionParts[0].equals("master")) {
       return pluginsDateCheck(versionParts[1]);
     } else if (versionParts[0].equals("release")
         && versionParts.length >= 3
-        && Versions.greaterThanEqual(versionParts[1].replace("x", "0"), "1.19.0")) {
+        && Versions.greaterThanEqual(versionParts[1].replace("x", "0"), baseReleaseWithPlugins())) {
       return pluginsDateCheck(versionParts[2]);
     }
     return false;
+  }
+
+  protected String baseReleaseWithPlugins() {
+    return "1.19.0";
+  }
+
+  protected String concreteReleaseWithPlugins() {
+    return "1.19.4";
   }
 
   private boolean pluginsDateCheck(String dateOrLatest) {

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringProfileFactorySpec.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringProfileFactorySpec.groovy
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Armory, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile
+
+import spock.lang.Specification
+
+
+class SpringProfileFactorySpec extends Specification {
+
+    def "version checks work"() {
+        given:
+        def subject = new SpringProfileFactory()
+
+        expect:
+        subject.spinnakerVersionSupportsPlugins(version) == should_support_plugins
+
+        where:
+        version                               | should_support_plugins
+        "1.7.5"                               | false
+        "1.19.3"                              | false
+        "1.19.11"                             | true
+        "master-20191121162350"               | false
+        "master-20200503040016"               | true
+        "io-codelab"                          | false
+        "release-1.10.x-latest-unvalidated"   | false
+        "release-1.18.x-20200314030017"       | false
+        "release-1.19.x-20200403040016"       | false
+        "release-1.19.x-20200503040016"       | true
+        "release-1.19.x-latest-validated"     | true
+        "release-1.7.x-latest-validated"      | false
+    }
+}


### PR DESCRIPTION
Now that PF4J has been introduced to Spinnaker, Halyard should deploy plugin configuration to the individual services.

Previous discussion on slack: https://spinnakerteam.slack.com/archives/CK9FK4XDF/p1582934543022800
Previous PR: https://github.com/spinnaker/halyard/pull/1559

I tested this with the `spinnaker-release-1.19.x-latest-unvalidated` service builds and setting the spinnaker version to `1.18.0` to ensure plugin configs weren't sent to the services. 