### PR TITLE
fix(azure): Add mandatory username to userInfoMapping

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth2.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth2.java
@@ -115,6 +115,7 @@ public class OAuth2 extends AuthnMethod {
         newUserInfoMapping.setEmail("userPrincipalName");
         newUserInfoMapping.setFirstName("givenName");
         newUserInfoMapping.setLastName("surname");
+        newUserInfoMapping.setUsername("userPrincipalName");
         break;
       case OTHER:
         newClient.setAccessTokenUri(client.getAccessTokenUri());


### PR DESCRIPTION
Default value of username in UserInfoMapping is "email" which doesn't exist in Azure.
This will set username to "userPrincipalName" and thus allow Azure to work with Halyard.