### PR TITLE
refactor(deps): remove fabric8-utils dependency

### DIFF
--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -21,7 +21,6 @@ dependencies {
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.squareup.okhttp:okhttp'
   implementation 'io.fabric8:kubernetes-client'
-  implementation 'io.fabric8:fabric8-utils:2.2.216'
   implementation 'redis.clients:jedis'
   implementation 'org.codehaus.groovy:groovy'
 

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/BakeService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/BakeService.java
@@ -21,7 +21,6 @@ import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
-import io.fabric8.utils.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +52,7 @@ public interface BakeService<T> extends HasServiceSettings<T> {
       }
     }
 
-    return Strings.join(allCommands, "\n");
+    return String.join("\n", allCommands);
   }
 
   class StartupPriority {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianService.java
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.BakeService;
-import io.fabric8.utils.Strings;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -68,6 +67,6 @@ public interface BakeDebianService<T> extends BakeService<T> {
     pinResource.setBindings(bindings);
     installResource.setBindings(bindings);
 
-    return Strings.join("\n", pinResource, installResource, ensureStopped);
+    return String.format("%s\n%s\n%s", pinResource, installResource, ensureStopped);
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/bake/debian/BakeDebianServiceProvider.java
@@ -30,7 +30,6 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.bake.BakeServiceProvider;
-import io.fabric8.utils.Strings;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -105,8 +104,8 @@ public class BakeDebianServiceProvider extends BakeServiceProvider {
             .collect(Collectors.toList());
 
     TemplatedResource resource = new StringReplaceJarResource("/debian/init.sh");
-    bindings.put("services", Strings.join(upstartNames, " "));
-    bindings.put("systemd-service-configs", Strings.join(systemdServiceConfigs, " "));
+    bindings.put("services", String.join(" ", upstartNames));
+    bindings.put("systemd-service-configs", String.join(" ", systemdServiceConfigs));
     String upstartInit = resource.setBindings(bindings).toString();
     BillOfMaterials.ArtifactSources artifactSources =
         artifactService.getArtifactSources(deploymentDetails.getDeploymentName());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v1/KubernetesV1DistributedService.java
@@ -77,7 +77,6 @@ import io.fabric8.kubernetes.api.model.VolumeBuilder;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSet;
 import io.fabric8.kubernetes.api.model.apps.ReplicaSetBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.utils.Strings;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -121,7 +120,7 @@ public interface KubernetesV1DistributedService<T>
   }
 
   default String buildAddress(String namespace) {
-    return Strings.join(".", getServiceName(), namespace);
+    return String.join(".", getServiceName(), namespace);
   }
 
   default List<LocalObjectReference> getImagePullSecrets(ServiceSettings settings) {
@@ -855,10 +854,10 @@ public interface KubernetesV1DistributedService<T>
               + namespace);
     }
 
-    return Strings.join(
+    return String.join(
+        " ",
         KubernetesV1ProviderUtils.kubectlPortForwardCommand(
-            details, namespace, latestInstances.get(0).getId(), settings.getPort(), localPort),
-        " ");
+            details, namespace, latestInstances.get(0).getId(), settings.getPort(), localPort));
   }
 
   default String connectCommand(

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -45,7 +45,6 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.Sid
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.KubernetesSharedServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.distributed.kubernetes.v2.KubernetesV2Utils.SecretMountPair;
-import io.fabric8.utils.Strings;
 import java.io.File;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -761,7 +760,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
   }
 
   default Optional<String> buildAddress(String namespace) {
-    return Optional.of(Strings.join(".", getServiceName(), namespace));
+    return Optional.of(String.join(".", getServiceName(), namespace));
   }
 
   default ServiceSettings buildServiceSettings(DeploymentConfiguration deploymentConfiguration) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/LocalService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/LocalService.java
@@ -22,7 +22,6 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
-import io.fabric8.utils.Strings;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -63,6 +62,6 @@ public interface LocalService<T> extends HasServiceSettings<T>, LogCollector<T, 
       }
     }
 
-    return Strings.join(allCommands, "\n");
+    return String.join("\n", allCommands);
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianDeckService.java
@@ -26,7 +26,6 @@ import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.HasServiceSetti
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.LogCollector;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.ServiceSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalLogCollectorFactory;
-import io.fabric8.utils.Strings;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.experimental.Delegate;
@@ -73,14 +72,14 @@ public class LocalDebianDeckService extends DeckService
                 .isEnabled()
             ? "a2enmod ssl"
             : "";
-    return Strings.join("\n", install, ssl);
+    return String.join("\n", install, ssl);
   }
 
   @Override
   public String stageProfilesCommand(
       DeploymentDetails details, GenerateService.ResolvedConfiguration resolvedConfiguration) {
     String stage = LocalDebianService.super.stageProfilesCommand(details, resolvedConfiguration);
-    return Strings.join("\n", stage, "a2ensite spinnaker", "a2dissite 000-default");
+    return String.join("\n", stage, "a2ensite spinnaker", "a2dissite 000-default");
   }
 
   public String getArtifactId(String deploymentName) {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianService.java
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.halyard.deploy.deployment.v1.DeploymentDetails;
 import com.netflix.spinnaker.halyard.deploy.services.v1.ArtifactService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalService;
-import io.fabric8.utils.Strings;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
@@ -68,7 +67,7 @@ public interface LocalDebianService<T> extends LocalService<T> {
     pinResource.setBindings(bindings);
     installResource.setBindings(bindings);
 
-    return Strings.join("\n", pinResource, installResource, ensureStopped);
+    return String.format("%s\n%s\n%s", pinResource, installResource, ensureStopped);
   }
 
   default String uninstallArtifactCommand() {

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianServiceProvider.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianServiceProvider.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerRuntimeSettings;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.SpinnakerService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalServiceProvider;
-import io.fabric8.utils.Strings;
 import java.util.*;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -87,8 +86,8 @@ public class LocalDebianServiceProvider extends LocalServiceProvider {
             .collect(Collectors.toList());
 
     TemplatedResource resource = new StringReplaceJarResource("/debian/init.sh");
-    bindings.put("services", Strings.join(upstartNames, " "));
-    bindings.put("systemd-service-configs", Strings.join(systemdServiceConfigs, " "));
+    bindings.put("services", String.join(" ", upstartNames));
+    bindings.put("systemd-service-configs", String.join(" ", systemdServiceConfigs));
     String upstartInit = resource.setBindings(bindings).toString();
     BillOfMaterials.ArtifactSources artifactSources =
         artifactService.getArtifactSources(deploymentDetails.getDeploymentName());

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/git/LocalGitService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/git/LocalGitService.java
@@ -28,7 +28,6 @@ import com.netflix.spinnaker.halyard.deploy.services.v1.GenerateService;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.SpinnakerArtifact;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.profile.Profile;
 import com.netflix.spinnaker.halyard.deploy.spinnaker.v1.service.local.LocalService;
-import io.fabric8.utils.Strings;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -137,6 +136,6 @@ public interface LocalGitService<T> extends LocalService<T> {
       }
     }
 
-    return Strings.join(allCommands, "\n");
+    return String.join("\n", allCommands);
   }
 }


### PR DESCRIPTION
Since the removal of the Kubernetes V1 provider, Clouddriver no longer has a dependency on the `fabric8` library. Given problematic `fabric8` upgrades in the past, let's try to remove Spinnaker's dependency on this library. Halyard currently uses `fabric8`'s `Strings.join` method in several places; let's replace these with Java's built-in `String.join` when possible (i.e, when the arguments to be joined extend `CharSequence`), and `String.format` otherwise.

The upcoming deprecation of distributed deployments using the V1 provider will remove Halyard's dependency on `fabric8:kubernetes-client`.