### PR TITLE
feat(cli): add upperBound for liveManifestCalls flag

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -81,6 +81,12 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
   String kubectlPath;
   Integer kubectlRequestTimeoutSeconds;
   Boolean checkPermissionsOnStartup;
+
+  @ValidForSpinnakerVersion(
+      lowerBound = "1.12.0",
+      tooLowMessage = "Live manifest mode not available prior to 1.12.0.",
+      upperBound = "1.23.0",
+      tooHighMessage = "Live manifest mode no longer necessary as of 1.23.0.")
   Boolean liveManifestCalls;
 
   // Without the annotations, these are written as `oauthServiceAccount` and `oauthScopes`,


### PR DESCRIPTION
The `liveManifestCalls` flag was [removed](https://github.com/spinnaker/clouddriver/pull/4904) from Clouddriver; update Halyard to indicate that it is no longer necessary when upgrading to 1.23.