### PR TITLE
fix(misc): Remove hard dependency on resolvedEnv endpoint and add run…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 clouddriverVersion=5.67.0
 fiatVersion=1.22.0
 front50Version=2.21.0
-korkVersion=7.56.0
+korkVersion=7.58.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.4.0
 

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -33,6 +33,7 @@ dependencies {
   implementation 'org.codehaus.groovy:groovy'
   implementation "com.netflix.spinnaker.kork:kork-web"
   implementation "com.netflix.spinnaker.kork:kork-config"
+  runtimeOnly    "com.netflix.spinnaker.kork:kork-actuator"
 
   implementation project(':halyard-backup')
   // halyard-cli is required as a dependency even though it is not used directly by halyard-web

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
@@ -16,7 +16,6 @@
 
 package com.netflix.spinnaker.halyard;
 
-import com.netflix.spinnaker.config.ResolvedEnvironmentConfigurationProperties;
 import com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder;
 import com.netflix.spinnaker.kork.configserver.ConfigServerBootstrap;
 import java.util.Map;
@@ -26,12 +25,10 @@ import org.springframework.boot.web.servlet.support.SpringBootServletInitializer
 import org.springframework.cloud.config.server.EnableConfigServer;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Import;
 
 @Configuration
-@ComponentScan(value = {"com.netflix.spinnaker.halyard", "com.netflix.spinnaker.endpoint"})
+@ComponentScan(value = {"com.netflix.spinnaker.halyard"})
 @EnableAutoConfiguration
-@Import(ResolvedEnvironmentConfigurationProperties.class)
 @EnableConfigServer
 public class Main extends SpringBootServletInitializer {
   private static final Map<String, Object> DEFAULT_PROPS = new DefaultPropertiesBuilder().build();


### PR DESCRIPTION
- Moved custom actuator endpoint config into separate module `kork-actuator`
- Added `kork-actuator` as a runtime dep and removed config bean imports which are not necessary now.