### PR TITLE
refactor(kubernetes): deprecate ProviderVersion

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -21,9 +21,9 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider.ProviderVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount.ProviderVersion;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -21,9 +21,9 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.DockerRegistryReference;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.kubernetes.KubernetesAccount.ProviderVersion;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -222,7 +222,7 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
   @Parameter(
       names = "--provider-version",
       description = KubernetesCommandProperties.PROVIDER_VERSION_DESCRIPTION)
-  private Provider.ProviderVersion providerVersion;
+  private ProviderVersion providerVersion;
 
   @Override
   protected Account editAccount(KubernetesAccount account) {

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import java.util.ArrayList;
@@ -25,11 +26,11 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
+@JsonIgnoreProperties({"providerVersion"})
 public abstract class Account extends Node implements Cloneable {
   String name;
   String environment;
   List<String> requiredGroupMembership = new ArrayList<>();
-  Provider.ProviderVersion providerVersion = Provider.ProviderVersion.V1;
   Permissions.Builder permissions = new Permissions.Builder();
 
   @Override

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Provider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Provider.java
@@ -72,22 +72,6 @@ public abstract class Provider<A extends Account> extends Node implements Clonea
 
   public abstract ProviderType providerType();
 
-  public enum ProviderVersion {
-    V1("v1"),
-    V2("v2");
-
-    private final String name;
-
-    ProviderVersion(String name) {
-      this.name = name;
-    }
-
-    @Override
-    public String toString() {
-      return this.name;
-    }
-  }
-
   public enum ProviderType {
     APPENGINE("appengine"),
     AWS("aws"),

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider.ProviderVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.ValidForSpinnakerVersion;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
@@ -33,7 +32,16 @@ import org.apache.commons.lang3.StringUtils;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class KubernetesAccount extends ContainerAccount implements Cloneable {
+  @ValidForSpinnakerVersion(
+      lowerBound = "",
+      tooLowMessage = "",
+      upperBound = "1.21.0",
+      tooHighMessage =
+          "The legacy (V1) Kubernetes provider is now deprecated. All accounts will "
+              + "now be wired as standard (V2) accounts, and providerVersion can be removed from "
+              + "all configured accounts.")
   ProviderVersion providerVersion = ProviderVersion.V2;
+
   String context;
   String cluster;
   String user;
@@ -178,5 +186,27 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
   @JsonProperty("oauthServiceAccount")
   public void setOauthServiceAccount(String oAuthServiceAccount) {
     this.oAuthServiceAccount = oAuthServiceAccount;
+  }
+
+  /**
+   * @deprecated All ProviderVersion-related logic will be removed from Clouddriver by Spinnaker
+   *     1.22. We will continue to support this enum in Halyard so that we can notify users with
+   *     this field configured that it is no longer read.
+   */
+  @Deprecated
+  public enum ProviderVersion {
+    V1("v1"),
+    V2("v2");
+
+    private final String name;
+
+    ProviderVersion(String name) {
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      return this.name;
+    }
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/ServiceProviderFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/deployment/v1/ServiceProviderFactory.java
@@ -86,11 +86,6 @@ public class ServiceProviderFactory {
 
     switch (providerType) {
       case KUBERNETES:
-        if (account.getProviderVersion() == Provider.ProviderVersion.V1) {
-          throw new HalException(
-              Problem.Severity.FATAL,
-              "Distributed deployment is only available for standard Kubernetes (V2) accounts.");
-        }
         return kubectlServiceProvider;
       case GOOGLE:
         return googleDistributedServiceProvider;

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/services/v1/DeployService.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.halyard.deploy.services.v1;
 
-import static com.netflix.spinnaker.halyard.config.model.v1.node.Provider.ProviderVersion.V1;
 import static com.netflix.spinnaker.halyard.core.problem.v1.Problem.Severity.FATAL;
 
 import com.netflix.spinnaker.halyard.config.config.v1.HalconfigDirectoryStructure;
@@ -25,7 +24,6 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentConfiguration;
 import com.netflix.spinnaker.halyard.config.model.v1.node.DeploymentEnvironment;
 import com.netflix.spinnaker.halyard.config.model.v1.node.NodeDiff;
-import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
 import com.netflix.spinnaker.halyard.config.services.v1.AccountService;
 import com.netflix.spinnaker.halyard.config.services.v1.DeploymentService;
 import com.netflix.spinnaker.halyard.core.RemoteAction;
@@ -349,18 +347,6 @@ public class DeployService {
               "An account name must be "
                   + "specified as the desired place to run your distributed deployment.");
         }
-
-        Account account =
-            accountService.getAnyProviderAccount(deploymentConfiguration.getName(), accountName);
-        Provider.ProviderType providerType = ((Provider) account.getParent()).providerType();
-
-        if (providerType == Provider.ProviderType.KUBERNETES
-            && account.getProviderVersion() == V1) {
-          throw new HalException(
-              Problem.Severity.FATAL,
-              "Distributed deployment is only available for standard Kubernetes (V2) accounts.");
-        }
-
         return kubectlDeployer;
       default:
         throw new IllegalArgumentException("Unrecognized deployment type " + type);


### PR DESCRIPTION
Related to: https://github.com/spinnaker/spinnaker/issues/5749

* Since ProviderVersion was only ever relevant to KubernetesAccount, move the enum from Provider to KubernetesAccount before deprecating it. Hopefully this will prevent any future cloud providers from needlessly including the providerVersion field in every account.
* We have included warnings that V1 accounts cannot be used for a Distributed install for a couple of Halyard releases; let's remove these for the next release.