### PR TITLE
fix(kubernetes): fix custom service annotations

### DIFF
--- a/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/service.yml
@@ -9,10 +9,10 @@ metadata:
     {% for key, value in serviceLabels.items() %}
     "{{ key }}": "{{ value }}"
     {% endfor %}
-annotations:
-  {% for key, value in serviceAnnotations.items() %}
-  "{{ key }}": "{{ value }}"
-  {% endfor %}
+  annotations:
+    {% for key, value in serviceAnnotations.items() %}
+    "{{ key }}": "{{ value }}"
+    {% endfor %}
 spec:
   selector:
     app: spin


### PR DESCRIPTION
Hi

Service annotations are in the metadata object.

When i tried to `deploy apply` i got this :
```
error: error validating "STDIN": error validating data:
  ValidationError(Service): unknown field "annotations" in
  io.k8s.api.core.v1.Service; if you choose to ignore these errors, turn
  validation off with --validate=false
```