### PR TITLE
feat(plugins): support top level plugin config

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/plugins/Plugin.java
@@ -31,6 +31,7 @@ public class Plugin extends Node {
   private Boolean enabled;
   @Deprecated private String uiResourceLocation;
   private String version;
+  private Map<String, Object> config = new HashMap<>();
   private Map<String, PluginExtension> extensions = new HashMap<>();
 
   @Override
@@ -50,6 +51,7 @@ public class Plugin extends Node {
     Map<String, Object> pluginYaml = new LinkedHashMap<>();
     pluginYaml.put("enabled", enabled);
     pluginYaml.put("version", version);
+    pluginYaml.put("config", config);
     pluginYaml.put("extensions", extensionsConfig());
     return pluginYaml;
   }

--- a/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/ExtensibilitySpec.groovy
+++ b/halyard-config/src/test/groovy/com/netflix/spinnaker/halyard/config/model/v1/ExtensibilitySpec.groovy
@@ -43,6 +43,7 @@ class ExtensibilitySpec extends Specification {
                 "Test.Plugin": [
                         'enabled': true,
                         'version': '1.2.3',
+                        "config": [:],
                         'extensions': [
                                 "test.plugin": [
                                         "enabled": true,
@@ -53,5 +54,4 @@ class ExtensibilitySpec extends Specification {
         ]
         subject == expectedOptions
     }
-
 }


### PR DESCRIPTION
For plugins that do not use extensions, it would be nice to support top-level configuration.

closes https://github.com/armory-plugins/armory-observability-plugin/issues/21