### PR TITLE
fix(cli): Fix health response type

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/Daemon.java
@@ -51,7 +51,17 @@ import retrofit.converter.JacksonConverter;
 @Slf4j
 public class Daemon {
   public static boolean isHealthy() {
-    return getService().getHealth().get("status").equalsIgnoreCase("up");
+    // Hal /health endpoint can return:
+    // {
+    //   "status" : "UP",
+    //   "groups" : [ "liveness", "readiness" ]
+    // }
+    // So the return type must be Map<String, Object>
+    Object status = getService().getHealth().get("status");
+    if (status instanceof String) {
+      return ((String) status).equalsIgnoreCase("up");
+    }
+    return false;
   }
 
   public static String shutdown() {

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/services/v1/DaemonService.java
@@ -37,8 +37,14 @@ import retrofit.client.Response;
 import retrofit.http.*;
 
 public interface DaemonService {
+  // Hal /health endpoint can return:
+  // {
+  //   "status" : "UP",
+  //   "groups" : [ "liveness", "readiness" ]
+  // }
+  // So the return type must be Map<String, Object>
   @GET("/health")
-  Map<String, String> getHealth();
+  Map<String, Object> getHealth();
 
   @POST("/shutdown")
   Map<String, String> shutdown(@Body StringBodyRequest _ignore);


### PR DESCRIPTION
Hal /health endpoint can return:
{
  "status" : "UP",
  "groups" : [ "liveness", "readiness" ]
}

So the return type must be Map<String, Object>
instead of Map<String, String>

Fixes: https://github.com/spinnaker/spinnaker/issues/6655