### PR TITLE
chore(redis): Move Halyard's redis image into the CDF-owned GCP project

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2RedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2RedisService.java
@@ -43,7 +43,7 @@ public class KubernetesV2RedisService extends RedisService implements Kubernetes
   }
 
   public String getArtifactId(DeploymentConfiguration deploymentConfiguration) {
-    return "gcr.io/kubernetes-spinnaker/redis-cluster:v2";
+    return "us-docker.pkg.dev/spinnaker-community/redis/redis-cluster:v2";
   }
 
   @Override


### PR DESCRIPTION
The `kubernetes-spinnaker` project seemingly exists solely to host this one image. I have no idea why. Let's move it into its own Artifact Registry repository in the CDF-owned `spinnaker-community` project.

Also, the version of Redis in this image is 3.2.11, which is three years old, but I suppose that's a problem for another day.