### PR TITLE
feat(kubernetes): allow adding custom service annotations

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/KubernetesSettings.java
@@ -31,6 +31,7 @@ public class KubernetesSettings {
   Map<String, String> podAnnotations = new HashMap<>();
   Map<String, String> podLabels = new HashMap<>();
   Map<String, String> serviceLabels = new HashMap<>();
+  Map<String, String> serviceAnnotations = new HashMap<>();
   List<ConfigSource> volumes = new ArrayList<>();
   String serviceAccountName = null;
   String serviceType = "ClusterIP";

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -146,6 +146,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     service.addBinding("type", settings.getKubernetes().getServiceType());
     service.addBinding("nodePort", settings.getKubernetes().getNodePort());
     service.addBinding("serviceLabels", settings.getKubernetes().getServiceLabels());
+    service.addBinding("serviceAnnotations", setting.getKubernetes().getServiceAnnotations());
 
     return service.toString();
   }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -146,7 +146,7 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
     service.addBinding("type", settings.getKubernetes().getServiceType());
     service.addBinding("nodePort", settings.getKubernetes().getNodePort());
     service.addBinding("serviceLabels", settings.getKubernetes().getServiceLabels());
-    service.addBinding("serviceAnnotations", setting.getKubernetes().getServiceAnnotations());
+    service.addBinding("serviceAnnotations", settings.getKubernetes().getServiceAnnotations());
 
     return service.toString();
   }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml
@@ -9,6 +9,10 @@ metadata:
     {% for key, value in serviceLabels.items() %}
     "{{ key }}": "{{ value }}"
     {% endfor %}
+annotations:
+  {% for key, value in serviceAnnotations.items() %}
+  "{{ key }}": "{{ value }}"
+  {% endfor %}
 spec:
   selector:
     app: spin


### PR DESCRIPTION
## What

This allows adding customized annotations to Kubernetes service.

## Why

There are many cases that we want to add annotations to Kubernetes Service.
One example is Google Cloud Platform's [Network endpoint group (NEG)](https://cloud.google.com/load-balancing/docs/negs). This required to add a NEG configuration in Kubernetes Service annotation.
But currently, halyard doesn't allow to add it. It allows only `podLabels`, `podAnnotations`, `serviceLabels`. (ref: [podAnnotations, podLabels and serviceLabels, Spinnaker](https://spinnaker.io/reference/halyard/custom/#podannotations-podlabels-and-servicelabels))
Therefore, I've added to use this in many cases.

After this PR has merged, I will like to update the spinnaker.github.io document as well.