### PR TITLE
Fix link to stats

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/StatsValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/StatsValidator.java
@@ -27,7 +27,7 @@ public class StatsValidator extends Validator<Stats> {
     }
 
     msg.append("To learn more about what and how stats data is used, please see ");
-    msg.append("https://www.spinnaker.io/community/stats.");
+    msg.append("https://spinnaker.io/docs/community/stay-informed/stats.");
     p.addProblem(Severity.INFO, msg.toString());
   }
 }


### PR DESCRIPTION
Noticed this message while running Halyard, which points to 404 page:
```
 INFO Stats are currently ENABLED. Usage statistics are being
  collected. Thank you! These stats inform improvements to the product, and that
  helps the community. To disable, run `hal config stats disable`. To learn more
  about what and how stats data is used, please see
  https://www.spinnaker.io/community/stats.
```
Looks like the site is accessible under new address?