### PR TITLE
fix(cli): ignore providerVersion in all non-Kubernetes account types

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Account.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.node;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.fiat.model.resources.Permissions;
 import com.netflix.spinnaker.halyard.config.config.v1.ArtifactSourcesConfig;
 import java.util.ArrayList;
@@ -26,7 +25,6 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = false)
-@JsonIgnoreProperties({"providerVersion"})
 public abstract class Account extends Node implements Cloneable {
   String name;
   String environment;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
@@ -17,6 +17,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.aws;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +26,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class AwsAccount extends Account {
   private String defaultKeyPair;
   private String edda;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/azure/AzureAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.azure;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class AzureAccount extends Account {
   private String clientId;
   @Secret private String appKey;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudfoundry/CloudFoundryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudfoundry/CloudFoundryAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.cloudfoundry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
@@ -25,6 +26,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class CloudFoundryAccount extends Account {
   @JsonProperty("api")
   String apiHost;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dcos/DCOSAccount.java
@@ -1,5 +1,6 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.dcos;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.containers.ContainerAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
@@ -11,6 +12,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class DCOSAccount extends ContainerAccount {
   private List<ClusterCredential> clusters;
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dockerRegistry/DockerRegistryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/dockerRegistry/DockerRegistryAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
@@ -27,6 +28,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class DockerRegistryAccount extends Account {
   private String address;
   private String username;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/ecs/EcsAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/ecs/EcsAccount.java
@@ -1,11 +1,13 @@
 package com.netflix.spinnaker.halyard.config.model.v1.providers.ecs;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class EcsAccount extends Account {
 
   private String awsAccount;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/CommonGoogleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/CommonGoogleAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.google;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
@@ -26,6 +27,7 @@ import lombok.ToString;
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class CommonGoogleAccount extends Account {
   private String project;
   @LocalFile @SecretFile private String jsonPath;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/huaweicloud/HuaweiCloudAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/huaweicloud/HuaweiCloudAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.huaweicloud;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import java.util.List;
@@ -24,6 +25,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class HuaweiCloudAccount extends Account {
   private String accountType;
   private String authUrl;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/oracle/OracleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/oracle/OracleAccount.java
@@ -9,6 +9,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.oracle;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
@@ -18,6 +19,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class OracleAccount extends Account {
   private String compartmentId;
   private String userId;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/tencentcloud/TencentCloudAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/tencentcloud/TencentCloudAccount.java
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.model.v1.providers.tencentcloud;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Secret;
 import java.util.ArrayList;
@@ -25,6 +26,7 @@ import lombok.EqualsAndHashCode;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
+@JsonIgnoreProperties({"providerVersion"})
 public class TencentCloudAccount extends Account {
   private String secretId;
   @Secret private String secretKey;


### PR DESCRIPTION
Instead of ignoring `providerVersion` in the base Account class, ignore it in each non-Kubernetes subclass, so that `providerVersion: v1` is respected for legacy Kubernetes accounts.