### PR TITLE
feat(boms): Change default dockerRegistry to GAR

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ArtifactSourcesConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/ArtifactSourcesConfig.java
@@ -30,7 +30,7 @@ import org.springframework.context.annotation.Configuration;
 public class ArtifactSourcesConfig {
   String gitPrefix = "https://github.com/spinnaker";
   String googleImageProject = "marketplace-spinnaker-release";
-  String dockerRegistry = "gcr.io/spinnaker-marketplace";
+  String dockerRegistry = "us-docker.pkg.dev/spinnaker-community/releases";
   String debianRepository = "https://dl.bintray.com/spinnaker-releases/debians";
 
   public ArtifactSourcesConfig mergeWithBomSources(

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/WriteableProfileRegistryProperties.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/WriteableProfileRegistryProperties.java
@@ -24,5 +24,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 @ConfigurationProperties("spinnaker.config.input.gcs")
 public class WriteableProfileRegistryProperties {
   private String jsonPath = "";
-  private String project = "spinnaker-marketplace";
+  private String project = "spinnaker-community";
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2RedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2RedisService.java
@@ -43,7 +43,7 @@ public class KubernetesV2RedisService extends RedisService implements Kubernetes
   }
 
   public String getArtifactId(DeploymentConfiguration deploymentConfiguration) {
-    return "gcr.io/kubernetes-spinnaker/redis-cluster:v2";
+    return "us-docker.pkg.dev/spinnaker-community/releases/redis-cluster:v2";
   }
 
   @Override

--- a/halyard-web/config/halyard.yml
+++ b/halyard-web/config/halyard.yml
@@ -11,7 +11,7 @@ halconfig:
 spinnaker:
   artifacts:
     debian: https://dl.bintray.com/spinnaker-releases/debians
-    docker: gcr.io/spinnaker-marketplace
+    docker: us-docker.pkg.dev/spinnaker-community/releases
   config:
     input:
       gcs:

--- a/install/Installer.sh
+++ b/install/Installer.sh
@@ -7,7 +7,7 @@ set -o pipefail
 
 REPOSITORY_URL="https://dl.bintray.com/spinnaker-releases/debians"
 SPINNAKER_REPOSITORY_URL="https://dl.bintray.com/spinnaker-releases/debians"
-SPINNAKER_DOCKER_REGISTRY="gcr.io/spinnaker-marketplace"
+SPINNAKER_DOCKER_REGISTRY="us-docker.pkg.dev/spinnaker-community/releases"
 SPINNAKER_GCE_PROJECT="marketplace-spinnaker-release"
 CONFIG_BUCKET="halconfig" 
 

--- a/release/promote.sh
+++ b/release/promote.sh
@@ -25,9 +25,18 @@ function pull_tag_push() {
 }
 
 if [ "$PLATFORM" = "docker" ]; then
+  # Still publishing to old spinnaker-marketplace project until all known Halyard installation instructions are updated.
   PUBLISH_HALYARD_DOCKER_IMAGE_BASE=${PUBLISH_HALYARD_DOCKER_IMAGE_BASE:-gcr.io/spinnaker-marketplace/halyard}
   SOURCE_IMAGE=$PUBLISH_HALYARD_DOCKER_IMAGE_BASE:$SOURCE_VERSION
   TARGET_IMAGE=$PUBLISH_HALYARD_DOCKER_IMAGE_BASE:$TARGET_VERSION
+
+  pull_tag_push $SOURCE_IMAGE $TARGET_IMAGE
+  pull_tag_push ${SOURCE_IMAGE}-ubuntu ${TARGET_IMAGE}-ubuntu
+
+  PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE=${PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE:-us-docker.pkg.dev/spinnaker-community/nightly/halyard}
+  PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE=${PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE:-us-docker.pkg.dev/spinnaker-community/releases/halyard}
+  SOURCE_IMAGE=PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_SRC_BASE:$SOURCE_VERSION
+  TARGET_IMAGE=PUBLISH_HALYARD_ARTIFACT_DOCKER_IMAGE_TARGET_BASE:$TARGET_VERSION
 
   pull_tag_push $SOURCE_IMAGE $TARGET_IMAGE
   pull_tag_push ${SOURCE_IMAGE}-ubuntu ${TARGET_IMAGE}-ubuntu


### PR DESCRIPTION
This also modifies the promotion script to move the built container image from `nightly` to `releases` repo.