### PR TITLE
fix(build): use versions of dependencies that are available on maven central

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,9 @@
-clouddriverVersion=5.72.1
-fiatVersion=1.26.0
+clouddriverVersion=5.75.0
+fiatVersion=1.28.0
 korkVersion=7.117.0
-front50Version=2.23.0
+front50Version=2.24.0
 org.gradle.parallel=true
-spinnakerGradleVersion=8.12.0
+spinnakerGradleVersion=8.15.0
 targetJava11=true
 
 # To enable a composite reference to a project, set the

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -16,12 +16,7 @@ dependencies {
   implementation 'org.aspectj:aspectjweaver'
   implementation 'org.yaml:snakeyaml:1.24'
   implementation 'org.codehaus.groovy:groovy'
-  implementation('com.beust:jcommander:1.71') {
-    // 1.72 made JCommander.getMainParameter() weird
-    // This was reverted in master but not released yet. Sticking with 1.71 instead of catching NPE in
-    // com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand :287 and :414
-    force = true
-  }
+  implementation 'com.beust:jcommander:1.75'
   implementation 'org.nibor.autolink:autolink:0.10.0'
 
   implementation project(':halyard-config')

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -3,7 +3,7 @@ dependencies {
   annotationProcessor 'org.projectlombok:lombok'
 
   implementation 'org.springframework.boot:spring-boot'
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation 'io.spinnaker.kork:kork-secrets'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.commons:commons-text:1.6'

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -304,7 +304,8 @@ public abstract class NestableCommand {
       paragraph.addSnippet("PARAMETERS").addStyle(AnsiStyle.BOLD);
       story.addNewline();
 
-      ParameterDescription mainParameter = commander.getMainParameter();
+      ParameterDescription mainParameter =
+          (commander.getMainParameter() != null) ? commander.getMainParameterValue() : null;
       if (mainParameter != null) {
         paragraph = story.addParagraph().setIndentWidth(indentWidth);
         paragraph.addSnippet(getMainParameter().toUpperCase()).addStyle(AnsiStyle.UNDERLINE);
@@ -448,7 +449,8 @@ public abstract class NestableCommand {
         .append("\n```\n")
         .append(fullCommandName);
 
-    ParameterDescription mainParameter = commander.getMainParameter();
+    ParameterDescription mainParameter =
+        (commander.getMainParameter() != null) ? commander.getMainParameterValue() : null;
     if (mainParameter != null) {
       result.append(" ").append(getMainParameter().toUpperCase());
     }

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -4,17 +4,17 @@ dependencies {
 
   // TODO(plumpy): remove version once added to kork
   implementation "com.google.cloud:google-cloud-storage:1.108.0"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-api:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-docker:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-appengine:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-azure:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-cloudfoundry:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-security:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.fiat:fiat-core:$fiatVersion"
-  implementation "com.netflix.spinnaker.front50:front50-core:$front50Version"
-  implementation "com.netflix.spinnaker.front50:front50-gcs:$front50Version"
-  implementation "com.netflix.spinnaker.front50:front50-s3:$front50Version"
+  implementation "io.spinnaker.clouddriver:clouddriver-api:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-docker:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-appengine:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-azure:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-cloudfoundry:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-security:$clouddriverVersion"
+  implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
+  implementation "io.spinnaker.front50:front50-core:$front50Version"
+  implementation "io.spinnaker.front50:front50-gcs:$front50Version"
+  implementation "io.spinnaker.front50:front50-s3:$front50Version"
   implementation 'io.spinnaker.kork:kork-secrets'
   implementation 'io.spinnaker.kork:kork-secrets-aws'
   implementation 'io.spinnaker.kork:kork-secrets-gcp'

--- a/halyard-core/halyard-core.gradle
+++ b/halyard-core/halyard-core.gradle
@@ -5,7 +5,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.springframework.boot:spring-boot-gradle-plugin:1.4.7.RELEASE'
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-aws:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-aws:$clouddriverVersion"
   implementation 'io.spinnaker.kork:kork-secrets'
   implementation 'io.spinnaker.kork:kork-secrets-aws'
   implementation 'io.spinnaker.kork:kork-secrets-gcp'

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -4,10 +4,10 @@ dependencies {
 
   implementation 'org.springframework.boot:spring-boot-starter-actuator'
   implementation 'org.springframework.boot:spring-boot-starter-web'
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-api:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-core:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
-  implementation "com.netflix.spinnaker.clouddriver:clouddriver-security:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-api:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-core:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-google:$clouddriverVersion"
+  implementation "io.spinnaker.clouddriver:clouddriver-security:$clouddriverVersion"
   implementation "io.spinnaker.kork:kork-secrets"
   implementation "io.spinnaker.kork:kork-cloud-config-server"
   implementation 'com.netflix.frigga:frigga'

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -30,7 +30,7 @@ dependencies {
   implementation 'org.springframework.boot:spring-boot-starter-web'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'com.squareup.retrofit:retrofit'
-  implementation 'org.lognet:grpc-spring-boot-starter:2.3.2'
+  implementation 'io.github.lognet:grpc-spring-boot-starter:2.4.4'
   implementation 'org.codehaus.groovy:groovy'
   implementation "io.spinnaker.kork:kork-web"
   implementation "io.spinnaker.kork:kork-config"


### PR DESCRIPTION
This effectively combines the autobump PRs for [clouddriver](https://github.com/spinnaker/halyard/pull/1892), [fiat](https://github.com/spinnaker/halyard/pull/1868), [front50](https://github.com/spinnaker/halyard/pull/1893), and [spinnaker-gradle-project](https://github.com/spinnaker/halyard/pull/1885), along with the maven coordinate change from `com.netflix.spinnaker` to `io.spinnaker`.

There are also some other version changes to use dependencies that exist on maven central, though I haven't been able to exercise them much because...

There have been [some changes to clouddriver-cloudfoundry](https://github.com/spinnaker/clouddriver/pull/5294) that mean we need some tweaks here too.  Or at least I get the following compiler errors:
```
$ ./gradlew build

> Task :halyard-config:compileJava
/Users/dbyron/src/spinnaker/halyard/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/cloudfoundry/CloudFoundryAccountValidator.java:124: error: cannot find symbol
      int count = spaceService.all(null, null, null).getResources().size();
                                                    ^
  symbol:   method getResources()
  location: interface Call<Pagination<Space>>
/Users/dbyron/src/spinnaker/halyard/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/cloudfoundry/CloudFoundryAccountValidator.java:161: error: incompatible types: Call<Token> cannot be converted to Token
    return uaaService.passwordToken("password", user, password, "cf", "");
                                   ^
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.
2 errors

> Task :halyard-config:compileJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':halyard-config:compileJava'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.7/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 5s
48 actionable tasks: 3 executed, 45 up-to-date
```