### PR TITLE
fix(cli): replace gremlin commands for 1.18 and 1.19 compatibility

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -6358,6 +6358,7 @@ hal config features edit [parameters]
  * `--artifacts-rewrite`: Enable new artifact support. Read more at [https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/](https://www.spinnaker.io/reference/artifacts-with-artifactsrewrite/)
  * `--chaos`: Enable Chaos Monkey support. For this to work, you'll need a running Chaos Monkey deployment. Currently, Halyard doesn't configure Chaos Monkey for you; read more instructions here [https://github.com/Netflix/chaosmonkey/wiki](https://github.com/Netflix/chaosmonkey/wiki).
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--gremlin`: Enable Gremlin fault-injection support.
  * `--managed-pipeline-templates-v2-ui`: Enable managed pipeline templates v2 UI support.
  * `--mine-canary`: Enable canary support. For this to work, you'll need a canary judge configured. Currently, Halyard does not configure canary judge for you.
  * `--no-validate`: (*Default*: `false`) Skip validation.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/EditFeaturesCommand.java
@@ -77,6 +77,12 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
       arity = 1)
   private Boolean managedPipelineTemplatesV2UI = null;
 
+  @Parameter(
+      names = "--gremlin",
+      description = "Enable Gremlin fault-injection support.",
+      arity = 1)
+  private Boolean gremlin = null;
+
   @Override
   protected void executeThis() {
     String currentDeployment = getCurrentDeployment();
@@ -100,6 +106,7 @@ public class EditFeaturesCommand extends AbstractConfigCommand {
         managedPipelineTemplatesV2UI != null
             ? managedPipelineTemplatesV2UI
             : features.getManagedPipelineTemplatesV2UI());
+    features.setGremlin(gremlin != null ? gremlin : features.getGremlin());
 
     if (originalHash == features.hashCode()) {
       AnsiUi.failure("No changes supplied.");

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -133,6 +133,9 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
             features.getManagedPipelineTemplatesV2UI() != null
                 ? features.getManagedPipelineTemplatesV2UI()
                 : false));
+    bindings.put(
+        "features.gremlin",
+        Boolean.toString(features.getGremlin() != null ? features.getGremlin() : false));
 
     // Configure Kubernetes
     KubernetesProvider kubernetesProvider = deploymentConfiguration.getProviders().getKubernetes();


### PR DESCRIPTION
Partially reverts https://github.com/spinnaker/halyard/pull/1619

We need to support Gremlin in Halyard until we release Spinnaker 1.22, because 1.19 Orca still reads this flag.