### PR TITLE
feat(cli): remove unused appengine feature flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6354,7 +6354,6 @@ hal config features edit [parameters]
 ```
 
 #### Parameters
- * `--appengine-container-image-url-deployments`: Enable appengine deployments using a container image URL from gcr.io.
  * `--artifacts`: Enable artifact support. Read more at [https://spinnaker.io/reference/artifacts/](https://spinnaker.io/reference/artifacts/)
  * `--artifacts-rewrite`: Enable new artifact support. Read more at [https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/](https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/)
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here [https://github.com/Netflix/chaosmonkey/wiki](https://github.com/Netflix/chaosmonkey/wiki).

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -78,12 +78,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
       arity = 1)
   private Boolean infrastructureStages = null;
 
-  @Parameter(
-      names = "--appengine-container-image-url-deployments",
-      description = "Enable appengine deployments using a container image URL from gcr.io.",
-      arity = 1)
-  private Boolean appengineContainerImageUrlDeployments = null;
-
   @Parameter(names = "--travis", description = "Enable the Travis CI stage.", arity = 1)
   private Boolean travis = null;
 
@@ -123,10 +117,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setMineCanary(mineCanary != null ? mineCanary : features.getMineCanary());
     features.setInfrastructureStages(
         infrastructureStages != null ? infrastructureStages : features.getInfrastructureStages());
-    features.setAppengineContainerImageUrlDeployments(
-        appengineContainerImageUrlDeployments != null
-            ? appengineContainerImageUrlDeployments
-            : features.getAppengineContainerImageUrlDeployments());
     features.setTravis(travis != null ? travis : features.getTravis());
     features.setWercker(wercker != null ? wercker : features.getWercker());
     features.setManagedPipelineTemplatesV2UI(

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -22,7 +22,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@JsonIgnoreProperties({"jobs"})
+@JsonIgnoreProperties({"jobs", "appengineContainerImageUrlDeployments"})
 public class Features extends Node {
   @Override
   public String getNodeName() {
@@ -61,15 +61,6 @@ public class Features extends Node {
       tooLowMessage =
           "Canary is not configurable prior to this release. Will be stable at a later release.")
   private Boolean mineCanary;
-
-  @ValidForSpinnakerVersion(
-      lowerBound = "1.7.0",
-      upperBound = "1.11.0",
-      tooLowMessage =
-          "Appengine container URL deployments were not supported prior to this version.",
-      tooHighMessage =
-          "Appengine container URL deployments are stable; the feature flag will be removed in a future version of Halyard.")
-  private Boolean appengineContainerImageUrlDeployments;
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.7.0",

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -128,12 +128,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
         "features.mineCanary",
         Boolean.toString(features.getMineCanary() != null ? features.getMineCanary() : false));
     bindings.put(
-        "features.appengineContainerImageUrlDeployments",
-        Boolean.toString(
-            features.getAppengineContainerImageUrlDeployments() != null
-                ? features.getAppengineContainerImageUrlDeployments()
-                : false));
-    bindings.put(
         "features.travis",
         Boolean.toString(features.getTravis() != null ? features.getTravis() : false));
     bindings.put(


### PR DESCRIPTION
In preparation for strongly typing the rest of the Halconfig for Kleat, let's remove as many unneeded feature flags as possible. Since the `appengineContainerImageUrlDeployments` has not been used by Deck since release 1.11, let's remove the command to set it and simply ignore the field in existing Halconfigs.