### PR TITLE
fix(install): Support Java17 for Halyard Installation on MacOS

### DIFF
--- a/install/macos/InstallHalyard.sh
+++ b/install/macos/InstallHalyard.sh
@@ -157,6 +157,7 @@ function install_java() {
      [[ "$java_version" == *"13"* ]] || \
      [[ "$java_version" == *"14"* ]] || \
      [[ "$java_version" == *"16"* ]] || \
+     [[ "$java_version" == *"17"* ]] || \
      [[ "$java_version" == "java version \"10\""* ]]; then
     echo "Java is already installed & at the right version"
     return 0;


### PR DESCRIPTION
Added Java17 support for Halyard Installation on MacOS