### PR TITLE
fix(halyard): Bugfix 6112: Populate settings.js with default settings for Oracle provider

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -143,6 +143,10 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     bindings.put("kubernetes.default.namespace", "default");
     bindings.put("kubernetes.default.proxy", "localhost:8001");
 
+    bindings.put("oracle.default.account", "Default");
+    bindings.put("oracle.default.bakeryRegions", "us-phoenix-1");
+    bindings.put("oracle.default.region", "us-phoenix-1");
+
     // Configure GCE
     GoogleProvider googleProvider = deploymentConfiguration.getProviders().getGoogle();
     bindings.put("google.default.account", googleProvider.getPrimaryAccount());


### PR DESCRIPTION
fix(halyard): settings.js doesn't have Oracle default settings
This settings.js is being used as template by halyard and gets hydrated with default settings. Without these settings, oracle default settings were not getting populated, causing at least one know failure while creating OCI load balancer template.

After this fix, default settings for oracle provider will be populated properly