### PR TITLE
feat(provider/kubernetes): Add persistentVolumeClaim support

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConfigSource.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/ConfigSource.java
@@ -31,6 +31,7 @@ public class ConfigSource {
   public enum Type {
     emptyDir,
     configMap,
-    secret
+    secret,
+    persistentVolumeClaim
   }
 }

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/distributed/kubernetes/v2/KubernetesV2Service.java
@@ -163,6 +163,9 @@ public interface KubernetesV2Service<T> extends HasServiceSettings<T>, Kubernete
       case configMap:
         volume = new JinjaJarResource("/kubernetes/manifests/configMapVolume.yml");
         break;
+      case persistentVolumeClaim:
+        volume = new JinjaJarResource("/kubernetes/manifests/persistentVolumeClaimVolume.yml");
+        break;
       default:
         throw new IllegalStateException("Unknown volume type: " + configSource.getType());
     }

--- a/halyard-deploy/src/main/resources/kubernetes/manifests/persistentVolumeClaimVolume.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/persistentVolumeClaimVolume.yml
@@ -1,0 +1,6 @@
+{
+  "name": "{{ name }}",
+  "persistentVolumeClaim": {
+    "claimName": "{{ name }}"
+  }
+}


### PR DESCRIPTION
I needed to mount a persistentVolumeClaim in Rosco in order to build an AMI.
Some people may need this too.