### PR TITLE
fix(container): restore openssl to alpine image

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -10,6 +10,7 @@ RUN apk --no-cache add --update \
   bash \
   curl \
   openjdk8-jre \
+  openssl \
   py-pip \
   python
 RUN pip install --upgrade awscli==${AWS_CLI_VERSION}


### PR DESCRIPTION
removed by https://github.com/spinnaker/halyard/commit/43dfc6744ea6dbe6fd65cb349a53696d96329dae

In addition to putting back something that was there previously, openssl is in the ubuntu
container, so let's have it here as well.

Not sure whether `fix` is really fair here?  Maybe this is more `feat` ?