### PR TITLE
fix(profile): write correct changelog file name to Deck settings.js

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -101,7 +101,7 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     if (validatedVersion.isPresent()) {
       String changelog = validatedVersion.get().getChangelog();
       bindings.put("changelog.gist.id", changelog.substring(changelog.lastIndexOf("/") + 1));
-      bindings.put("changelog.gist.name", "changelog.md");
+      bindings.put("changelog.gist.name", String.format("%s.md", version));
     } else {
       bindings.put("changelog.gist.id", "");
       bindings.put("changelog.gist.name", "");


### PR DESCRIPTION
Since [this change](https://github.com/spinnaker/buildtool/pull/48) to spinnaker/buildtool, the OSS release changelog gists have been published with one top-level gist per minor release and individual files for each patch release. However, Halyard and Deck continued to expect one changelog per patch release named "changelog.md."

Although we have[ replaced the What's New modal changelog experience with a link to the changelog on spinnaker.io for users moving forward,](https://github.com/spinnaker/deck/pull/8341) let's write the correct changelog to settings.js for Halyard users deploying to a pre-1.21 version of Spinnaker.