### PR TITLE
fix(oauth2): add roles to user info mapping

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth2/EditOAuth2Command.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/security/authn/oauth2/EditOAuth2Command.java
@@ -81,6 +81,11 @@ public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
   private String userInfoMappingUsername;
 
   @Parameter(
+      names = "--user-info-mapping-roles",
+      description = "The roles field returned from your OAuth provider.")
+  private String userInfoMappingRoles;
+
+  @Parameter(
       names = "--provider",
       description =
           "The OAuth provider handling authentication. The supported options are Google, GitHub, Oracle, Azure and Other",
@@ -143,6 +148,9 @@ public class EditOAuth2Command extends AbstractEditAuthnMethodCommand<OAuth2> {
         isSet(userInfoMappingLastName) ? userInfoMappingLastName : userInfoMapping.getLastName());
     userInfoMapping.setUsername(
         isSet(userInfoMappingUsername) ? userInfoMappingUsername : userInfoMapping.getUsername());
+
+    userInfoMapping.setRoles(
+        isSet(userInfoMappingRoles) ? userInfoMappingRoles : userInfoMapping.getRoles());
 
     authnMethod.setProvider(provider != null ? provider : authnMethod.getProvider());
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth2.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/security/OAuth2.java
@@ -128,6 +128,7 @@ public class OAuth2 extends AuthnMethod {
         newUserInfoMapping.setFirstName(userInfoMapping.getFirstName());
         newUserInfoMapping.setLastName(userInfoMapping.getLastName());
         newUserInfoMapping.setUsername(userInfoMapping.getUsername());
+        newUserInfoMapping.setRoles(userInfoMapping.getRoles());
         break;
       default:
         throw new RuntimeException("Unknown provider type " + provider);
@@ -161,6 +162,7 @@ public class OAuth2 extends AuthnMethod {
     private String firstName;
     private String lastName;
     private String username;
+    private String roles;
   }
 
   @Data


### PR DESCRIPTION
When using an "OTHER" oauth2 provider we need to specify the user roles mapping field.

[Gate supports this](https://github.com/spinnaker/gate/blob/master/gate-oauth2/src/main/groovy/com/netflix/spinnaker/gate/security/oauth2/OAuth2SsoConfig.groovy#L111) but halyard doesn't so it has to be configured with a profile file.