### PR TITLE
fix(provider/google): Added support to service account impersonation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8896,6 +8896,8 @@ hal config provider google account add ACCOUNT [parameters]
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--image-projects`: (*Default*: `[]`) A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See [https://cloud.google.com/compute/docs/images/sharing-images-across-projects](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) for more information about sharing images across GCP projects.
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
+ * `--service-account-id`: The service account to be impersonated.
+ * `--service-account-project`: The google cloud project associated with the service account to be impersonated.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: (*Required*) The Google Cloud Platform project this Spinnaker account will manage.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
@@ -8942,6 +8944,8 @@ hal config provider google account edit ACCOUNT [parameters]
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--image-projects`: A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See [https://cloud.google.com/compute/docs/images/sharing-images-across-projects](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) for more information about sharing images across GCP projects.
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
+ * `--service-account-id`: The service account to be impersonated.
+ * `--service-account-project`: The google cloud project associated with the service account to be impersonated. 
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: The Google Cloud Platform project this Spinnaker account will manage.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8896,13 +8896,13 @@ hal config provider google account add ACCOUNT [parameters]
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--image-projects`: (*Default*: `[]`) A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See [https://cloud.google.com/compute/docs/images/sharing-images-across-projects](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) for more information about sharing images across GCP projects.
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
- * `--service-account-id`: The service account to be impersonated.
- * `--service-account-project`: The google cloud project associated with the service account to be impersonated.
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: (*Required*) The Google Cloud Platform project this Spinnaker account will manage.
  * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
  * `--regions`: A list of regions for caching and mutating calls. This overwrites any default-regions set on the provider.
  * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
+ * `--service-account-id`: The service account to be impersonated.
+ * `--service-account-project`: The google cloud project associated with the service account to be impersonated.
  * `--user-data`: The path to user data template file. Spinnaker has the ability to inject userdata into generated instance templates. The mechanism is via a template file that is token replaced to provide some specifics about the deployment. See [https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md) for more information.
  * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
 
@@ -8944,8 +8944,6 @@ hal config provider google account edit ACCOUNT [parameters]
  * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
  * `--image-projects`: A list of Google Cloud Platform projects Spinnaker will be able to cache and deploy images from. When this is omitted, it defaults to the current project. Each project must have granted the IAM role `compute.imageUser` to the service account associated with the json key used by this account, as well as to the 'Google APIs service account' automatically created for the project being managed (should look similar to `12345678912@cloudservices.gserviceaccount.com`). See [https://cloud.google.com/compute/docs/images/sharing-images-across-projects](https://cloud.google.com/compute/docs/images/sharing-images-across-projects) for more information about sharing images across GCP projects.
  * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
- * `--service-account-id`: The service account to be impersonated.
- * `--service-account-project`: The google cloud project associated with the service account to be impersonated. 
  * `--no-validate`: (*Default*: `false`) Skip validation.
  * `--project`: The Google Cloud Platform project this Spinnaker account will manage.
  * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
@@ -8956,6 +8954,8 @@ hal config provider google account edit ACCOUNT [parameters]
  * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
  * `--remove-write-permission`: Remove this permission to from list of write permissions.
  * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
+ * `--service-account-id`: The service account to be impersonated.
+ * `--service-account-project`: The google cloud project associated with the service account to be impersonated.
  * `--set-alpha-listed`: Enable this flag if your project has access to alpha features and you want Spinnaker to take advantage of them.
  * `--user-data`: The path to user data template file. Spinnaker has the ability to inject userdata into generated instance templates. The mechanism is via a template file that is token replaced to provide some specifics about the deployment. See [https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-aws/UserData.md) for more information.
  * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/google/CommonGoogleCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/google/CommonGoogleCommandProperties.java
@@ -26,6 +26,10 @@ public class CommonGoogleCommandProperties {
           + "or needs permissions not afforded to the VM it is running on. "
           + "See https://cloud.google.com/compute/docs/access/service-accounts for more information.";
 
+  public static final String SERVICE_ACCOUNT_ID = "The service account to be impersonated.";
+
+  public static final String SERVICE_ACCOUNT_PROJECT =
+      "The google cloud project associated with the service account to be impersonated.";
   public static final String USER_DATA_DESCRIPTION =
       "The path to user data template file. "
           + "Spinnaker has the ability to inject userdata into generated instance templates. "

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/google/GoogleAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/google/GoogleAddAccountCommand.java
@@ -44,6 +44,16 @@ public class GoogleAddAccountCommand extends AbstractAddAccountCommand {
   private String jsonPath;
 
   @Parameter(
+      names = "--service-account-id",
+      description = CommonGoogleCommandProperties.SERVICE_ACCOUNT_ID)
+  private String serviceAccountId;
+
+  @Parameter(
+      names = "--service-account-project",
+      description = CommonGoogleCommandProperties.SERVICE_ACCOUNT_PROJECT)
+  private String serviceAccountProject;
+
+  @Parameter(
       names = "--image-projects",
       variableArity = true,
       description = GoogleCommandProperties.IMAGE_PROJECTS_DESCRIPTION)
@@ -70,7 +80,13 @@ public class GoogleAddAccountCommand extends AbstractAddAccountCommand {
   @Override
   protected Account buildAccount(String accountName) {
     GoogleAccount account = (GoogleAccount) new GoogleAccount().setName(accountName);
-    account = (GoogleAccount) account.setJsonPath(jsonPath).setProject(project);
+    account =
+        (GoogleAccount)
+            account
+                .setJsonPath(jsonPath)
+                .setProject(project)
+                .setServiceAccountId(serviceAccountId)
+                .setServiceAccountProject(serviceAccountProject);
 
     account
         .setAlphaListed(alphaListed)

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/google/GoogleEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/google/GoogleEditAccountCommand.java
@@ -41,6 +41,16 @@ public class GoogleEditAccountCommand extends AbstractEditAccountCommand<GoogleA
   private String jsonPath;
 
   @Parameter(
+      names = "--service-account-id",
+      description = CommonGoogleCommandProperties.SERVICE_ACCOUNT_ID)
+  private String serviceAccountId;
+
+  @Parameter(
+      names = "--service-account-project",
+      description = CommonGoogleCommandProperties.SERVICE_ACCOUNT_PROJECT)
+  private String serviceAccountProject;
+
+  @Parameter(
       names = "--image-projects",
       variableArity = true,
       description = GoogleCommandProperties.IMAGE_PROJECTS_DESCRIPTION)
@@ -89,6 +99,10 @@ public class GoogleEditAccountCommand extends AbstractEditAccountCommand<GoogleA
   protected Account editAccount(GoogleAccount account) {
     account.setJsonPath(isSet(jsonPath) ? jsonPath : account.getJsonPath());
     account.setProject(isSet(project) ? project : account.getProject());
+    account.setServiceAccountId(
+        isSet(serviceAccountId) ? serviceAccountId : account.getServiceAccountId());
+    account.setServiceAccountProject(
+        isSet(serviceAccountProject) ? serviceAccountProject : account.getServiceAccountProject());
     account.setAlphaListed(alphaListed != null ? alphaListed : account.isAlphaListed());
     account.setUserDataFile(userDataFile != null ? userDataFile : account.getUserDataFile());
 

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/CommonGoogleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/CommonGoogleAccount.java
@@ -31,4 +31,6 @@ import lombok.ToString;
 public class CommonGoogleAccount extends Account {
   private String project;
   @LocalFile @SecretFile private String jsonPath;
+  private String serviceAccountId;
+  private String serviceAccountProject;
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/google/GoogleAccount.java
@@ -47,7 +47,9 @@ public class GoogleAccount extends CommonGoogleAccount implements Cloneable, Sup
   @JsonIgnore
   public GoogleNamedAccountCredentials getNamedAccountCredentials(
       String version, String jsonKey, ConfigProblemSetBuilder p) {
-    if (jsonKey == null) {
+    String serviceAccountId = getServiceAccountId();
+    String serviceAccountProject = getServiceAccountProject();
+    if (jsonKey == null && (serviceAccountId == null || serviceAccountProject == null)) {
       return null;
     } else if (jsonKey.isEmpty()) {
       p.addProblem(Problem.Severity.WARNING, "The supplied credentials file is empty.");
@@ -62,6 +64,8 @@ public class GoogleAccount extends CommonGoogleAccount implements Cloneable, Sup
       return new GoogleNamedAccountCredentials.Builder()
           .jsonKey(jsonKey)
           .project(getProject())
+          .serviceAccountId(serviceAccountId)
+          .serviceAccountProject(serviceAccountProject)
           .computeVersion(isAlphaListed() ? ComputeVersion.ALPHA : ComputeVersion.DEFAULT)
           .imageProjects(getImageProjects())
           .applicationName("halyard " + version)


### PR DESCRIPTION
This is to address the issue [ #6660](https://github.com/spinnaker/spinnaker/issues/6660)

Two new fields(serviceAccountId & serviceAccountProject) need to be added to google account fields in hal config which will be used in clouddriver for service account impersonation. 

Updated hal commands documentation as well.