### PR TITLE
feat(validations/cf): Updated CF client for validations

### DIFF
--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -29,6 +29,7 @@ dependencies {
   implementation 'commons-io:commons-io:2.6'
   implementation 'io.fabric8:kubernetes-client'
   implementation 'com.squareup.retrofit:retrofit'
+  implementation "com.squareup.retrofit:converter-jackson"
   implementation 'com.jcraft:jsch'
   implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid'
 


### PR DESCRIPTION
Adjusted CloudFoundry validations due to changes on CF code used to query spaces introduced by https://github.com/spinnaker/clouddriver/pull/5071

Now the validator doesn't depend on clouddriver internal objects, and instead depends on retrofit API interfaces, still exposed by clouddriver.