### PR TITLE
fix(local-bom): Fix issues blocking use of locally hosted configuration files

### DIFF
--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/LocalDiskProfileReader.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/LocalDiskProfileReader.java
@@ -89,13 +89,14 @@ public class LocalDiskProfileReader implements ProfileReader {
   public InputStream readArchiveProfile(String artifactName, String version, String profileName)
       throws IOException {
     version = version.substring("local:".length());
+    String fileName = profileName + ".tar.gz";
 
     try {
-      Path profilePath = Paths.get(profilePath(artifactName, version, profileName));
+      Path profilePath = Paths.get(profilePath(artifactName, version, fileName));
       return readArchiveProfileFrom(profilePath);
     } catch (IOException e) {
       log.debug("Failed to get archive profile, retrying default location", e);
-      Path profilePath = Paths.get(defaultProfilePath(artifactName, profileName));
+      Path profilePath = Paths.get(defaultProfilePath(artifactName, fileName));
       return readArchiveProfileFrom(profilePath);
     }
   }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
@@ -71,11 +71,14 @@ public class Versions {
     }
 
     static SemVer fromString(String version) {
+      String versionExpression = version;
       if (isBranch(version)) {
         return null;
+      } else if (isLocal(version)) {
+        versionExpression = fromLocal(version);
       }
 
-      String[] parts = truncateToHyphen(version).split(Pattern.quote("."));
+      String[] parts = truncateToHyphen(versionExpression).split(Pattern.quote("."));
       if (parts.length != 3) {
         throw new IllegalArgumentException("Versions must satisfy the X.Y.Z naming convention");
       }

--- a/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
+++ b/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/registry/v1/Versions.java
@@ -142,27 +142,38 @@ public class Versions {
   }
 
   public static String toMajorMinor(String fullVersion) {
-    int lastDot = fullVersion.lastIndexOf(".");
+    String version = removePrefixes(fullVersion);
+    int lastDot = version.lastIndexOf(".");
     if (lastDot < 0) {
       return null;
     }
 
-    return fullVersion.substring(0, lastDot);
+    return version.substring(0, lastDot);
   }
 
   public static String toMajorMinorPatch(String fullVersion) {
-    int lastDash = fullVersion.indexOf("-");
+    String version = removePrefixes(fullVersion);
+    int lastDash = version.indexOf("-");
     if (lastDash < 0) {
-      return fullVersion;
+      return version;
     }
 
-    return fullVersion.substring(0, lastDash);
+    return version.substring(0, lastDash);
+  }
+
+  private static String removePrefixes(String fullVersion) {
+    if (isBranch(fullVersion)) {
+      return fromBranch(fullVersion);
+    } else if (isLocal(fullVersion)) {
+      return fromLocal(fullVersion);
+    }
+    return fullVersion;
   }
 
   public static Comparator<String> orderBySemVer() {
     Comparator<SemVer> comparator = Comparator.nullsLast(SemVer.comparator());
     return Comparator.comparing(SemVer::fromString, comparator)
-        .thenComparing(Comparator.naturalOrder());
+        .thenComparing(Versions::toMajorMinorPatch, Comparator.naturalOrder());
   }
 
   public static boolean lessThan(String v1, String v2) {

--- a/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/registry/v1/VersionsSpec.groovy
+++ b/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/registry/v1/VersionsSpec.groovy
@@ -24,12 +24,25 @@ class VersionsSpec extends Specification {
         Versions.lessThan(a, b) == result
 
         where:
-        a        | b                        | result
-        "1.0.0"  | "1.0.0"                  | false
-        "1.0.0"  | "1.0.1"                  | true
-        "1.0.1"  | "1.0.0"                  | false
-        "2.0.0"  | "10.0.0"                 | true
-        "1.0.0"  | "branch:upstream/master" | true
+        a              | b                        | result
+        "1.0.0"        | "1.0.0"                  | false
+        "1.0.0"        | "1.0.1"                  | true
+        "1.0.1"        | "1.0.0"                  | false
+        "2.0.0"        | "10.0.0"                 | true
+        "1.0.0"        | "branch:upstream/master" | true
+        "local:1.0.0"  | "1.0.0"                  | false
+        "1.0.0"        | "local:1.0.0"            | false
+        "local:1.0.0"  | "local:1.0.0"            | false
+        "local:1.0.0"  | "1.0.1"                  | true
+        "1.0.0"        | "local:1.0.1"            | true
+        "local:1.0.0"  | "local:1.0.1"            | true
+        "local:1.0.1"  | "1.0.0"                  | false
+        "1.0.1"        | "local:1.0.0"            | false
+        "local:1.0.1"  | "local:1.0.0"            | false
+        "local:2.0.0"  | "10.0.0"                 | true
+        "2.0.0"        | "local:10.0.0"           | true
+        "local:2.0.0"  | "10.0.0"                 | true
+        "local:1.0.0"  | "branch:upstream/master" | true
     }
 
     def "lessThan looks up to the first hyphen"() {
@@ -37,10 +50,21 @@ class VersionsSpec extends Specification {
         Versions.lessThan(a, b) == result
 
         where:
-        a              | b                        | result
-        "1.0.0-99999"  | "1.0.0-00000"            | false
-        "1.0.0-12345"  | "1.0.1-99999"            | true
-        "1.0.0-12345"  | "branch:upstream/master" | true
+        a                    | b                        | result
+        "1.0.0-99999"        | "1.0.0-00000"            | false
+        "1.0.0-00000"        | "1.0.0-99999"            | false
+        "1.0.0-12345"        | "1.0.1-99999"            | true
+        "1.0.0-12345"        | "branch:upstream/master" | true
+        "local:1.0.0-99999"  | "1.0.0-00000"            | false
+        "1.0.0-99999"        | "local:1.0.0-00000"      | false
+        "local:1.0.0-99999"  | "local:1.0.0-00000"      | false
+        "local:1.0.0-00000"  | "1.0.0-99999"            | false
+        "1.0.0-00000"        | "local:1.0.0-99999"      | false
+        "local:1.0.0-00000"  | "local:1.0.0-99999"      | false
+        "local:1.0.0-12345"  | "1.0.1-99999"            | true
+        "1.0.0-12345"        | "local:1.0.1-99999"      | true
+        "local:1.0.0-12345"  | "local:1.0.1-99999"      | true
+        "local:1.0.0-12345"  | "branch:upstream/master" | true
     }
 
     def "lessThan throws an exception for invalid versions"() {
@@ -51,34 +75,34 @@ class VersionsSpec extends Specification {
         thrown Exception
 
         where:
-        badVersion << ["1.0", "1.0.0.0", "1.a.b", "zzz"]
+        badVersion << ["1.0", "1.0.0.0", "1.a.b", "zzz", "local:foo", "local:1.0.0.0"]
     }
 
     def "orderBySemVer sorts versions"() {
         when:
-        def versions = ["1.1.0", "2.1.1", "1.1.1"]
+        def versions = ["1.1.0", "2.1.1", "local:1.1.1"]
         Collections.sort(versions, Versions.orderBySemVer());
 
         then:
-        versions == ["1.1.0", "1.1.1", "2.1.1"]
+        versions == ["1.1.0", "local:1.1.1", "2.1.1"]
     }
 
     def "orderBySemVer sorts each part as an integer"() {
         when:
-        def versions = ["2.2.2", "10.0.0", "0.10.0", "0.0.10"]
+        def versions = ["2.2.2", "local:10.0.0", "local:0.10.0", "0.0.10"]
         Collections.sort(versions, Versions.orderBySemVer())
 
         then:
-        versions == ["0.0.10", "0.10.0", "2.2.2", "10.0.0"]
+        versions == ["0.0.10", "local:0.10.0", "2.2.2", "local:10.0.0"]
     }
 
     def "orderBySemVer sorts branches to the end"() {
         when:
-        def versions = ["1.0.0", "branch:upstream/master", "1.1.0"]
+        def versions = ["local:1.0.0", "branch:upstream/master", "1.1.0"]
         Collections.sort(versions, Versions.orderBySemVer())
 
         then:
-        versions == ["1.0.0", "1.1.0", "branch:upstream/master"]
+        versions == ["local:1.0.0", "1.1.0", "branch:upstream/master"]
     }
 
     def "orderBySemVer breaks ties with string sort"() {
@@ -99,6 +123,6 @@ class VersionsSpec extends Specification {
         thrown Exception
 
         where:
-        badVersion << ["1.0", "1.0.0.0", "1.a.b", "zzz"]
+        badVersion << ["1.0", "1.0.0.0", "1.a.b", "zzz", "local:foo", "local:1.0.0.0"]
     }
 }

--- a/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/LocalDiskProfileReaderSpec.groovy
+++ b/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/resource/v1/LocalDiskProfileReaderSpec.groovy
@@ -86,7 +86,7 @@ class LocalDiskProfileReaderSpec extends Specification {
             localDiskProfileReader.localBomPath = new File(".").getCanonicalPath() + "/src/test/resources/profiles"
             String artifactName = "test-artifact"
             String version = "local:test-version"
-            String profileName = "test-artifact.tar.gz"
+            String profileName = "test-artifact"
         when:
             def archiveProfileStream = localDiskProfileReader.readArchiveProfile(artifactName, version, profileName)
             TarArchiveInputStream tis
@@ -105,7 +105,7 @@ class LocalDiskProfileReaderSpec extends Specification {
             } catch (IOException e) {
                     throw new HalException(Problem.Severity.FATAL, "Failed to read profile entry", e)
             }
-            def fileInputStream =  localDiskProfileReader.readProfile(artifactName, version, profileName)
+            def fileInputStream =  localDiskProfileReader.readProfile(artifactName, version, profileName + ".tar.gz")
             def fileContents = IOUtils.toString(fileInputStream)
         then:
             tarContents == fileContents

--- a/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringProfileFactorySpec.groovy
+++ b/halyard-deploy/src/test/groovy/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/SpringProfileFactorySpec.groovy
@@ -42,5 +42,10 @@ class SpringProfileFactorySpec extends Specification {
         "release-1.19.x-20200503040016"       | true
         "release-1.19.x-latest-validated"     | true
         "release-1.7.x-latest-validated"      | false
+        "local:1.7.5"                         | false
+        "local:1.19.3"                        | false
+        "local:1.19.11"                       | true
+        "branch:master-20191121162350"        | false
+        "branch:master-20200503040016"        | false
     }
 }


### PR DESCRIPTION
Addresses bug with local BOM deployments where the 'local:' is not pruned from the version string before converting to a SemVer object. See https://github.com/spinnaker/spinnaker/issues/5703 for details.

Also addresses bug with orderBySemVer where versions which were supposed to be treated as equivalent were not actually being treated as such if they weren't the exact same string. For example, according to the spec, 1.0.0-00000 is supposed to be equal to 1.0.0-99999 since lessThan is not supposed to care about the part after the hyphen. However, 1.0.0-00000 was treated as lessThan 1.0.0-99999 because of the secondary naturalOrder sorting.

Also addresses bug with LocalDiskProfileReader where it does not add the ".tar.gz" file extension to profileName when readArchiveProfile like GoogleProfileReader does