### PR TITLE
refactor(kubernetes): Allow cacheThreads 0. This will disable cache for an account.

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/kubernetes/KubernetesAccountValidator.java
@@ -172,8 +172,8 @@ public class KubernetesAccountValidator extends Validator<KubernetesAccount> {
   }
 
   private void validateCacheThreads(ConfigProblemSetBuilder psBuilder, KubernetesAccount account) {
-    if (account.getCacheThreads() < 1) {
-      psBuilder.addProblem(ERROR, "\"cacheThreads\" should be greater or equal to 1.");
+    if (account.getCacheThreads() < 0) {
+      psBuilder.addProblem(ERROR, "\"cacheThreads\" should be greater or equal to 0.");
     }
   }
 


### PR DESCRIPTION
I am using 0 cacheThreads on one of my accounts to disable caching as it uses a lot of resources and fills redis up.
On previous halyard versions it did not complain, but now, setting it to 0 (zero) complains about it.
Deploying with `--no-validation` works fine, but it is not elegant.

If there is no other way to disable caching for some account, could you allow to use 0 (zero) ? It can still default to 1, but the use of 0 helped us a lot.