### PR TITLE
fix(google): Update constructors to account for retry changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 clouddriverVersion=5.58.0
 fiatVersion=1.18.3
-front50Version=2.17.1
+front50Version=2.18.0
 korkVersion=7.38.1
 org.gradle.parallel=true
 spinnakerGradleVersion=8.0.4

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/canary/google/GoogleCanaryAccountValidator.java
@@ -45,10 +45,10 @@ public class GoogleCanaryAccountValidator extends CanaryAccountValidator<GoogleC
 
   private int connectTimeoutSec = 45;
   private int readTimeoutSec = 45;
-  private long maxWaitInterval = 60000;
-  private long retryIntervalBase = 2;
-  private long jitterMultiplier = 1000;
-  private long maxRetries = 10;
+  private int maxWaitInterval = 60000;
+  private int retryIntervalBase = 2;
+  private int jitterMultiplier = 1000;
+  private int maxRetries = 10;
 
   GoogleCanaryAccountValidator(SecretSessionManager secretSessionManager) {
     this.secretSessionManager = secretSessionManager;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/GCSValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/GCSValidator.java
@@ -39,10 +39,10 @@ public class GCSValidator extends Validator<GcsPersistentStore> {
 
   private int connectTimeoutSec = 45;
   private int readTimeoutSec = 45;
-  private long maxWaitInterval = 60000;
-  private long retryIntervalbase = 2;
-  private long jitterMultiplier = 1000;
-  private long maxRetries = 10;
+  private int maxWaitInterval = 60000;
+  private int retryIntervalbase = 2;
+  private int jitterMultiplier = 1000;
+  private int maxRetries = 10;
 
   @Override
   public void validate(ConfigProblemSetBuilder ps, GcsPersistentStore n) {


### PR DESCRIPTION
The changes to the retry logic updated some fields from Long to int (because we won't be waiting 24 days between retries); this commit just updates the places we called them in Halyard to pass an int.