### PR TITLE
fix(cli): replace artifacts commands

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6354,6 +6354,8 @@ hal config features edit [parameters]
 ```
 
 #### Parameters
+ * `--artifacts`: Enable artifact support. Read more at [https://spinnaker.io/reference/artifacts/](https://spinnaker.io/reference/artifacts/)
+ * `--artifacts-rewrite`: Enable new artifact support. Read more at [https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/](https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/)
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here [https://github.com/Netflix/chaosmonkey/wiki](https://github.com/Netflix/chaosmonkey/wiki).
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
  * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -50,6 +50,20 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
   private Boolean pipelineTemplates = null;
 
   @Parameter(
+      names = "--artifacts",
+      description =
+          "Enable artifact support. Read more at https://spinnaker.io/reference/artifacts/",
+      arity = 1)
+  private Boolean artifacts = null;
+
+  @Parameter(
+      names = "--artifacts-rewrite",
+      description =
+          "Enable new artifact support. Read more at https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/",
+      arity = 1)
+  private Boolean artifactsRewrite = null;
+
+  @Parameter(
       names = "--mine-canary",
       description =
           "Enable canary support. For this to work, you'll need a canary judge configured. "
@@ -78,6 +92,9 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
     features.setChaos(chaos != null ? chaos : features.isChaos());
     features.setPipelineTemplates(
         pipelineTemplates != null ? pipelineTemplates : features.getPipelineTemplates());
+    features.setArtifacts(artifacts != null ? artifacts : features.getArtifacts());
+    features.setArtifactsRewrite(
+        artifactsRewrite != null ? artifactsRewrite : features.getArtifactsRewrite());
     features.setMineCanary(mineCanary != null ? mineCanary : features.getMineCanary());
     features.setManagedPipelineTemplatesV2UI(
         managedPipelineTemplatesV2UI != null

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -118,6 +118,13 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
         Boolean.toString(
             features.getPipelineTemplates() != null ? features.getPipelineTemplates() : false));
     bindings.put(
+        "features.artifacts",
+        Boolean.toString(features.getArtifacts() != null ? features.getArtifacts() : false));
+    bindings.put(
+        "features.artifactsRewrite",
+        Boolean.toString(
+            features.getArtifactsRewrite() != null ? features.getArtifactsRewrite() : false));
+    bindings.put(
         "features.mineCanary",
         Boolean.toString(features.getMineCanary() != null ? features.getMineCanary() : false));
     bindings.put(


### PR DESCRIPTION
Partially reverts: https://github.com/spinnaker/halyard/pull/1620

Given the confusion on Slack and GitHub, let's replace the `artifacts` and `artifacts-rewrite` commands until no supported Spinnaker release consumes these flags.  Users on 1.20 will still get the `tooHighMessage` letting them know that these parameters are no longer necessary.