### PR TITLE
fix(cli): fix validation of main parameters that specify arity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ subprojects {
   apply plugin: 'groovy'
 
   test {
+    useJUnitPlatform()
     testLogging {
       showStandardStreams = false
       exceptionFormat = 'full'

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -16,7 +16,7 @@ dependencies {
   implementation 'org.aspectj:aspectjweaver'
   implementation 'org.yaml:snakeyaml:1.24'
   implementation 'org.codehaus.groovy:groovy'
-  implementation 'com.beust:jcommander:1.75'
+  implementation 'com.beust:jcommander:1.81'
   implementation 'org.nibor.autolink:autolink:0.10.0'
 
   implementation project(':halyard-config')
@@ -24,6 +24,11 @@ dependencies {
   implementation project(':halyard-deploy')
   implementation project(':halyard-proto')
 
+  testImplementation 'org.assertj:assertj-core'
+  testImplementation 'uk.org.webcompere:system-stubs-jupiter:1.2.0'
+  testImplementation 'org.junit.jupiter:junit-jupiter-api'
+  testImplementation 'org.junit.jupiter:junit-jupiter-params'
+  testImplementation 'org.junit.platform:junit-platform-runner'
   testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
   testImplementation 'org.springframework:spring-test'
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestCommand.java
@@ -23,8 +23,6 @@ import com.netflix.spinnaker.halyard.cli.command.v1.DeprecatedCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -45,18 +43,14 @@ public class PublishLatestCommand extends NestableCommand implements DeprecatedC
     return "version";
   }
 
-  @Parameter(description = "The latest version of Spinnaker to record.", arity = 1)
-  List<String> versions = new ArrayList<>();
+  @Parameter(description = "The latest version of Spinnaker to record.")
+  String version;
 
   public String getVersion() {
-    switch (versions.size()) {
-      case 0:
-        throw new IllegalArgumentException("No version supplied.");
-      case 1:
-        return versions.get(0);
-      default:
-        throw new IllegalArgumentException("More than one version supplied");
+    if (version == null) {
+      throw new IllegalArgumentException("No version supplied.");
     }
+    return version;
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestHalyardCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestHalyardCommand.java
@@ -23,8 +23,6 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -42,18 +40,14 @@ public class PublishLatestHalyardCommand extends NestableCommand {
     return "version";
   }
 
-  @Parameter(description = "The latest version of Spinnaker to record.", arity = 1)
-  List<String> versions = new ArrayList<>();
+  @Parameter(description = "The latest version of Spinnaker to record.")
+  String version;
 
   public String getVersion() {
-    switch (versions.size()) {
-      case 0:
-        throw new IllegalArgumentException("No version supplied.");
-      case 1:
-        return versions.get(0);
-      default:
-        throw new IllegalArgumentException("More than one version supplied");
+    if (version == null) {
+      throw new IllegalArgumentException("No version supplied.");
     }
+    return version;
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestSpinnakerCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishLatestSpinnakerCommand.java
@@ -23,8 +23,6 @@ import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -42,18 +40,14 @@ public class PublishLatestSpinnakerCommand extends NestableCommand {
     return "version";
   }
 
-  @Parameter(description = "The latest version of Spinnaker to record.", arity = 1)
-  List<String> versions = new ArrayList<>();
+  @Parameter(description = "The latest version of Spinnaker to record.")
+  String version;
 
   public String getVersion() {
-    switch (versions.size()) {
-      case 0:
-        throw new IllegalArgumentException("No version supplied.");
-      case 1:
-        return versions.get(0);
-      default:
-        throw new IllegalArgumentException("More than one version supplied");
+    if (version == null) {
+      throw new IllegalArgumentException("No version supplied.");
     }
+    return version;
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/admin/PublishProfileCommand.java
@@ -23,8 +23,6 @@ import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -52,9 +50,8 @@ public class PublishProfileCommand extends NestableCommand {
   private String profilePath;
 
   @Parameter(
-      description = "The name of the artifact whose profile is being published (e.g. clouddriver).",
-      arity = 1)
-  List<String> artifacts = new ArrayList<>();
+      description = "The name of the artifact whose profile is being published (e.g. clouddriver).")
+  String artifact;
 
   @Override
   public String getMainParameter() {
@@ -62,14 +59,10 @@ public class PublishProfileCommand extends NestableCommand {
   }
 
   public String getArtifactName() {
-    switch (artifacts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No artifact name supplied");
-      case 1:
-        return artifacts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one artifact supplied");
+    if (artifact == null) {
+      throw new IllegalArgumentException("No artifact name supplied");
     }
+    return artifact;
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractHasArtifactAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/account/AbstractHasArtifactAccountCommand.java
@@ -21,14 +21,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.account;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.AbstractArtifactProviderCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for commands that accept ACCOUNT as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasArtifactAccountCommand extends AbstractArtifactProviderCommand {
-  @Parameter(description = "The name of the account to operate on.", arity = 1)
-  List<String> accounts = new ArrayList<>();
+  @Parameter(description = "The name of the account to operate on.")
+  String account;
 
   @Override
   public String getMainParameter() {
@@ -44,13 +42,9 @@ public abstract class AbstractHasArtifactAccountCommand extends AbstractArtifact
   }
 
   public String getArtifactAccountName() {
-    switch (accounts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No account name supplied");
-      case 1:
-        return accounts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one account supplied");
+    if (account == null) {
+      throw new IllegalArgumentException("No account name supplied");
     }
+    return account;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/AbstractHasArtifactTemplateCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/artifacts/templates/AbstractHasArtifactTemplateCommand.java
@@ -19,14 +19,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.artifacts.templates;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for commands that accept TEMPLATE as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasArtifactTemplateCommand extends AbstractConfigCommand {
-  @Parameter(description = "The name of the artifact template to operate on.", arity = 1)
-  List<String> templates = new ArrayList<>();
+  @Parameter(description = "The name of the artifact template to operate on.")
+  String template = null;
 
   @Override
   public String getMainParameter() {
@@ -42,13 +40,9 @@ public abstract class AbstractHasArtifactTemplateCommand extends AbstractConfigC
   }
 
   public String getArtifactTemplate() {
-    switch (templates.size()) {
-      case 0:
-        throw new IllegalArgumentException("No template supplied");
-      case 1:
-        return templates.get(0);
-      default:
-        throw new IllegalArgumentException("More than one template supplied");
+    if (template == null) {
+      throw new IllegalArgumentException("No template supplied");
     }
+    return template;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractHasCanaryAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/canary/account/AbstractHasCanaryAccountCommand.java
@@ -18,16 +18,14 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.canary.account;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for canary commands that accept ACCOUNT as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasCanaryAccountCommand
     extends AbstractCanaryServiceIntegrationCommand {
 
-  @Parameter(description = "The name of the canary account to operate on.", arity = 1)
-  List<String> accounts = new ArrayList<>();
+  @Parameter(description = "The name of the canary account to operate on.")
+  String account;
 
   @Override
   public String getMainParameter() {
@@ -43,13 +41,9 @@ public abstract class AbstractHasCanaryAccountCommand
   }
 
   public String getAccountName() {
-    switch (accounts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No canary account name supplied");
-      case 1:
-        return accounts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one canary account supplied");
+    if (account == null) {
+      throw new IllegalArgumentException("No canary account name supplied");
     }
+    return account;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractHasAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/account/AbstractHasAccountCommand.java
@@ -19,14 +19,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.account;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractCiCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for commands that accept 'account' as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasAccountCommand extends AbstractCiCommand {
-  @Parameter(description = "The name of the account to operate on.", arity = 1)
-  List<String> accounts = new ArrayList<>();
+  @Parameter(description = "The name of the account to operate on.")
+  String account;
 
   @Override
   public String getMainParameter() {
@@ -34,13 +32,9 @@ public abstract class AbstractHasAccountCommand extends AbstractCiCommand {
   }
 
   public String getAccountName() {
-    switch (accounts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No account name supplied");
-      case 1:
-        return accounts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one account supplied");
+    if (account == null) {
+      throw new IllegalArgumentException("No account name supplied");
     }
+    return account;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractHasMasterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/ci/master/AbstractHasMasterCommand.java
@@ -20,14 +20,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.ci.master;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.ci.AbstractCiCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for commands that accept MASTER as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasMasterCommand extends AbstractCiCommand {
-  @Parameter(description = "The name of the master to operate on.", arity = 1)
-  List<String> masters = new ArrayList<>();
+  @Parameter(description = "The name of the master to operate on.")
+  String master;
 
   @Override
   public String getMainParameter() {
@@ -35,13 +33,9 @@ public abstract class AbstractHasMasterCommand extends AbstractCiCommand {
   }
 
   public String getMasterName() {
-    switch (masters.size()) {
-      case 0:
-        throw new IllegalArgumentException("No master name supplied");
-      case 1:
-        return masters.get(0);
-      default:
-        throw new IllegalArgumentException("More than one master supplied");
+    if (master == null) {
+      throw new IllegalArgumentException("No master name supplied");
     }
+    return master;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractHasPublisherCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/notifications/pubsub/AbstractHasPublisherCommand.java
@@ -20,13 +20,11 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.notifications.pubsub
 
 import com.beust.jcommander.Parameter;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.pubsubs.AbstractPubsubCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 public abstract class AbstractHasPublisherCommand extends AbstractPubsubCommand {
 
-  @Parameter(description = "The name of the publishers to operate on.", arity = 1)
-  List<String> publishers = new ArrayList<>();
+  @Parameter(description = "The name of the publishers to operate on.")
+  String publisher;
 
   @Override
   public String getMainParameter() {
@@ -42,13 +40,9 @@ public abstract class AbstractHasPublisherCommand extends AbstractPubsubCommand 
   }
 
   public String getPublisherName() {
-    switch (publishers.size()) {
-      case 0:
-        throw new IllegalArgumentException("No topic name supplied");
-      case 1:
-        return publishers.get(0);
-      default:
-        throw new IllegalArgumentException("More than one topic supplied");
+    if (publisher == null) {
+      throw new IllegalArgumentException("No topic name supplied");
     }
+    return publisher;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractHasAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/account/AbstractHasAccountCommand.java
@@ -20,14 +20,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for commands that accept ACCOUNT as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasAccountCommand extends AbstractProviderCommand {
-  @Parameter(description = "The name of the account to operate on.", arity = 1)
-  List<String> accounts = new ArrayList<>();
+  @Parameter(description = "The name of the account to operate on.")
+  String account;
 
   @Override
   public String getMainParameter() {
@@ -43,13 +41,9 @@ public abstract class AbstractHasAccountCommand extends AbstractProviderCommand 
   }
 
   public String getAccountName() {
-    switch (accounts.size()) {
-      case 0:
-        throw new IllegalArgumentException("No account name supplied");
-      case 1:
-        return accounts.get(0);
-      default:
-        throw new IllegalArgumentException("More than one account supplied");
+    if (account == null) {
+      throw new IllegalArgumentException("No account name supplied");
     }
+    return account;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractHasBaseImageCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/bakery/AbstractHasBaseImageCommand.java
@@ -20,14 +20,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.bakery;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
-import java.util.ArrayList;
-import java.util.List;
 
-/** An abstract definition for commands that accept ACCOUNT as a main parameter */
+/** An abstract definition for commands that accept BASE-IMAGE as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasBaseImageCommand extends AbstractProviderCommand {
-  @Parameter(description = "The name of the base image to operate on.", arity = 1)
-  List<String> baseImages = new ArrayList<>();
+  @Parameter(description = "The name of the base image to operate on.")
+  String baseImage;
 
   @Override
   public String getMainParameter() {
@@ -35,13 +33,9 @@ public abstract class AbstractHasBaseImageCommand extends AbstractProviderComman
   }
 
   public String getBaseImageId() {
-    switch (baseImages.size()) {
-      case 0:
-        throw new IllegalArgumentException("No base image name supplied");
-      case 1:
-        return baseImages.get(0);
-      default:
-        throw new IllegalArgumentException("More than one base image supplied");
+    if (baseImage == null) {
+      throw new IllegalArgumentException("No base image name supplied");
     }
+    return baseImage;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/AbstractClusterCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/dcos/cluster/AbstractClusterCommand.java
@@ -3,13 +3,11 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.dcos.clust
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 @Parameters(separators = "=")
 public abstract class AbstractClusterCommand extends AbstractProviderCommand {
-  @Parameter(description = "The name of the cluster to operate on.", arity = 1)
-  List<String> clusters = new ArrayList<>();
+  @Parameter(description = "The name of the cluster to operate on.")
+  String cluster;
 
   @Override
   public String getCommandName() {
@@ -42,13 +40,9 @@ public abstract class AbstractClusterCommand extends AbstractProviderCommand {
   }
 
   public String getClusterName() {
-    switch (clusters.size()) {
-      case 0:
-        throw new IllegalArgumentException("No cluster name supplied");
-      case 1:
-        return clusters.get(0);
-      default:
-        throw new IllegalArgumentException("More than one cluster supplied");
+    if (cluster == null) {
+      throw new IllegalArgumentException("No cluster name supplied");
     }
+    return cluster;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractHasSubscriptionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/pubsubs/subscription/AbstractHasSubscriptionCommand.java
@@ -21,14 +21,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.pubsubs.subscription
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.pubsubs.AbstractPubsubCommand;
-import java.util.ArrayList;
-import java.util.List;
 
-/** An abstract definition for commands that accept ACCOUNT as a main parameter */
+/** An abstract definition for commands that accept SUBSCRIPTION as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasSubscriptionCommand extends AbstractPubsubCommand {
-  @Parameter(description = "The name of the subscription to operate on.", arity = 1)
-  List<String> subscriptions = new ArrayList<>();
+  @Parameter(description = "The name of the subscription to operate on.")
+  String subscription;
 
   @Override
   public String getMainParameter() {
@@ -44,13 +42,9 @@ public abstract class AbstractHasSubscriptionCommand extends AbstractPubsubComma
   }
 
   public String getSubscriptionName() {
-    switch (subscriptions.size()) {
-      case 0:
-        throw new IllegalArgumentException("No subscription name supplied");
-      case 1:
-        return subscriptions.get(0);
-      default:
-        throw new IllegalArgumentException("More than one subscription supplied");
+    if (subscription == null) {
+      throw new IllegalArgumentException("No subscription name supplied");
     }
+    return subscription;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/repository/search/AbstractHasSearchCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/repository/search/AbstractHasSearchCommand.java
@@ -19,14 +19,12 @@ package com.netflix.spinnaker.halyard.cli.command.v1.config.repository.search;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.repository.AbstractRepositoryCommand;
-import java.util.ArrayList;
-import java.util.List;
 
 /** An abstract definition for commands that accept SEARCH as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasSearchCommand extends AbstractRepositoryCommand {
-  @Parameter(description = "The name of the search to operate on.", arity = 1)
-  List<String> searches = new ArrayList<>();
+  @Parameter(description = "The name of the search to operate on.")
+  String search;
 
   @Override
   public String getMainParameter() {
@@ -34,13 +32,9 @@ public abstract class AbstractHasSearchCommand extends AbstractRepositoryCommand
   }
 
   public String getSearchName() {
-    switch (searches.size()) {
-      case 0:
-        throw new IllegalArgumentException("No search name supplied");
-      case 1:
-        return searches.get(0);
-      default:
-        throw new IllegalArgumentException("More than one search supplied");
+    if (search == null) {
+      throw new IllegalArgumentException("No search name supplied");
     }
+    return search;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AbstractHasPluginCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/plugins/AbstractHasPluginCommand.java
@@ -22,14 +22,12 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.plugins.Plugin;
-import java.util.ArrayList;
-import java.util.List;
 
-/** An abstract definition for commands that accept plugins as a main parameter */
+/** An abstract definition for commands that accept PLUGIN as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasPluginCommand extends AbstractConfigCommand {
-  @Parameter(description = "The name of the plugin to operate on.", arity = 1)
-  private List<String> plugins = new ArrayList<>();
+  @Parameter(description = "The name of the plugin to operate on.")
+  private String plugin;
 
   @Override
   public String getMainParameter() {
@@ -39,18 +37,14 @@ public abstract class AbstractHasPluginCommand extends AbstractConfigCommand {
   public Plugin getPlugin() {
     return new OperationHandler<Plugin>()
         .setFailureMesssage("Failed to get plugin")
-        .setOperation(Daemon.getPlugin(getCurrentDeployment(), plugins.get(0), false))
+        .setOperation(Daemon.getPlugin(getCurrentDeployment(), getPluginName(), false))
         .get();
   }
 
   public String getPluginName() {
-    switch (plugins.size()) {
-      case 0:
-        throw new IllegalArgumentException("No plugin supplied");
-      case 1:
-        return plugins.get(0);
-      default:
-        throw new IllegalArgumentException("More than one plugin supplied");
+    if (plugin == null) {
+      throw new IllegalArgumentException("No plugin supplied");
     }
+    return plugin;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/repositories/AbstractHasPluginRepositoryCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/repositories/AbstractHasPluginRepositoryCommand.java
@@ -22,14 +22,12 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.AbstractConfigCommand
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
 import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.config.model.v1.plugins.PluginRepository;
-import java.util.ArrayList;
-import java.util.List;
 
-/** An abstract definition for commands that accept plugins as a main parameter */
+/** An abstract definition for commands that accept REPOSITORY as a main parameter */
 @Parameters(separators = "=")
 public abstract class AbstractHasPluginRepositoryCommand extends AbstractConfigCommand {
-  @Parameter(description = "The name of the plugin repository to operate on.", arity = 1)
-  private List<String> repositories = new ArrayList<>();
+  @Parameter(description = "The name of the plugin repository to operate on.")
+  private String repository;
 
   @Override
   public String getMainParameter() {
@@ -40,18 +38,14 @@ public abstract class AbstractHasPluginRepositoryCommand extends AbstractConfigC
     return new OperationHandler<PluginRepository>()
         .setFailureMesssage("Failed to get repository")
         .setOperation(
-            Daemon.getPluginRepository(getCurrentDeployment(), repositories.get(0), false))
+            Daemon.getPluginRepository(getCurrentDeployment(), getPluginRepositoryId(), false))
         .get();
   }
 
   public String getPluginRepositoryId() {
-    switch (repositories.size()) {
-      case 0:
-        throw new IllegalArgumentException("No plugin repository supplied");
-      case 1:
-        return repositories.get(0);
-      default:
-        throw new IllegalArgumentException("More than one plugin repository supplied");
+    if (repository == null) {
+      throw new IllegalArgumentException("No plugin repository supplied");
     }
+    return repository;
   }
 }

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/task/InterruptTaskCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/task/InterruptTaskCommand.java
@@ -21,8 +21,6 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 import com.netflix.spinnaker.halyard.cli.command.v1.NestableCommand;
 import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 
@@ -39,18 +37,14 @@ public class InterruptTaskCommand extends NestableCommand {
     return "uuid";
   }
 
-  @Parameter(description = "The UUID of the task to interrupt", arity = 1)
-  List<String> uuids = new ArrayList<>();
+  @Parameter(description = "The UUID of the task to interrupt")
+  String uuid;
 
   private String getUuid() {
-    switch (uuids.size()) {
-      case 0:
-        throw new IllegalArgumentException("No UUID supplied.");
-      case 1:
-        return uuids.get(0);
-      default:
-        throw new IllegalArgumentException("More than one UUID supplied");
+    if (uuid == null) {
+      throw new IllegalArgumentException("No UUID supplied.");
     }
+    return uuid;
   }
 
   @Override

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/versions/BomVersionCommand.java
@@ -26,15 +26,13 @@ import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils;
 import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiPrinter;
 import com.netflix.spinnaker.halyard.core.registry.v1.BillOfMaterials;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 
 @Parameters(separators = "=")
 public class BomVersionCommand extends AbstractConfigCommand {
-  @Parameter(description = "The version whose Bill of Materials (BOM) to lookup.", arity = 1)
-  List<String> versions = new ArrayList<>();
+  @Parameter(description = "The version whose Bill of Materials (BOM) to lookup.")
+  String version;
 
   @Getter(AccessLevel.PUBLIC)
   private String commandName = "bom";
@@ -63,17 +61,13 @@ public class BomVersionCommand extends AbstractConfigCommand {
   }
 
   public String getVersion() {
-    switch (versions.size()) {
-      case 0:
-        return new OperationHandler<String>()
-            .setOperation(Daemon.getVersion(getCurrentDeployment(), false))
-            .setFailureMesssage("Failed to get version of Spinnaker configured in your halconfig.")
-            .get();
-      case 1:
-        return versions.get(0);
-      default:
-        throw new IllegalArgumentException("More than one version supplied");
+    if (version == null) {
+      return new OperationHandler<String>()
+          .setOperation(Daemon.getVersion(getCurrentDeployment(), false))
+          .setFailureMesssage("Failed to get version of Spinnaker configured in your halconfig.")
+          .get();
     }
+    return version;
   }
 
   @Override

--- a/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
+++ b/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2021 Salesforce, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.halyard.cli.command.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitPlatform.class)
+class HalCommandTest {
+
+  private HalCommand hal;
+
+  private JCommander jc;
+
+  private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+  private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+  private final PrintStream originalOut = System.out;
+  private final PrintStream originalErr = System.err;
+
+  @BeforeEach
+  void setup(TestInfo testInfo) {
+    System.setOut(new PrintStream(outContent));
+    System.setErr(new PrintStream(errContent));
+    System.out.println("--------------- Test " + testInfo.getDisplayName());
+
+    hal = new HalCommand();
+    jc = new JCommander(hal);
+    jc.setVerbose(1);
+    hal.setCommander(jc).configureSubcommands();
+  }
+
+  @AfterEach
+  public void restoreStreams() {
+    System.setOut(originalOut);
+    System.setErr(originalErr);
+  }
+
+  @ParameterizedTest(name = "noArgsWhenOneIsRequired {0}")
+  @MethodSource("commandProvider")
+  void noArgsWhenOneIsRequired(String[] args, String expectedMessage) throws Exception {
+    // jcommander's validation isn't enough to fail in this case.  It is if we
+    // specify arity = 1, but then correctly passing one argument also fails, so
+    // we rely on validation in halyard to catch this, which doesn't happen
+    // until executing the command.
+    jc.parse(args);
+
+    catchSystemExit(() -> hal.execute());
+
+    assertThat(errContent.toString()).contains(expectedMessage);
+  }
+
+  @ParameterizedTest(name = "oneArgWhenOneIsRequired {0}")
+  @MethodSource("commandProvider")
+  void oneArgWhenOneIsRequired(String[] args) throws Exception {
+    jc.parse(ArrayUtils.add(args, "foo"));
+
+    // Here, running hal.execute() actually attempts to connect to the halyard
+    // daemon since the command is valid.
+    catchSystemExit(() -> hal.execute());
+
+    assertThat(errContent.toString()).contains("Is your daemon running");
+  }
+
+  @ParameterizedTest(name = "twoArgsWhenOneIsRequired {0}")
+  @MethodSource("commandProvider")
+  void twoArgsWhenOneIsRequired(String[] args) {
+    // And here, jcommander's built-in validation catches the error.  Perhaps
+    // one day specifying "arity = 1" in the relevant @Parameter annotations
+    // will work, and then the message to expect is "There should be exactly 1
+    // main parameters but 2 were found".
+    assertThatThrownBy(() -> jc.parse(ArrayUtils.addAll(args, "foo", "bar")))
+        .isInstanceOf(ParameterException.class)
+        .hasMessageContaining("Only one main parameter allowed but found several");
+  }
+
+  void testHalyardVersionBomNoArgs() throws Exception {
+    // hal version bom takes an optional VERSION.  So it's supposed to work with
+    // no args.
+    String[] args = {"hal", "version", "bom", "--deployment", "deployment"};
+    jc.parse(args);
+    catchSystemExit(() -> hal.execute());
+
+    assertThat(errContent.toString()).contains("Failed to get version of Spinnaker");
+  }
+
+  void testHalyardVersionBomOneArg() throws Exception {
+    // hal version bom takes an optional VERSION.  So it's supposed to work with
+    // 1 arg.
+    String[] args = {"hal", "version", "bom", "my-bom-version"};
+    jc.parse(args);
+    catchSystemExit(() -> hal.execute());
+
+    assertThat(errContent.toString()).contains("Is your daemon foo");
+  }
+
+  void testHalyardVersionBomMoreThanOneArg() {
+    // hal version bom takes an optional VERSION, but more than one is invalid
+    String[] args = {"hal", "version", "bom", "my-bom-version", "another-bom-version"};
+    assertThatThrownBy(() -> jc.parse(ArrayUtils.addAll(args)))
+        .isInstanceOf(ParameterException.class)
+        .hasMessageContaining("Only one main parameter allowed but found several");
+  }
+
+  // Inspired by https://stackoverflow.com/a/46931618
+  static Stream<Arguments> commandProvider() {
+    // These are examples of commands that require on argument...not an
+    // exhaustive list.  It attempts to cover all the base classes that declare
+    // things like accounts that require one name, but not all the child
+    // classes.  For example, for providers/account/AbstractHasAccountCommand,
+    // any account command for any provider is sufficient.
+    return Stream.of(
+        Arguments.of((Object) new String[] {"admin", "publish", "latest"}, "No version supplied"),
+        Arguments.of(
+            (Object) new String[] {"admin", "publish", "latest-halyard"}, "No version supplied"),
+        Arguments.of(
+            (Object) new String[] {"admin", "publish", "latest-spinnaker"}, "No version supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {
+                  "admin", "publish", "profile", "--bom-path", "path", "--profile-path", "path"
+                },
+            "No artifact name supplied"),
+        Arguments.of(
+            (Object) new String[] {"config", "artifact", "gcs", "account", "add"},
+            "No account name supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {
+                  "config", "artifact", "templates", "delete", "--deployment", "my-deploy"
+                },
+            "No template supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {"config", "ci", "codebuild", "account", "add", "--region", "region"},
+            "No account name supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {"config", "ci", "jenkins", "master", "add", "--address", "address"},
+            "No master name supplied"),
+        Arguments.of(
+            (Object) new String[] {"config", "notification", "pubsub", "google", "add"},
+            "No topic name supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {
+                  "config",
+                  "provider",
+                  "azure",
+                  "bakery",
+                  "base-image",
+                  "add",
+                  "--publisher",
+                  "publisher",
+                  "--sku",
+                  "sku",
+                  "--offer",
+                  "offer"
+                },
+            "No base image name supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {"config", "provider", "dcos", "cluster", "add", "--dcos-url", "url"},
+            "No cluster name supplied"),
+        Arguments.of(
+            (Object) new String[] {"config", "provider", "kubernetes", "account", "add"},
+            "No account name supplied"),
+        Arguments.of(
+            (Object) new String[] {"config", "pubsub", "google", "subscription", "add"},
+            "No subscription name supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {
+                  "config",
+                  "repository",
+                  "artifactory",
+                  "search",
+                  "add",
+                  "--username",
+                  "user",
+                  "--password",
+                  "password",
+                  "--repo",
+                  "repo",
+                  "--base-url",
+                  "url",
+                  "--groupId",
+                  "groupId"
+                },
+            "No search name supplied"),
+        Arguments.of(
+            (Object) new String[] {"plugins", "repository", "add", "--url", "url"},
+            "No plugin repository supplied"),
+        Arguments.of(
+            (Object)
+                new String[] {
+                  "task", "interrupt",
+                },
+            "No UUID supplied"));
+
+    // Testing canary commands doesn't work in this setup, as they try to
+    // contact the daemon to get canary information before the "real" command.
+    // Perhaps mocking the (static) Daemon methods makes for a cleaner, more
+    // complete test?  Until then, commenting this out.
+    // Arguments.of((Object)new String[]{"config", "canary", "aws", "account", "add",
+    // "--deployment", "my-deploy"}, "No canary account name supplied")
+
+    // For some reason, this command causes hal.execute to output "null"...
+    // Arguments.of((Object)new String[]{"plugins", "add", "--deployment", "deployment"}, "No plugin
+    // supplied")
+  }
+}


### PR DESCRIPTION
https://github.com/spinnaker/halyard/pull/1894 brought in version 1.75 of
com.beust:jcommander where we previously had 1.71.  1.75 includes
https://github.com/cbeust/jcommander/commit/192ec8695636e6793dfbebd8aaab2f1d467b922e which
adds additional arity validation, which causes halyard commands with main parameters that
specify an arity to fail.  I suspect it's a bug in jcommander, but...

1.75 also includes
https://github.com/cbeust/jcommander/commit/d51a5b722331c2b69bbf86c238a14a9a396c3b44 which
allows us to replace List<String> and arity of 1 with String, simplifying our code.  It
would be nice for jcommander's validation to handle the missing case, but this is still
simpler than what we had before, and works.

Bumping to 1.81 at the same time to stay up to date, and to demonstrate that specifying
arity = 1 still doesn't work with 1.81, but these fixes do.

FWIW, I searched for the parameters to change with:
```
$ git grep -A 1 'arity = 1'  | grep List
```