### PR TITLE
fix(mergify): remove duplicate line from mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -66,7 +66,6 @@ pull_request_rules:
       - base=master
       - status-failure=build
       - "label~=autobump-*"
-      - base=master
     actions:
       request_reviews:
         teams: ["oss-approvers"]


### PR DESCRIPTION
Was trying to figure out why mergify cancelling a check on @mattsanta's [first Halyard PR](https://github.com/spinnaker/halyard/pull/1706) (:tada:) caused the PR build to fail and noticed this duplicate line in the mergify config, which is likely not the actual problem here, but thought I'd remove it if we can while I was here.