### PR TITLE
feat(config): add upperBound/tooHighMessage for mineCanary feature flag

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Features.java
@@ -64,8 +64,11 @@ public class Features extends Node {
 
   @ValidForSpinnakerVersion(
       lowerBound = "1.5.0",
+      upperBound = "1.22.0",
       tooLowMessage =
-          "Canary is not configurable prior to this release. Will be stable at a later release.")
+          "Canary is not configurable prior to this release. Will be stable at a later release.",
+      tooHighMessage =
+          "This flag gates legacy canary stages and does not need to be enabled for OSS canary analysis support.")
   private Boolean mineCanary;
 
   @ValidForSpinnakerVersion(


### PR DESCRIPTION
Related to: https://github.com/spinnaker/spinnaker/issues/5939

This flag gates legacy, pre-Kayenta stages in Deck's canary module that are likely not used by OSS users. To reduce confusion, deprecate this flag.