### PR TITLE
feat(cli): remove Travis, Wercker, Gremlin, and InfrastructureStages feature flags

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6356,7 +6356,6 @@ hal config features edit [parameters]
 #### Parameters
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here [https://github.com/Netflix/chaosmonkey/wiki](https://github.com/Netflix/chaosmonkey/wiki).
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--infrastructure-stages`: Enable infrastructure stages. Allows for creating Load Balancers as part of pipelines.
  * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6356,7 +6356,6 @@ hal config features edit [parameters]
 #### Parameters
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here [https://github.com/Netflix/chaosmonkey/wiki](https://github.com/Netflix/chaosmonkey/wiki).
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
- * `--gremlin`: Enable Gremlin fault-injection support.
  * `--infrastructure-stages`: Enable infrastructure stages. Allows for creating Load Balancers as part of pipelines.
  * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6362,7 +6362,6 @@ hal config features edit [parameters]
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--pipeline-templates`: Enable pipeline template support. Read more at [https://github.com/spinnaker/dcd-spec](https://github.com/spinnaker/dcd-spec).
- * `--travis`: Enable the Travis CI stage.
  * `--wercker`: Enable the Wercker CI stage.
 
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6362,7 +6362,6 @@ hal config features edit [parameters]
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--pipeline-templates`: Enable pipeline template support. Read more at [https://github.com/spinnaker/dcd-spec](https://github.com/spinnaker/dcd-spec).
- * `--wercker`: Enable the Wercker CI stage.
 
 
 ---

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -64,9 +64,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
       arity = 1)
   private Boolean infrastructureStages = null;
 
-  @Parameter(names = "--wercker", description = "Enable the Wercker CI stage.", arity = 1)
-  private Boolean wercker = null;
-
   @Parameter(
       names = "--managed-pipeline-templates-v2-ui",
       description = "Enable managed pipeline templates v2 UI support.",
@@ -97,7 +94,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setMineCanary(mineCanary != null ? mineCanary : features.getMineCanary());
     features.setInfrastructureStages(
         infrastructureStages != null ? infrastructureStages : features.getInfrastructureStages());
-    features.setWercker(wercker != null ? wercker : features.getWercker());
     features.setManagedPipelineTemplatesV2UI(
         managedPipelineTemplatesV2UI != null
             ? managedPipelineTemplatesV2UI

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -58,13 +58,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   private Boolean mineCanary = null;
 
   @Parameter(
-      names = "--infrastructure-stages",
-      description =
-          "Enable infrastructure stages. Allows for creating Load Balancers as part of pipelines.",
-      arity = 1)
-  private Boolean infrastructureStages = null;
-
-  @Parameter(
       names = "--managed-pipeline-templates-v2-ui",
       description = "Enable managed pipeline templates v2 UI support.",
       arity = 1)
@@ -86,8 +79,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setPipelineTemplates(
         pipelineTemplates != null ? pipelineTemplates : features.getPipelineTemplates());
     features.setMineCanary(mineCanary != null ? mineCanary : features.getMineCanary());
-    features.setInfrastructureStages(
-        infrastructureStages != null ? infrastructureStages : features.getInfrastructureStages());
     features.setManagedPipelineTemplatesV2UI(
         managedPipelineTemplatesV2UI != null
             ? managedPipelineTemplatesV2UI

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -70,12 +70,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
       arity = 1)
   private Boolean managedPipelineTemplatesV2UI = null;
 
-  @Parameter(
-      names = "--gremlin",
-      description = "Enable Gremlin fault-injection support.",
-      arity = 1)
-  private Boolean gremlin = null;
-
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -98,7 +92,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
         managedPipelineTemplatesV2UI != null
             ? managedPipelineTemplatesV2UI
             : features.getManagedPipelineTemplatesV2UI());
-    features.setGremlin(gremlin != null ? gremlin : features.getGremlin());
 
     if (originalHash == features.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -64,9 +64,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
       arity = 1)
   private Boolean infrastructureStages = null;
 
-  @Parameter(names = "--travis", description = "Enable the Travis CI stage.", arity = 1)
-  private Boolean travis = null;
-
   @Parameter(names = "--wercker", description = "Enable the Wercker CI stage.", arity = 1)
   private Boolean wercker = null;
 
@@ -100,7 +97,6 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setMineCanary(mineCanary != null ? mineCanary : features.getMineCanary());
     features.setInfrastructureStages(
         infrastructureStages != null ? infrastructureStages : features.getInfrastructureStages());
-    features.setTravis(travis != null ? travis : features.getTravis());
     features.setWercker(wercker != null ? wercker : features.getWercker());
     features.setManagedPipelineTemplatesV2UI(
         managedPipelineTemplatesV2UI != null

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -80,7 +80,9 @@ public class Features extends Node {
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.9.0",
-      tooLowMessage = "Wercker stage is not available prior to this release.")
+      upperBound = "1.20.0",
+      tooLowMessage = "Wercker stage is not available prior to this release.",
+      tooHighMessage = "Wercker stage is now enabled by default.")
   private Boolean wercker;
 
   @ValidForSpinnakerVersion(

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -92,7 +92,9 @@ public class Features extends Node {
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.13.0",
-      tooLowMessage = "Gremlin is not available prior to this release.")
+      upperBound = "1.20.0",
+      tooLowMessage = "Gremlin stage is not available prior to this release.",
+      tooHighMessage = "Gremlin stage is now enabled by default.")
   private Boolean gremlin;
 
   public boolean isAuth(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -67,8 +67,10 @@ public class Features extends Node {
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.7.0",
+      upperBound = "1.20.0",
       tooLowMessage =
-          "Infrastructure Stages is not configurable prior to this release. Will be stable at a later release.")
+          "Infrastructure Stages is not configurable prior to this release. Will be stable at a later release.",
+      tooHighMessage = "Travis stage is now enabled by default.")
   private Boolean infrastructureStages;
 
   @ValidForSpinnakerVersion(

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -73,7 +73,9 @@ public class Features extends Node {
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.9.0",
-      tooLowMessage = "Travis stage is not available prior to this release.")
+      upperBound = "1.20.0",
+      tooLowMessage = "Travis stage is not available prior to this release.",
+      tooHighMessage = "Travis stage is now enabled by default.")
   private Boolean travis;
 
   @ValidForSpinnakerVersion(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -121,9 +121,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
         "features.mineCanary",
         Boolean.toString(features.getMineCanary() != null ? features.getMineCanary() : false));
     bindings.put(
-        "features.wercker",
-        Boolean.toString(features.getWercker() != null ? features.getWercker() : false));
-    bindings.put(
         "features.managedPipelineTemplatesV2UI",
         Boolean.toString(
             features.getManagedPipelineTemplatesV2UI() != null

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -126,12 +126,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
             features.getManagedPipelineTemplatesV2UI() != null
                 ? features.getManagedPipelineTemplatesV2UI()
                 : false));
-    bindings.put(
-        "features.infrastructureStages",
-        Boolean.toString(
-            features.getInfrastructureStages() != null
-                ? features.getInfrastructureStages()
-                : false));
 
     // Configure Kubernetes
     KubernetesProvider kubernetesProvider = deploymentConfiguration.getProviders().getKubernetes();

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -121,9 +121,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
         "features.mineCanary",
         Boolean.toString(features.getMineCanary() != null ? features.getMineCanary() : false));
     bindings.put(
-        "features.travis",
-        Boolean.toString(features.getTravis() != null ? features.getTravis() : false));
-    bindings.put(
         "features.wercker",
         Boolean.toString(features.getWercker() != null ? features.getWercker() : false));
     bindings.put(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -127,9 +127,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
                 ? features.getManagedPipelineTemplatesV2UI()
                 : false));
     bindings.put(
-        "features.gremlin",
-        Boolean.toString(features.getGremlin() != null ? features.getGremlin() : false));
-    bindings.put(
         "features.infrastructureStages",
         Boolean.toString(
             features.getInfrastructureStages() != null


### PR DESCRIPTION
We [replaced](https://github.com/spinnaker/deck/pull/8175) Deck's stage-specific feature flags with a single `hiddenStages` setting , so we should remove their corresponding Halyard commands.

* feat(cli): remove Travis feature flag 

* feat(cli): remove Wercker feature flag 

* feat(cli): remove Gremlin feature flag 

* feat(cli): remove infrastructureStages feature flag

Corresponding docs PR: https://github.com/spinnaker/spinnaker.github.io/pull/1807