### PR TITLE
chore(dependencies): update protobuf/protoc for m1 support

### DIFF
--- a/halyard-proto/halyard-proto.gradle
+++ b/halyard-proto/halyard-proto.gradle
@@ -12,11 +12,11 @@ dependencies {
 
 protobuf {
   protoc {
-    artifact = 'com.google.protobuf:protoc:3.5.1-1'
+    artifact = 'com.google.protobuf:protoc:3.19.4'
   }
   plugins {
     grpc {
-      artifact = "io.grpc:protoc-gen-grpc-java:1.9.0"
+      artifact = "io.grpc:protoc-gen-grpc-java:1.45.1"
     }
   }
 


### PR DESCRIPTION
Allow successfull build on M1 mac
This change is similar to: https://github.com/spinnaker/clouddriver/pull/5765

Relevant discussion: https://github.com/spinnaker/clouddriver/pull/5752#issuecomment-1214587680