### PR TITLE
fix(daemon): Fix startup failure by reverting incorrect ps usage

### DIFF
--- a/startup/debian/hal
+++ b/startup/debian/hal
@@ -53,7 +53,7 @@ if [ -z "$HALYARD_DAEMON_PID" ]; then
     start_daemon
 else
     set +e
-    ps -e $HALYARD_DAEMON_PID &> /dev/null
+    ps $HALYARD_DAEMON_PID &> /dev/null
     exit_code=$?
     set -e
 


### PR DESCRIPTION
Fixes spinnaker/spinnaker#5705

I'm not sure what I was thinking with this original PR; adding the -e flag will return all processes regardless of PID, and is not necessary when passing a PID.

This is causing halyard to fail to startup because we think that the daemon is always running.

This reverts commit 4a686e906fbfce8ef565c3c1aeadffa74ad6535e.