### PR TITLE
chore(spotless): upgrade spinnaker gradle plugin

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ fiatVersion=1.22.0
 front50Version=2.21.0
 korkVersion=7.56.0
 org.gradle.parallel=true
-spinnakerGradleVersion=8.3.0
+spinnakerGradleVersion=8.4.0
 
 # To enable a composite reference to a project, set the
 #  project property `'<projectName>Composite=true'`.

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/google/GoogleDistributedService.java
@@ -618,8 +618,10 @@ public interface GoogleDistributedService<T> extends DistributedService<T, Googl
 
     Set<String> healthyConsulInstances =
         consulEnabled
-            ? getConsulServerService().connectToPrimaryService(details, runtimeSettings)
-                .serviceHealth(getService().getCanonicalName(), true).stream()
+            ? getConsulServerService()
+                .connectToPrimaryService(details, runtimeSettings)
+                .serviceHealth(getService().getCanonicalName(), true)
+                .stream()
                 .map(s -> s != null && s.getNode() != null ? s.getNode().getNodeName() : null)
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet())


### PR DESCRIPTION
This includes updates to google-java-format and ktlint, so requires some
formatting changes. These were made with a simple `./gradlew spotlessApply`.