### PR TITLE
style(core): Add missing space to log

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/tasks/v1/DaemonTask.java
@@ -190,7 +190,7 @@ public class DaemonTask<C, T> {
 
     TaskRepository.getTask(childTask.getUuid());
 
-    log.info(this + "Collected child task " + childTask + " with state " + childTask.getState());
+    log.info(this + " Collected child task " + childTask + " with state " + childTask.getState());
     if (childTask.getResponse() == null) {
       throw new RuntimeException("Child response may not be null.");
     }


### PR DESCRIPTION
This will make the logs more readable as we move from this:
`RUNNINGCollected child task [Deploy spin-redis]`

to this:
`RUNNING Collected child task [Deploy spin-redis]`