### PR TITLE
fix(install): Fixed bugs in Halyard Debian installtion scripts that broke the repos, and also fixed the deprecation warnings for '--force-yes' when installing apt packages

### DIFF
--- a/halyard-deploy/src/main/resources/debian/install-component.sh
+++ b/halyard-deploy/src/main/resources/debian/install-component.sh
@@ -1,1 +1,1 @@
-apt-get install -y --force-yes --allow-unauthenticated spinnaker-{%artifact%}={%version%}
+apt-get install -y --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages spinnaker-{%artifact%}={%version%}


### PR DESCRIPTION
1. Halyard installation script on Debian package installation was configuring the Spinnaker and Redis repos incorrectly, which resulted in errors when running `apt update`.
2. There were various deprecation warnings when using `--force-yes` with `apt-get install`.