### PR TITLE
fix(install): support Java 14 in installation for macOS

### DIFF
--- a/install/macos/InstallHalyard.sh
+++ b/install/macos/InstallHalyard.sh
@@ -155,6 +155,7 @@ function install_java() {
      [[ "$java_version" == *"11"* ]] || \
      [[ "$java_version" == *"12"* ]] || \
      [[ "$java_version" == *"13"* ]] || \
+     [[ "$java_version" == *"14"* ]] || \
      [[ "$java_version" == "java version \"10\""* ]]; then
     echo "Java is already installed & at the right version"
     return 0;


### PR DESCRIPTION
Support Java 14 in the installation script for macOS.

