### PR TITLE
fix: add edit canary datadog

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -133,6 +133,7 @@
  * [**hal config canary datadog account get**](#hal-config-canary-datadog-account-get)
  * [**hal config canary datadog account list**](#hal-config-canary-datadog-account-list)
  * [**hal config canary datadog disable**](#hal-config-canary-datadog-disable)
+ * [**hal config canary datadog edit**](#hal-config-canary-datadog-edit)
  * [**hal config canary datadog enable**](#hal-config-canary-datadog-enable)
  * [**hal config canary disable**](#hal-config-canary-disable)
  * [**hal config canary edit**](#hal-config-canary-edit)
@@ -2806,6 +2807,7 @@ hal config canary datadog [parameters] [subcommands]
 #### Subcommands
  * `account`: Manage and view Spinnaker configuration for the Datadog service integration's canary accounts.
  * `disable`: Set Spinnaker's canary analysis Datadog service integration to disabled.
+ * `edit`: Edit Spinnaker's canary analysis Datadog service integration settings.
  * `enable`: Set Spinnaker's canary analysis Datadog service integration to enabled.
 
 ---
@@ -2927,6 +2929,22 @@ hal config canary datadog disable [parameters]
 
 #### Parameters
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config canary datadog edit
+
+Edit Spinnaker's canary analysis Datadog service integration settings.
+
+#### Usage
+```
+hal config canary datadog edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--metadata-caching-interval-ms`: Number of milliseconds to wait in between caching the names of available metric types (for use in building canary configs; *Default*: `60000`).
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/datadog/CanaryDatadogCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/datadog/CanaryDatadogCommand.java
@@ -39,6 +39,7 @@ public class CanaryDatadogCommand extends AbstractConfigCommand {
       "Configure your canary analysis Datadog service integration settings for Spinnaker.";
 
   public CanaryDatadogCommand() {
+    registerSubcommand(new EditCanaryDatadogCommand());
     registerSubcommand(
         new EnableDisableCanaryServiceIntegrationCommandBuilder()
             .setName("Datadog")

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/datadog/EditCanaryDatadogCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/datadog/EditCanaryDatadogCommand.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2018 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1.config.canary.datadog;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.AbstractEditCanaryServiceIntegrationCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.canary.account.CanaryUtils;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.Canary;
+import com.netflix.spinnaker.halyard.config.model.v1.canary.datadog.DatadogCanaryServiceIntegration;
+
+@Parameters(separators = "=")
+public class EditCanaryDatadogCommand extends AbstractEditCanaryServiceIntegrationCommand {
+
+  @Override
+  protected String getServiceIntegration() {
+    return "Datadog";
+  }
+
+  @Parameter(
+      names = "--metadata-caching-interval-ms",
+      description =
+          "Number of milliseconds to wait in between caching the names of available metric types (for use in building canary configs; *Default*: `60000`).")
+  private Long metadataCachingIntervalMS;
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+    // Disable validation here, since we don't want an illegal config to prevent us from fixing it.
+    Canary canary =
+        new OperationHandler<Canary>()
+            .setFailureMesssage("Failed to get canary.")
+            .setOperation(Daemon.getCanary(currentDeployment, false))
+            .get();
+
+    int originalHash = canary.hashCode();
+
+    DatadogCanaryServiceIntegration datadogCanaryServiceIntegration =
+        (DatadogCanaryServiceIntegration)
+            CanaryUtils.getServiceIntegrationByClass(canary, DatadogCanaryServiceIntegration.class);
+
+    datadogCanaryServiceIntegration.setMetadataCachingIntervalMS(
+        isSet(metadataCachingIntervalMS)
+            ? metadataCachingIntervalMS
+            : datadogCanaryServiceIntegration.getMetadataCachingIntervalMS());
+
+    if (originalHash == canary.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+
+    new OperationHandler<Void>()
+        .setOperation(Daemon.setCanary(currentDeployment, !noValidate, canary))
+        .setFailureMesssage("Failed to edit canary analysis Datadog service integration settings.")
+        .setSuccessMessage(
+            "Successfully edited canary analysis Datadog service integration settings.")
+        .get();
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/datadog/DatadogCanaryServiceIntegration.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/datadog/DatadogCanaryServiceIntegration.java
@@ -31,4 +31,5 @@ public class DatadogCanaryServiceIntegration
   public static final String NAME = "datadog";
 
   String name = NAME;
+  private Long metadataCachingIntervalMS;
 }


### PR DESCRIPTION
- allows halyard command edit canary datadog
- allows setting metadataCachingIntervalMS in the same manner as prometheus