### PR TITLE
refactor(deck): remove unneeded notifications.enabled binding

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -221,8 +221,6 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     }
 
     // Configure notifications
-    bindings.put("notifications.enabled", notifications.isEnabled() + "");
-
     SlackNotification slackNotification = notifications.getSlack();
     bindings.put("notifications.slack.enabled", slackNotification.isEnabled() + "");
     bindings.put("notifications.slack.botName", slackNotification.getBotName());


### PR DESCRIPTION
I lied, _this_ is the final cleanup of unread bindings made in Deck's profile factory.