### PR TITLE
feat(docs): document poor performance of sortTagsByDate flag

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8491,7 +8491,7 @@ hal config provider docker-registry account add ACCOUNT [parameters]
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--repositories`: (*Default*: `[]`) An optional list of repositories to cache images from. If not provided, Spinnaker will attempt to read accessible repositories from the registries _catalog endpoint
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
- * `--sort-tags-by-date`: (*Default*: `false`) Sort tags by creation date.
+ * `--sort-tags-by-date`: (*Default*: `false`) Sort tags by creation date. Not recommended for use with large registries; sorting performance scales poorly due to limitations of the Docker V2 API.
  * `--track-digests`: (*Default*: `false`) Track digest changes. This is not recommended as it consumes a high QPM, and most registries are flaky.
  * `--username`: Your docker registry username
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
@@ -8555,7 +8555,7 @@ hal config provider docker-registry account edit ACCOUNT [parameters]
  * `--remove-write-permission`: Remove this permission to from list of write permissions.
  * `--repositories`: (*Default*: `[]`) An optional list of repositories to cache images from. If not provided, Spinnaker will attempt to read accessible repositories from the registries _catalog endpoint
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
- * `--sort-tags-by-date`: Sort tags by creation date.
+ * `--sort-tags-by-date`: Sort tags by creation date. Not recommended for use with large registries; sorting performance scales poorly due to limitations of the Docker V2 API.
  * `--track-digests`: Track digest changes. This is not recommended as it consumes a high QPM, and most registries are flaky.
  * `--username`: Your docker registry username
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dockerRegistry/DockerRegistryCommandProperties.java
@@ -61,7 +61,9 @@ class DockerRegistryCommandProperties {
   static final String PAGINATE_SIZE_DESCRIPTION =
       "Paginate size for the docker repository _catalog endpoint.";
 
-  static final String SORT_TAGS_BY_DATE_DESCRIPTION = "Sort tags by creation date.";
+  static final String SORT_TAGS_BY_DATE_DESCRIPTION =
+      "Sort tags by creation date. Not recommended for use with large "
+          + "registries; sorting performance scales poorly due to limitations of the Docker V2 API.";
 
   static final String TRACK_DIGESTS_DESCRIPTION =
       "Track digest changes. This is not recommended as it consumes a high QPM, and most registries are flaky.";


### PR DESCRIPTION
As reported in https://github.com/spinnaker/spinnaker/issues/5538, the `sortTagsByDate` flag has prohibitive performance implications for registries with tens or hundreds of thousands of tags. However, we learned from conversations in Slack and at the Kubernetes SIG that users with smaller registries still find this flag valuable. Let's at least add a warning to the documentation, and in the future we can revisit either removing the flag or improving the performance of its implementation if the Docker V2 API ever supports fetching tags chronologically (or even batching requests for individual tags to get their creation date).

Corresponding Kleat PR: https://github.com/spinnaker/kleat/pull/28