### PR TITLE
fix(daemon): Don't try to kill daemon created by another user

### DIFF
--- a/startup/debian/hal
+++ b/startup/debian/hal
@@ -53,7 +53,7 @@ if [ -z "$HALYARD_DAEMON_PID" ]; then
     start_daemon
 else
     set +e
-    ps $HALYARD_DAEMON_PID &> /dev/null
+    ps -e $HALYARD_DAEMON_PID &> /dev/null
     exit_code=$?
     set -e
 


### PR DESCRIPTION
Currently if the Halyard daemon was created by another user, we kill it and try to start one of our own (likely failing as we probably don't have permission to kill it).

This is because we look up the PID in the pid file, then try to see if the process exists with 'ps' but don't pass the '-e' flag to get all processes (including those created by other users). This is particularly important given that the Halyard install process specifically asks you to specify a user with which to run Halyard.