### PR TITLE
feat(kubernetes): Add CacheIntervalSeconds config to Kubernetes

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9588,6 +9588,7 @@ hal config provider kubernetes account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--cache-all-application-relationships`: If true, will add application relationships in the cache for all types of resources.
 This includes CRDs and resources that aren't used in the Clusters, Load Balancers or Firewalls sections.
+ * `--cache-interval-seconds`: (*Default*: `30`) How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.
  * `--cache-threads`: (*Default*: `1`) Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. By default, only 1 agent caches all kinds for all namespaces in the account.
  * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
 during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.
@@ -9663,6 +9664,7 @@ hal config provider kubernetes account edit ACCOUNT [parameters]
  * `--all-namespaces`: (*Default*: `false`) Set the list of namespaces to cache and deploy to every namespace available to your supplied credentials.
  * `--cache-all-application-relationships`: If true, will add application relationships in the cache for all types of resources.
 This includes CRDs and resources that aren't used in the Clusters, Load Balancers or Firewalls sections.
+ * `--cache-interval-seconds`: (*Default*: `30`) How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.
  * `--cache-threads`: Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. By default, only 1 agent caches all kinds for all namespaces in the account.
  * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
 during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -9588,7 +9588,7 @@ hal config provider kubernetes account add ACCOUNT [parameters]
 `ACCOUNT`: The name of the account to operate on.
  * `--cache-all-application-relationships`: If true, will add application relationships in the cache for all types of resources.
 This includes CRDs and resources that aren't used in the Clusters, Load Balancers or Firewalls sections.
- * `--cache-interval-seconds`: (*Default*: `30`) How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.
+ * `--cache-interval-seconds`: How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.
  * `--cache-threads`: (*Default*: `1`) Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. By default, only 1 agent caches all kinds for all namespaces in the account.
  * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
 during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.
@@ -9664,7 +9664,7 @@ hal config provider kubernetes account edit ACCOUNT [parameters]
  * `--all-namespaces`: (*Default*: `false`) Set the list of namespaces to cache and deploy to every namespace available to your supplied credentials.
  * `--cache-all-application-relationships`: If true, will add application relationships in the cache for all types of resources.
 This includes CRDs and resources that aren't used in the Clusters, Load Balancers or Firewalls sections.
- * `--cache-interval-seconds`: (*Default*: `30`) How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.
+ * `--cache-interval-seconds`: How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.
  * `--cache-threads`: Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. By default, only 1 agent caches all kinds for all namespaces in the account.
  * `--check-permissions-on-startup`: When false, clouddriver will skip the permission checks for all kubernetes kinds at startup. This can save a great deal of time
 during clouddriver startup when you have many kubernetes accounts configured. This disables the log messages at startup about missing permissions.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -124,7 +124,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
       names = "--cache-interval-seconds",
       arity = 1,
       description = KubernetesCommandProperties.CACHE_INTERVAL_SECONDS_DESCRIPTION)
-  private Long cacheIntervalSeconds = 30L;
+  private Long cacheIntervalSeconds;
 
   @Parameter(
       names = "--cache-all-application-relationships",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesAddAccountCommand.java
@@ -121,6 +121,12 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
   private int cacheThreads = 1;
 
   @Parameter(
+      names = "--cache-interval-seconds",
+      arity = 1,
+      description = KubernetesCommandProperties.CACHE_INTERVAL_SECONDS_DESCRIPTION)
+  private Long cacheIntervalSeconds = 30L;
+
+  @Parameter(
       names = "--cache-all-application-relationships",
       arity = 1,
       description = KubernetesCommandProperties.CACHE_ALL_APPLICATION_RELATIONSHIPS)
@@ -167,6 +173,7 @@ public class KubernetesAddAccountCommand extends AbstractAddAccountCommand {
     account.setCheckPermissionsOnStartup(checkPermissionsOnStartup);
     account.setLiveManifestCalls(liveManifestCalls);
     account.setCacheThreads(cacheThreads);
+    account.setCacheIntervalSeconds(cacheIntervalSeconds);
     account.setCacheAllApplicationRelationships(cacheAllApplicationRelationships);
     account.getRawResourcesEndpointConfig().setKindExpressions(rawResourcekindExpressions);
     account.getRawResourcesEndpointConfig().setOmitKindExpressions(rawResourceOmitKindExpressions);

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesCommandProperties.java
@@ -70,6 +70,10 @@ public class KubernetesCommandProperties {
       "Number of caching agents for this kubernetes account. Each agent handles a subset of the namespaces available to this account. "
           + "By default, only 1 agent caches all kinds for all namespaces in the account.";
 
+  static final String CACHE_INTERVAL_SECONDS_DESCRIPTION =
+      "How many seconds elapse between polling your kubernetes api. Kubernetes apis are sensitive to over-polling, and "
+          + "larger intervals (e.g. 10 minutes = 600 seconds) are desirable if you're seeing rate limiting.";
+
   static final String CACHE_ALL_APPLICATION_RELATIONSHIPS =
       "If true, will add application relationships in the cache for all types of resources.\n"
           + "This includes CRDs and resources that aren't used in the Clusters, Load Balancers or Firewalls sections.";

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -258,7 +258,7 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
       names = "--cache-interval-seconds",
       arity = 1,
       description = KubernetesCommandProperties.CACHE_INTERVAL_SECONDS_DESCRIPTION)
-  private Long cacheIntervalSeconds = 30L;
+  private Long cacheIntervalSeconds;
 
   @Parameter(
       names = "--cache-all-application-relationships",

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/kubernetes/KubernetesEditAccountCommand.java
@@ -255,6 +255,12 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
   private Integer cacheThreads;
 
   @Parameter(
+      names = "--cache-interval-seconds",
+      arity = 1,
+      description = KubernetesCommandProperties.CACHE_INTERVAL_SECONDS_DESCRIPTION)
+  private Long cacheIntervalSeconds = 30L;
+
+  @Parameter(
       names = "--cache-all-application-relationships",
       arity = 1,
       description = KubernetesCommandProperties.CACHE_ALL_APPLICATION_RELATIONSHIPS)
@@ -384,6 +390,8 @@ public class KubernetesEditAccountCommand extends AbstractEditAccountCommand<Kub
     account.setLiveManifestCalls(
         isSet(liveManifestCalls) ? liveManifestCalls : account.getLiveManifestCalls());
     account.setCacheThreads(isSet(cacheThreads) ? cacheThreads : account.getCacheThreads());
+    account.setCacheIntervalSeconds(
+        isSet(cacheIntervalSeconds) ? cacheIntervalSeconds : account.getCacheIntervalSeconds());
     account.setCacheAllApplicationRelationships(
         isSet(cacheAllApplicationRelationships)
             ? cacheAllApplicationRelationships

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -53,7 +53,7 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
 
   Boolean serviceAccount;
   int cacheThreads = 1;
-  Long cacheIntervalSeconds = 30L;
+  Long cacheIntervalSeconds;
   List<String> namespaces = new ArrayList<>();
   List<String> omitNamespaces = new ArrayList<>();
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccount.java
@@ -53,6 +53,7 @@ public class KubernetesAccount extends ContainerAccount implements Cloneable {
 
   Boolean serviceAccount;
   int cacheThreads = 1;
+  Long cacheIntervalSeconds = 30L;
   List<String> namespaces = new ArrayList<>();
   List<String> omitNamespaces = new ArrayList<>();
 


### PR DESCRIPTION
The kubernetes account configuration was missing the cache-interval-seconds option, this change adds the capability to configure kubernetes account with cache-interval configuration in the cloud driver.