### PR TITLE
chore(java11): Compile with Java 11 (but targeting Java 8)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -27,4 +32,4 @@ jobs:
           BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-        run: ./gradlew -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace
+        run: ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" build snapshot --stacktrace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    # Install Java 8 for cross-compilation support. Setting it up before
+    # Java 11 means it comes later in $PATH (because of how setup-java works)
     - uses: actions/setup-java@v1
       with:
         java-version: 8
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 11
     - uses: actions/cache@v1
       with:
         path: ~/.gradle
@@ -19,4 +24,4 @@ jobs:
     - name: Build
       env:
         GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
-      run: ./gradlew build javadoc
+      run: ./gradlew -PenableCrossCompilerPlugin=true build javadoc

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,14 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git fetch --prune --unshallow
+      # Install Java 8 for cross-compilation support. Setting it up before
+      # Java 11 means it comes later in $PATH (because of how setup-java works)
       - uses: actions/setup-java@v1
         with:
           java-version: 8
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 11
       - uses: actions/cache@v1
         with:
           path: ~/.gradle
@@ -37,7 +42,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" candidate
       - name: Release build
         if: steps.release_info.outputs.IS_CANDIDATE == 'false'
         env:
@@ -45,7 +50,7 @@ jobs:
           BINTRAY_API_KEY: ${{ secrets.BINTRAY_API_KEY }}
           GRADLE_OPTS: -Xmx6g -Xms6g -Dorg.gradle.daemon=false
         run: |
-          ./gradlew -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
+          ./gradlew -PenableCrossCompilerPlugin=true -PenablePublishing=true --info -Prelease.disableGitChecks=true -Prelease.useLastTag=true -PbintrayUser="${BINTRAY_USER}" -PbintrayKey="${BINTRAY_API_KEY}" final
       - name: Create release
         if: steps.release_info.outputs.SKIP_RELEASE == 'false'
         uses: actions/create-release@v1

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,5 +1,11 @@
-FROM openjdk:8
+FROM ubuntu:bionic
+RUN apt-get update && apt-get install -y \
+    openjdk-8-jdk \
+    openjdk-11-jdk \
+ && rm -rf /var/lib/apt/lists/*
 MAINTAINER sig-platform@spinnaker.io
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+ENV JDK_18 /usr/lib/jvm/java-8-openjdk-amd64
 ENV GRADLE_USER_HOME /workspace/.gradle
-ENV GRADLE_OPTS -Xmx2048m
-CMD ./gradlew --no-daemon halyard-web:installDist -x test
+ENV GRADLE_OPTS -Xmx4g
+CMD ./gradlew --no-daemon -PenableCrossCompilerPlugin=true halyard-web:installDist -x test

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -9,7 +9,7 @@ ENV AWS_CLI_VERSION=1.18.18
 RUN apk --no-cache add --update \
   bash \
   curl \
-  openjdk8-jre \
+  openjdk11-jre \
   openssl \
   py-pip \
   python

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -9,7 +9,7 @@ ENV AWS_CLI_VERSION=1.18.18
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-      openjdk-8-jre-headless \
+      openjdk-11-jre-headless \
       curl \
       python-pip && \
     pip install awscli==${AWS_CLI_VERSION} --upgrade

--- a/halyard-proto/halyard-proto.gradle
+++ b/halyard-proto/halyard-proto.gradle
@@ -6,6 +6,19 @@ dependencies {
   implementation 'com.google.guava:guava:23.5-jre'
   api 'com.google.api.grpc:grpc-google-common-protos:1.0.5'
   implementation 'io.grpc:grpc-all:1.8.0'
+
+  // If we're targeting Java 8, protoc will generate old @Generated annotations.
+  // But developers likely won't have the cross-compiler plugin turned on, so
+  // those old annotations won't be available to javac (only the new Java 9
+  // versions will be). So we'll add those to the classpath.
+  //
+  // This can be deleted when we're properly targeting Java 11 (at which point
+  // protoc will generate code for the newer annotations.
+  if (JavaVersion.current().isJava9Compatible()
+      && targetCompatibility == JavaVersion.VERSION_1_8
+      && !Boolean.valueOf(project.findProperty('enableCrossCompilerPlugin'))) {
+    compile 'javax.annotation:javax.annotation-api:1.3.2'
+  }
 }
 
 protobuf {


### PR DESCRIPTION
Also:
* use a Java 11 JRE
* fix compilation for developers who aren't likely to have the cross-compilation plugin enabled