### PR TITLE
fix(build): use bom for kubernetes-client version

### DIFF
--- a/halyard-backup/halyard-backup.gradle
+++ b/halyard-backup/halyard-backup.gradle
@@ -11,7 +11,7 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io:2.6'
   implementation 'org.apache.commons:commons-compress:1.14'
-  implementation 'io.fabric8:kubernetes-client:4.1.1'
+  implementation 'io.fabric8:kubernetes-client'
   implementation 'org.codehaus.groovy:groovy'
 
   implementation project(':halyard-config')

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -33,7 +33,6 @@ dependencies {
   testImplementation 'org.springframework:spring-test'
 }
 
-apply plugin: 'java'
 apply plugin: 'application'
 
 mainClassName = 'com.netflix.spinnaker.halyard.cli.Main'

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -27,7 +27,7 @@ dependencies {
   implementation 'commons-collections:commons-collections:3.2.2'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io:2.6'
-  implementation 'io.fabric8:kubernetes-client:4.1.1'
+  implementation 'io.fabric8:kubernetes-client'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.jcraft:jsch'
   implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid'

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -20,7 +20,7 @@ dependencies {
   implementation 'commons-io:commons-io:2.6'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.squareup.okhttp:okhttp'
-  implementation 'io.fabric8:kubernetes-client:4.1.1'
+  implementation 'io.fabric8:kubernetes-client'
   implementation 'io.fabric8:fabric8-utils:2.2.216'
   implementation 'redis.clients:jedis'
   implementation 'org.codehaus.groovy:groovy'

--- a/halyard-proto/halyard-proto.gradle
+++ b/halyard-proto/halyard-proto.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
 
 dependencies {
@@ -17,7 +16,7 @@ dependencies {
   if (JavaVersion.current().isJava9Compatible()
       && targetCompatibility == JavaVersion.VERSION_1_8
       && !Boolean.valueOf(project.findProperty('enableCrossCompilerPlugin'))) {
-    compile 'javax.annotation:javax.annotation-api:1.3.2'
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
   }
 }
 

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -1,4 +1,3 @@
-apply plugin: 'com.google.protobuf'
 apply plugin: 'io.spinnaker.package'
 
 ext {


### PR DESCRIPTION
removes explicit version opinion which was causing the build to blow up
in some dependency resolution cases (:halyard-web:depInsight
--configuration runtimeClasspath --dependency kork-core)

also was causing the transitives of kubernetes-client not to end up in
the application/deb