### PR TITLE
feat(kubernetes): More configurable readiness/liveness probes

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditDeploymentEnvironmentCommand.java
@@ -174,10 +174,10 @@ public class EditDeploymentEnvironmentCommand extends AbstractConfigCommand {
       vault = new DeploymentEnvironment.Vault();
     }
 
-    DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
+    DeploymentEnvironment.K8SProbeConfig livenessProbeConfig =
         deploymentEnvironment.getLivenessProbeConfig();
     if (livenessProbeConfig == null) {
-      livenessProbeConfig = new DeploymentEnvironment.LivenessProbeConfig();
+      livenessProbeConfig = new DeploymentEnvironment.K8SProbeConfig();
     }
 
     deploymentEnvironment.setAccountName(

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/DeploymentEnvironment.java
@@ -136,7 +136,8 @@ public class DeploymentEnvironment extends Node {
   private Map<String, List<Toleration>> tolerations = new HashMap<>();
   private Map<String, String> nodeSelectors = new HashMap<>();
   private GitConfig gitConfig = new GitConfig();
-  private LivenessProbeConfig livenessProbeConfig = new LivenessProbeConfig();
+  private K8SProbeConfig livenessProbeConfig = new K8SProbeConfig();
+  private K8SProbeConfig readinessProbeConfig = new K8SProbeConfig();
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.10.0",
@@ -167,8 +168,12 @@ public class DeploymentEnvironment extends Node {
   }
 
   @Data
-  public static class LivenessProbeConfig {
+  public static class K8SProbeConfig {
     boolean enabled;
     Integer initialDelaySeconds;
+    Integer periodSeconds;
+    Integer timeoutSeconds;
+    Integer successThreshold;
+    Integer failureThreshold;
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -440,7 +440,7 @@ public interface KubernetesV1DistributedService<T>
     readinessProbe.setHandler(readinessHandler);
     container.setReadinessProbe(readinessProbe);
 
-    DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
+    DeploymentEnvironment.K8SProbeConfig livenessProbeConfig =
         deploymentEnvironment.getLivenessProbeConfig();
     if (livenessProbeConfig != null
         && livenessProbeConfig.isEnabled()

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/ResourceBuilder.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/ResourceBuilder.java
@@ -80,7 +80,7 @@ class ResourceBuilder {
     ProbeBuilder readinessProbeBuilder = buildProbeBuilder(port, scheme, healthEndpoint, null);
     ProbeBuilder livenessProbeBuilder = null;
 
-    DeploymentEnvironment.LivenessProbeConfig livenessProbeConfig =
+    DeploymentEnvironment.K8SProbeConfig livenessProbeConfig =
         deploymentEnvironment.getLivenessProbeConfig();
     if (livenessProbeConfig != null
         && livenessProbeConfig.isEnabled()

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/execProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/execProbe.yml
@@ -6,5 +6,9 @@
       {% endfor %}
     ]
   },
-  "initialDelaySeconds": {{ initialDelaySeconds }}
+  "initialDelaySeconds": {{ initialDelaySeconds }},
+  "periodSeconds": {{ periodSeconds }},
+  "timeoutSeconds": {{ timeoutSeconds }},
+  "successThreshold": {{ successThreshold }},
+  "failureThreshold": {{ failureThreshold }}
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/httpProbe.yml
@@ -4,5 +4,9 @@
     "path": "{{ path }}",
     "scheme": "{{ scheme }}"
   },
-  "initialDelaySeconds": {{ initialDelaySeconds }}
+  "initialDelaySeconds": {{ initialDelaySeconds }},
+  "periodSeconds": {{ periodSeconds }},
+  "timeoutSeconds": {{ timeoutSeconds }},
+  "successThreshold": {{ successThreshold }},
+  "failureThreshold": {{ failureThreshold }}
 }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/tcpSocketProbe.yml
@@ -2,5 +2,9 @@
   "tcpSocket": {
     "port": {{ port }}
   },
-  "initialDelaySeconds": {{ initialDelaySeconds }}
+  "initialDelaySeconds": {{ initialDelaySeconds }},
+  "periodSeconds": {{ periodSeconds }},
+  "timeoutSeconds": {{ timeoutSeconds }},
+  "successThreshold": {{ successThreshold }},
+  "failureThreshold": {{ failureThreshold }}
 }


### PR DESCRIPTION
Adds additional configuration options for liveness, and adds the same options for readiness.
Probes have the same basic options, so refactored the type to be shared for both.

Example halconfig block:

```
deploymentEnvironment:
  # Numbers arbitrary
  livenessProbeConfig:
    enabled: true
    initialDelaySeconds: 9001
    timeoutSeconds: 62
    periodSeconds: 60
    successThreshold: 1
    failureThreshold: 5
  readinessProbeConfig:
    enabled: true
    initialDelaySeconds: 9001
    timeoutSeconds: 64
    periodSeconds: 61
    successThreshold: 2
    failureThreshold: 4
```