### PR TITLE
fix(local-git): remove the Java version check from Halyard local-git deployment

### DIFF
--- a/halyard-deploy/src/main/resources/git/install.sh
+++ b/halyard-deploy/src/main/resources/git/install.sh
@@ -2,19 +2,6 @@
 
 ## auto-generated git install file written by halyard
 
-echo_err() {
-  echo "$@" 1>&2
-}
-
-set +e
-java_version=$(java -version 2>&1 head -1)
-set -e
-
-if [[ "$java_version" != *1.8* ]]; then
-  echo_err "You need the java jdk at version 1.8 to build & run Spinnaker. Please install it."
-  exit 1;
-fi
-
 STARTUP_SCRIPTS=()
 
 {%install-commands%}


### PR DESCRIPTION
I suppose I could put in something to check for Java 11, but only looking at the version of java in your $PATH seems like a pretty naïve way to go about doing this check, since there are myriad ways you could have a JDK configured for Gradle.