### PR TITLE
fix(gcs): Fix validation error when bucketLocation is not specified

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/canary/google/GoogleCanaryAccount.java
@@ -35,7 +35,7 @@ public class GoogleCanaryAccount extends AbstractCanaryAccount implements Clonea
   private String project;
   @LocalFile @SecretFile private String jsonPath;
   private String bucket;
-  private String bucketLocation;
+  private String bucketLocation = "";
   private String rootFolder = "kayenta";
   private SortedSet<AbstractCanaryServiceIntegration.SupportedTypes> supportedTypes =
       new TreeSet<>();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/GcsPersistentStore.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/persistentStorage/GcsPersistentStore.java
@@ -29,7 +29,7 @@ public class GcsPersistentStore extends PersistentStore {
   private String project;
   private String bucket;
   private String rootFolder = "front50";
-  private String bucketLocation;
+  private String bucketLocation = "";
 
   @Override
   public PersistentStoreType persistentStoreType() {


### PR DESCRIPTION
When the Front50 version was updated #1848 a change for GcsStorageService was introduced.

Prior to the rewrite of GcsStorageService, front50 accepted either null or empty string as the bucket location; now that GcsStorageService is in kotlin and does not use a String? for the field, an error occurs on trying to create the GcsStorageService.

PRs related spinnaker/front50#934