### PR TITLE
feat(plugins): Enable customizable configuration structures

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 
 @Data
+@JsonIgnoreProperties(ignoreUnknown = true)
 @EqualsAndHashCode(callSuper = true)
 public class Plugin extends Node {
 


### PR DESCRIPTION
For extensionless plugins, it would be nice to be able to stuff config at the top level.
https://github.com/armory-plugins/armory-observability-plugin
https://github.com/armory-plugins/armory-observability-plugin/blob/master/common/src/main/java/io/armory/plugin/observability/model/PluginConfig.java#L25

Currently, we have to install this plugin by using profiles and we can't use the plugin section of halyard because it blows up on unrecognized fields.

https://github.com/armory-plugins/armory-observability-plugin/issues/21