### PR TITLE
fix(containers): Add retry to Docker containers downloading kubectl

### DIFF
--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -22,7 +22,7 @@ RUN echo '#!/usr/bin/env bash' > /usr/local/bin/hal && \
   echo '/opt/halyard/bin/hal "$@"' > /usr/local/bin/hal && \
   chmod +x /usr/local/bin/hal
 
-RUN curl -f -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
+RUN curl -f -LO --retry 3 --retry-delay 3 https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -18,7 +18,7 @@ RUN echo '#!/usr/bin/env bash' | tee /usr/local/bin/hal > /dev/null && \
   echo '/opt/halyard/bin/hal "$@"' | tee /usr/local/bin/hal > /dev/null
 RUN chmod +x /usr/local/bin/hal
 
-RUN curl -f -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
+RUN curl -f -LO --retry 3 --retry-delay 3 https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
Lately we've been seeing the following Docker `RUN` command failing when building a Halyard container:

```
Step 12/18 : RUN curl -f -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin/kubectl
 ---> Running in cba63cce119f
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

curl: (56) OpenSSL SSL_read: Connection reset by peer
The command '/bin/sh -c curl -f -LO https://storage.googleapis.com/kubernetes-release/release/v${KUBECTL_RELEASE}/bin/linux/amd64/kubectl &&     chmod +x ./kubectl &&     mv ./kubectl /usr/local/bin/kubectl' returned a non-zero code: 56
```
[Sample failure](https://console.cloud.google.com/cloud-build/builds/fdafb2e8-18ae-439c-b56b-67057baeb908;step=3?organizationId=433637338589&project=spinnaker-community&ref=https:%2F%2Fpantheon.corp.google.com%2Fcloud-build%2Fbuilds%2Ffdafb2e8-18ae-439c-b56b-67057baeb908;step%3D3)

This change instructs `curl` to retry up to 3 times during transient failures like this. So far I've only seen it on kubectl.