### PR TITLE
fix(halyard-proto): Removed specified version for com.google.protobuf:protobuf-java

### DIFF
--- a/halyard-proto/halyard-proto.gradle
+++ b/halyard-proto/halyard-proto.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.google.protobuf'
 
 dependencies {
-  implementation 'com.google.protobuf:protobuf-java:3.0.0'
+  implementation 'com.google.protobuf:protobuf-java'
   implementation 'com.google.guava:guava:23.5-jre'
   api 'com.google.api.grpc:grpc-google-common-protos:1.0.5'
   implementation 'io.grpc:grpc-all:1.8.0'


### PR DESCRIPTION
Getting below conflict between spring plugin and protobuf plugin while upgrading spring boot 2.2.x(existing kork) to 2.3.x:

```"> Task :halyard-proto:generateProto FAILED> Task :halyard-core:compileJava
Note: /halyard/halyard-core/src/main/java/com/netflix/spinnaker/halyard/core/resource/v1/JarResourceReader.java uses or overrides a deprecated API.
Note: Recompile with -Xlint:deprecation for details.
Note: Some input files use unchecked or unsafe operations.
Note: Recompile with -Xlint:unchecked for details.FAILURE: Build failed with an exception.* What went wrong:
Execution failed for task ':halyard-proto:generateProto'.
> protoc: stdout: . stderr: google/longrunning/operations.proto:33:8: Option ""php_namespace"" unknown.
  deployments.proto: Import ""google/longrunning/operations.proto"" was not found or had errors.
  deployments.proto:13:50: ""google.longrunning.Operation"" is not defined."
```
Removing specified version of protobuf-java have no impact on current springboot version however will rectify an upcoming issue with springboot 2.3.12.
It is raised after verifying the effect of upgrading Kork with Springboot version.