### PR TITLE
Fix bugs in systemd service preventing halyard daemon from starting

### DIFF
--- a/halyard-web/lib/systemd/system/halyard.service
+++ b/halyard-web/lib/systemd/system/halyard.service
@@ -4,9 +4,9 @@ Description=A tool for managing the lifecycle of a Spinnaker installation
 [Service]
 Restart=always
 RestartSec=10
-Type=forking
-ExecStart=
-ExecStart=sudo -u $(cat /var/spinnaker/config/halyard-user) -g $(cat /var/spinnaker/config/halyard-user) /opt/halyard/bin/halyard 2>&1 > /var/log/spinnaker/halyard/halyard.log &
+Type=simple
+ExecStart=/opt/halyard/bin/halyard
+User=spinnaker
 
 [Install]
 WantedBy=user.target

--- a/halyard-web/pkg_scripts/postInstall.sh
+++ b/halyard-web/pkg_scripts/postInstall.sh
@@ -5,13 +5,21 @@ echo '/opt/halyard/bin/hal "$@"' | sudo tee -a /usr/local/bin/hal > /dev/null
 
 chmod +x /usr/local/bin/hal
 
-HAL_USER=""
-if [ -f "/opt/spinnaker/config/halyard-user" ]; then
+if [ -f "/opt/spinnaker/config/halyard-user" ];
+then
   HAL_USER=$(cat /opt/spinnaker/config/halyard-user)
-fi
-
-if [ -z "$HAL_USER" ]; then
-  HAL_USER="ubuntu"
+else
+  HAL_USER=spinnaker
+  getent passwd spinnaker > /dev/null
+  if [ $? -gt 0 ]; then
+    useradd -s /bin/bash $HAL_USER
+  fi
+  if [ ! -f "/opt/spinnaker/config/halyard-user" ];
+  then
+    mkdir -p /opt/spinnaker/config
+    chown -R spinnaker:spinnaker /opt/spinnaker
+    echo ${HAL_USER} > /opt/spinnaker/config/halyard-user
+  fi
 fi
 
 install --mode=755 --owner=$HAL_USER --group=$HAL_USER --directory /var/log/spinnaker/halyard


### PR DESCRIPTION
1. Fixed bugs in systemd service.
2. Create spinnaker user in postinst script if it does not exist.
3. Set default user in postinst script to spinnaker instead of ubuntu.