### PR TITLE
refactor(deck): remove unneeded env vars from DeckDockerProfileFactory

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckDockerProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckDockerProfileFactory.java
@@ -87,12 +87,5 @@ public class DeckDockerProfileFactory extends DeckProfileFactory {
             "PASSPHRASE", secretSessionManager.decrypt(apacheSsl.getSslCertificatePassphrase()));
       }
     }
-
-    env.put(
-        "AUTH_ENABLED",
-        Boolean.toString(deploymentConfiguration.getSecurity().getAuthn().isEnabled()));
-    env.put(
-        "FIAT_ENABLED",
-        Boolean.toString(deploymentConfiguration.getSecurity().getAuthz().isEnabled()));
   }
 }


### PR DESCRIPTION
When building Deck as a container, several environment variables are required when using SSL. However, the AUTH_ENABLED and FIAT_ENABLED environment variables are only read from Deck's settings.js when doing local development. When building Deck as a container, auth and fiat configs are read from the features configuration block, not environment variables, so we can safely remove this code.