### PR TITLE
refactor(config): remove unused feature properties

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -22,7 +22,13 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@JsonIgnoreProperties({"jobs", "appengineContainerImageUrlDeployments"})
+@JsonIgnoreProperties({
+  "jobs",
+  "appengineContainerImageUrlDeployments",
+  "auth",
+  "entityTags",
+  "fiat"
+})
 public class Features extends Node {
   @Override
   public String getNodeName() {
@@ -34,10 +40,7 @@ public class Features extends Node {
     return NodeIteratorFactory.makeEmptyIterator();
   }
 
-  private boolean auth;
-  private boolean fiat;
   private boolean chaos;
-  private boolean entityTags;
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.2.0",

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/FeaturesServiceSpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/services/v1/FeaturesServiceSpec.groovy
@@ -46,7 +46,6 @@ deploymentConfigurations:
   providers: null
   features:
     chaos: true
-    fiat: false
 """
     def featuresService = makeFeaturesService(config)
 
@@ -56,7 +55,6 @@ deploymentConfigurations:
     then:
     result != null
     result.chaos
-    !result.fiat
   }
 
   def "load a non-existent feature node"() {


### PR DESCRIPTION
Removes the following unused properties from `Features`:

- `auth`: We write `features.auth` to Deck's profile by checking `deploymentConfiguration.getSecurity().getAuthn().isEnabled()`, not this field, which isn't written to by calling a CLI command anyway.
- `fiat`: We write `features.fiat` to Deck's profile by checking `deploymentConfiguration.getSecurity().getAuthz().isEnabled()`, not this field, which is also not written to by calling a CLI command.
- `entityTags`: Halyard does not support enabling of entity tags; not sure how this field ended up here but it is not used.
 