### PR TITLE
refactor(deck): remove unneeded appengine.enabled binding from DeckPr…

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -157,8 +157,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     // Configure Appengine
     AppengineProvider appengineProvider = deploymentConfiguration.getProviders().getAppengine();
     bindings.put("appengine.default.account", appengineProvider.getPrimaryAccount());
-    bindings.put(
-        "appengine.enabled", Boolean.toString(appengineProvider.getPrimaryAccount() != null));
 
     // Configure DC/OS
     final DCOSProvider dcosProvider = deploymentConfiguration.getProviders().getDcos();


### PR DESCRIPTION
…ofileFactory

This should be the last cleanup related to Deck configuration. The field `appengine.enabled` is not read by Deck and does not need to be configured by Halyard.