### PR TITLE
chore(jre): revert to the Java 8 JRE

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -9,7 +9,7 @@ ENV AWS_CLI_VERSION=1.18.18
 RUN apk --no-cache add --update \
   bash \
   curl \
-  openjdk11-jre \
+  openjdk8-jre \
   openssl \
   py-pip \
   python

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -9,7 +9,7 @@ ENV AWS_CLI_VERSION=1.18.18
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
-      openjdk-11-jre-headless \
+      openjdk-8-jre-headless \
       curl \
       python-pip && \
     pip install awscli==${AWS_CLI_VERSION} --upgrade


### PR DESCRIPTION
(a patch to `release-1.34.x`)

Fixes spinnaker/spinnaker#5685