### PR TITLE
fix(provider/kubernetes): Clouddriver is not foud  config file 1342040884-config

### DIFF
--- a/halyard-deploy/src/main/resources/kubernetes/manifests/clouddriver.yml
+++ b/halyard-deploy/src/main/resources/kubernetes/manifests/clouddriver.yml
@@ -23,3 +23,5 @@ spec:
         image: {{ image }}
         ports:
         - containerPort: 80
+        securityContext:
+          runAsUser: 0


### PR DESCRIPTION
Fix "File /root/.hal/default/staging/dependencies/1342040884-config is not found"
https://github.com/spinnaker/spinnaker/issues/6573