### PR TITLE
chore(build): enable the spinnaker project plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,9 @@ allprojects {
   apply plugin: 'spinnaker.base-project'
   apply plugin: 'java-library'
   apply plugin: 'groovy'
+  if (Boolean.valueOf(enablePublishing)) {
+    apply plugin: 'spinnaker.project'
+  }
 
   test {
     testLogging {


### PR DESCRIPTION
Whoops, missed this part that used to be in init-publish.gradle.

This is how it's done in all the other microservices now.