### PR TITLE
fix(config): Add @Secret decorator to Password/Key properties in Config Models

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/prometheus/PrometheusCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/prometheus/PrometheusCanaryAccount.java
@@ -20,6 +20,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryAccoun
 import com.netflix.spinnaker.halyard.config.model.v1.canary.AbstractCanaryServiceIntegration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import java.util.Collections;
 import java.util.Set;
 import lombok.Data;
@@ -34,7 +35,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PrometheusCanaryAccount extends AbstractCanaryAccount implements Cloneable {
   private Endpoint endpoint;
   private String username;
-  private String password;
+  @Secret private String password;
 
   @LocalFile @SecretFile private String usernamePasswordFile;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuild.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/ci/codebuild/AwsCodeBuild.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.config.model.v1.ci.codebuild;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.Ci;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Data;
@@ -27,7 +28,7 @@ import lombok.EqualsAndHashCode;
 public class AwsCodeBuild extends Ci<AwsCodeBuildAccount> {
   private boolean enabled;
   private String accessKeyId;
-  private String secretAccessKey;
+  @Secret private String secretAccessKey;
   private List<AwsCodeBuildAccount> accounts = new ArrayList<>();
 
   public List<AwsCodeBuildAccount> listAccounts() {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/huaweicloud/HuaweiCloudBakeryDefaults.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/huaweicloud/HuaweiCloudBakeryDefaults.java
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.huaweicloud;
 
 import com.netflix.spinnaker.halyard.config.model.v1.node.BakeryDefaults;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -25,7 +26,7 @@ import lombok.EqualsAndHashCode;
 public class HuaweiCloudBakeryDefaults extends BakeryDefaults<HuaweiCloudBaseImage> {
   private String authUrl;
   private String username;
-  private String password;
+  @Secret private String password;
   private String projectName;
   private String domainName;
   private Boolean insecure;


### PR DESCRIPTION
A review of the Halyard Config Models uncovered three instances where either the Password or SecretKey property did not have the Secret decorator applied.  This fix imports and applies `@Secret` to these sensitive information properties in the following Config Models:

- PrometheusCanaryAccount.java
- AwsCodeBuild.java
- HuaweiCloudBakerDefaults.java