### PR TITLE
(AWS/Lambda): Add command to enable AWS Lambda on AWS Provider

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -7412,6 +7412,7 @@ Using {{region}} will make Spinnaker use AWS regions in the hostname to access d
  * `--edda`: The endpoint Edda is reachable at. Edda is not a hard dependency of Spinnaker, but is helpful for reducing the request volume against AWS. See [https://github.com/Netflix/edda](https://github.com/Netflix/edda) for more information.
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--external-id`: Optional parameter used to identify and control access to AWS resources. Set this to the same value as the ExternalID parameter in the trust policy for the role you want to assume.
+ * `--lambda-enabled`: Enables Lambda Functions in the account
  * `--launching-lifecycle-hook-default-result`: (*Default*: `ABANDON`) Defines the action the Auto Scaling group should take when the lifecycle hook timeout elapses or if an unexpected failure occurs. This parameter can be either CONTINUE or ABANDON. The default value is ABANDON.
  * `--launching-lifecycle-hook-heartbeat-timeout-seconds`: (*Default*: `3600`) Set the heartbeat timeout for the lifecycle hook. Instances can " +
           "remain in a wait state for a finite period of time. The default is one hour (3600 seconds).
@@ -7647,6 +7648,7 @@ hal config provider aws features edit [parameters]
 #### Parameters
  * `--cloud-formation`: (*Required*) Enable CloudFormation support for AWS.
  * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--lambda`: (*Required*) Enable Lambda support for AWS.
  * `--no-validate`: (*Default*: `false`) Skip validation.
 
 

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsAddAccountCommand.java
@@ -110,6 +110,12 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
       description = AwsCommandProperties.HOOK_ROLE_ARN_DESCRIPTION)
   private String terminatingHookRoleArn;
 
+  @Parameter(
+      names = "--lambda-enabled",
+      description = AwsCommandProperties.LAMBDA_ENABLED,
+      arity = 1)
+  private Boolean lambdaEnabled;
+
   @Override
   protected Account buildAccount(String accountName) {
     AwsAccount account = (AwsAccount) new AwsAccount().setName(accountName);
@@ -124,6 +130,7 @@ public class AwsAddAccountCommand extends AbstractAddAccountCommand {
                 .collect(Collectors.toList()))
         .setAssumeRole(assumeRole)
         .setExternalId(externalId)
+        .setLambdaEnabled(lambdaEnabled)
         .setLifecycleHooks(getLifecycleHooks());
 
     return account;

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsCommandProperties.java
@@ -72,4 +72,6 @@ public class AwsCommandProperties {
   public static final String HOOK_ROLE_ARN_DESCRIPTION =
       "The ARN of the IAM role that allows the Auto Scaling group "
           + "to publish to the specified notification target, for example, an Amazon SNS topic or an Amazon SQS queue.";
+
+  public static final String LAMBDA_ENABLED = "Enables Lambda Functions in the account";
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditAccountCommand.java
@@ -113,6 +113,12 @@ public class AwsEditAccountCommand extends AbstractEditAccountCommand<AwsAccount
       description = AwsCommandProperties.HOOK_ROLE_ARN_DESCRIPTION)
   private String terminatingHookRoleArn;
 
+  @Parameter(
+      names = "--lambda-enabled",
+      description = AwsCommandProperties.LAMBDA_ENABLED,
+      arity = 1)
+  private Boolean lambdaEnabled;
+
   @Override
   protected Account editAccount(AwsAccount account) {
     account.setDefaultKeyPair(isSet(defaultKeyPair) ? defaultKeyPair : account.getDefaultKeyPair());
@@ -121,6 +127,7 @@ public class AwsEditAccountCommand extends AbstractEditAccountCommand<AwsAccount
     account.setAccountId(isSet(accountId) ? accountId : account.getAccountId());
     account.setAssumeRole(isSet(assumeRole) ? assumeRole : account.getAssumeRole());
     account.setExternalId(isSet(externalId) ? externalId : account.getExternalId());
+    account.setLambdaEnabled(isSet(lambdaEnabled) ? lambdaEnabled : account.getLambdaEnabled());
 
     List<AwsLifecycleHook> hooks = getLifecycleHooks();
     account.setLifecycleHooks(!hooks.isEmpty() ? hooks : account.getLifecycleHooks());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditFeaturesCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/aws/AwsEditFeaturesCommand.java
@@ -41,17 +41,32 @@ public class AwsEditFeaturesCommand
       required = true)
   private Boolean cloudFormation;
 
+  @Parameter(
+      names = "--lambda",
+      description = "Enable Lambda support for AWS.",
+      arity = 1,
+      required = true)
+  private Boolean lambda;
+
   protected String getProviderName() {
     return Provider.ProviderType.AWS.getName();
   }
 
   @Override
   protected Provider editProvider(AwsProvider provider) {
+    if (provider.getLambda() != null) {
+      provider.getLambda().setEnabled(lambda);
+    } else {
+      provider.setLambda(new AwsProvider.Lambda(lambda));
+    }
     if (provider.getFeatures() != null) {
       provider.getFeatures().getCloudFormation().setEnabled(cloudFormation);
+      provider.getFeatures().getLambda().setEnabled(lambda);
     } else {
       provider.setFeatures(
-          new AwsProvider.Features(new AwsProvider.Features.CloudFormation(cloudFormation)));
+          new AwsProvider.Features(
+              new AwsProvider.Features.CloudFormation(cloudFormation),
+              new AwsProvider.Features.Lambda(lambda)));
     }
     System.out.println(provider);
     return provider;

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsAccount.java
@@ -37,4 +37,5 @@ public class AwsAccount extends Account {
   private String externalId;
   private String sessionName;
   private List<AwsProvider.AwsLifecycleHook> lifecycleHooks = new ArrayList<>();
+  private Boolean lambdaEnabled;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/aws/AwsProvider.java
@@ -38,6 +38,7 @@ public class AwsProvider extends HasImageProvider<AwsAccount, AwsBakeryDefaults>
       Collections.singletonList(new AwsRegion().setName("us-west-2"));
   private AwsDefaults defaults = new AwsDefaults();
   private Features features;
+  private Lambda lambda;
 
   @Data
   public static class AwsRegion {
@@ -59,21 +60,46 @@ public class AwsProvider extends HasImageProvider<AwsAccount, AwsBakeryDefaults>
   }
 
   @Data
+  public static class Lambda {
+
+    public Lambda() {}
+
+    public Lambda(boolean enable) {
+      this.enabled = enable;
+    }
+
+    Boolean enabled;
+  }
+
+  @Data
   public static class Features {
 
     public Features() {}
 
-    public Features(CloudFormation cloudFormation) {
+    public Features(CloudFormation cloudFormation, Lambda lambda) {
       this.cloudFormation = cloudFormation;
+      this.lambda = lambda;
     }
 
     CloudFormation cloudFormation;
+    Lambda lambda;
 
     @Data
     public static class CloudFormation {
       public CloudFormation() {}
 
       public CloudFormation(Boolean enabled) {
+        this.enabled = enabled;
+      }
+
+      Boolean enabled;
+    }
+
+    @Data
+    public static class Lambda {
+      public Lambda() {}
+
+      public Lambda(Boolean enabled) {
         this.enabled = enabled;
       }
 


### PR DESCRIPTION
This PR has the purpose of add the commands in order to Enable/Disable the Lambda functions on spinnaker.

### Enable Lambda at Provider level
using the command `--lambda`

### Enable Lambda by Account 
using the command `--lambda-enabled` 

The produced yaml should be something like this:
Note the flags for Lambda at Provider level: `aws.lambda.enabled` and `aws.features.lambda.enabled` 
Lambda by Account: `aws.accounts.lambdaEnabled` 

```
spinnakerConfig:
  config:
    providers:
      aws:
        enabled: true
        lambda:
          enabled: true
        primaryAccount: aws-pa
        accounts:
        - name: aws-pa
          accountId: "999999999999"
          assumeRole: role/spinManagedRole
          lifecycleHooks: []
          permissions: {}
          lambdaEnabled: true
          providerVersion: V1
          regions:
          - name: us-west-2
        defaultKeyPairTemplate: '{{"{{"}}name{{"}}"}}-keypair'
        defaultRegions:
        - name: us-west-2
        defaults:
          iamRole: BaseIAMRole
        features:
          cloudFormation:
            enabled: false
          lambda:
            enabled: true
```
