### PR TITLE
feat(aws): Adding property externalId to AWS account config for assuming roles.

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7411,6 +7411,7 @@ Example: [http://{{region}}.eureka.url.to.use:8080/eureka-server/v2](http://{{re
 Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See [https://github.com/Netflix/edda](https://github.com/Netflix/edda) for more information.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
+ * `--external-id`: Address and prevent the "confused deputy" problem. Provides a way for the account owner to permit the role to be assumed only under specific circumstances.
  * `--launching-lifecycle-hook-default-result`: (*Default*: `ABANDON`) Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. This parameter can be either CONTINUE or ABANDON. The default value is ABANDON.
  * `--launching-lifecycle-hook-heartbeat-timeout-seconds`: (*Default*: `3600`) Set the heartbeat timeout for the lifecycle hook. Instances can " +
           "remain in a wait state for a finite period of time. The default is one hour (3600 seconds).
@@ -7475,6 +7476,7 @@ Example: [http://{{region}}.eureka.url.to.use:8080/eureka-server/v2](http://{{re
 Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See [https://github.com/Netflix/edda](https://github.com/Netflix/edda) for more information.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
+ * `--external-id`: Address and prevent the "confused deputy" problem. Provides a way for the account owner to permit the role to be assumed only under specific circumstances.
  * `--launching-lifecycle-hook-default-result`: (*Default*: `ABANDON`) Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. This parameter can be either CONTINUE or ABANDON. The default value is ABANDON.
  * `--launching-lifecycle-hook-heartbeat-timeout-seconds`: (*Default*: `3600`) Set the heartbeat timeout for the lifecycle hook. Instances can " +
           "remain in a wait state for a finite period of time. The default is one hour (3600 seconds).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7411,7 +7411,7 @@ Example: [http://{{region}}.eureka.url.to.use:8080/eureka-server/v2](http://{{re
 Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See [https://github.com/Netflix/edda](https://github.com/Netflix/edda) for more information.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
- * `--external-id`: Address and prevent the "confused deputy" problem. Provides a way for the account owner to permit the role to be assumed only under specific circumstances.
+ * `--external-id`: Optional parameter used to identify and control access to AWS resources. Set this to the same value as the ExternalID parameter in the trust policy for the role you want to assume.
  * `--launching-lifecycle-hook-default-result`: (*Default*: `ABANDON`) Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. This parameter can be either CONTINUE or ABANDON. The default value is ABANDON.
  * `--launching-lifecycle-hook-heartbeat-timeout-seconds`: (*Default*: `3600`) Set the heartbeat timeout for the lifecycle hook. Instances can " +
           "remain in a wait state for a finite period of time. The default is one hour (3600 seconds).
@@ -7476,7 +7476,7 @@ Example: [http://{{region}}.eureka.url.to.use:8080/eureka-server/v2](http://{{re
 Using {{region}} will make Spinnaker use AWS regions in the hostname to access discovery so that you can have discovery for multiple regions.
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See [https://github.com/Netflix/edda](https://github.com/Netflix/edda) for more information.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
- * `--external-id`: Address and prevent the "confused deputy" problem. Provides a way for the account owner to permit the role to be assumed only under specific circumstances.
+ * `--external-id`: Optional parameter used to identify and control access to AWS resources. Set this to the same value as the ExternalID parameter in the trust policy for the role you want to assume.
  * `--launching-lifecycle-hook-default-result`: (*Default*: `ABANDON`) Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. This parameter can be either CONTINUE or ABANDON. The default value is ABANDON.
  * `--launching-lifecycle-hook-heartbeat-timeout-seconds`: (*Default*: `3600`) Set the heartbeat timeout for the lifecycle hook. Instances can " +
           "remain in a wait state for a finite period of time. The default is one hour (3600 seconds).

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
@@ -67,6 +67,9 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
       required = true)
   private String assumeRole;
 
+  @Parameter(names = "--external-id", description = AwsCommandProperties.EXTERNAL_ID_DESCRIPTION)
+  private String externalId;
+
   @Parameter(
       names = "--launching-lifecycle-hook-default-result",
       description = AwsCommandProperties.HOOK_DEFAULT_VALUE_DESCRIPTION)
@@ -120,6 +123,7 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
                 .map(r -> new AwsProvider.AwsRegion().setName(r))
                 .collect(Collectors.toList()))
         .setAssumeRole(assumeRole)
+        .setExternalId(externalId)
         .setLifecycleHooks(getLifecycleHooks());
 
     return account;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
@@ -45,6 +45,10 @@ public class AwsCommandProperties {
           + "Security Token Service to assume the specified role.\n\n"
           + "Example: \"user/spinnaker\" or \"role/spinnakerManaged\"";
 
+  public static final String EXTERNAL_ID_DESCRIPTION =
+      "Address and prevent the \"confused deputy\" problem. "
+          + "Provides a way for the account owner to permit the role to be assumed only under specific circumstances.";
+
   public static final String ACCESS_KEY_ID_DESCRIPTION =
       "Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials "
           + "as described at http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default";

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
@@ -46,8 +46,8 @@ public class AwsCommandProperties {
           + "Example: \"user/spinnaker\" or \"role/spinnakerManaged\"";
 
   public static final String EXTERNAL_ID_DESCRIPTION =
-      "Address and prevent the \"confused deputy\" problem. "
-          + "Provides a way for the account owner to permit the role to be assumed only under specific circumstances.";
+      "Optional parameter used to identify and control access to AWS resources. "
+          + "Set this to the same value as the ExternalID parameter in the trust policy for the role you want to assume.";
 
   public static final String ACCESS_KEY_ID_DESCRIPTION =
       "Your AWS Access Key ID. If not provided, Halyard/Spinnaker will try to find AWS credentials "

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditAccountCommand.java
@@ -70,6 +70,9 @@ public class AwsEditAccountCommand extends AbstractEditAccountCommand<AwsAccount
   @Parameter(names = "--assume-role", description = AwsCommandProperties.ASSUME_ROLE_DESCRIPTION)
   private String assumeRole;
 
+  @Parameter(names = "--external-id", description = AwsCommandProperties.EXTERNAL_ID_DESCRIPTION)
+  private String externalId;
+
   @Parameter(
       names = "--launching-lifecycle-hook-default-result",
       description = AwsCommandProperties.HOOK_DEFAULT_VALUE_DESCRIPTION)
@@ -117,6 +120,7 @@ public class AwsEditAccountCommand extends AbstractEditAccountCommand<AwsAccount
     account.setDiscovery(isSet(discovery) ? discovery : account.getDiscovery());
     account.setAccountId(isSet(accountId) ? accountId : account.getAccountId());
     account.setAssumeRole(isSet(assumeRole) ? assumeRole : account.getAssumeRole());
+    account.setExternalId(isSet(externalId) ? externalId : account.getExternalId());
 
     List<AwsLifecycleHook> hooks = getLifecycleHooks();
     account.setLifecycleHooks(!hooks.isEmpty() ? hooks : account.getLifecycleHooks());

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
@@ -34,6 +34,7 @@ public class AwsAccount extends Account {
   private String accountId;
   private List<AwsProvider.AwsRegion> regions = new ArrayList<>();
   private String assumeRole;
+  private String externalId;
   private String sessionName;
   private List<AwsProvider.AwsLifecycleHook> lifecycleHooks = new ArrayList<>();
 }


### PR DESCRIPTION
Enabling the use of the externalId parameter when assuming a role prevents the "confused deputy" problem.

https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html#external-id-purpose

Depends on: https://github.com/spinnaker/clouddriver/pull/4968