### PR TITLE
fix(install): Fixed various bugs in the Debian installation scripts

### DIFF
--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRedisService.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/service/local/debian/LocalDebianRedisService.java
@@ -54,7 +54,7 @@ public class LocalDebianRedisService extends RedisService implements LocalDebian
 
   @Override
   public String installArtifactCommand(DeploymentDetails deploymentDetails) {
-    return "apt-get -q -y --force-yes install redis-server && (systemctl start redis-server.service || true)";
+    return "apt-get -q -y --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install redis-server && (systemctl start redis-server.service || true)";
   }
 
   @Override

--- a/halyard-deploy/src/main/resources/debian/init.sh
+++ b/halyard-deploy/src/main/resources/debian/init.sh
@@ -1,23 +1,4 @@
-source /etc/os-release
-
-if [ "$VERSION_ID" = "14.04" ]; then
-  cat > /etc/init/spinnaker.conf <<EOL
-description "spinnaker"
-start on filesystem or runlevel [2345]
-stop on shutdown
-pre-start script
-  for i in {%services%}
-  do
-    if [ ! -d "/var/log/spinnaker/\$i" ]; then
-      echo "/var/log/spinnaker/\$i does not exist. Creating it..."
-      install --mode=755 --owner=spinnaker --group=spinnaker --directory /var/log/spinnaker/\$i
-    fi
-    service \$i start
-  done
-end script
-EOL
-else
-  cat > /lib/systemd/system/spinnaker.service <<EOL
+cat > /lib/systemd/system/spinnaker.service <<EOL
 [Unit]
 Description=All Spinnaker services
 After=network.target
@@ -29,4 +10,3 @@ RemainAfterExit=yes
 [Install]
 WantedBy=multi-user.target
 EOL
-fi

--- a/halyard-deploy/src/main/resources/debian/install.sh
+++ b/halyard-deploy/src/main/resources/debian/install.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 ## auto-generated debian install file written by halyard
+## which is executed when running 'hal deploy apply'.
 
 set -e
 set -o pipefail
@@ -8,7 +9,7 @@ set -o pipefail
 # install redis as a local service
 INSTALL_REDIS="{%install-redis%}"
 
-# install first-time spinnaker dependencies (java, setup apt repos)
+# install first-time spinnaker dependencies (setup apt repos)
 PREPARE_ENVIRONMENT="{%prepare-environment%}"
 
 REPOSITORY_URL="{%debian-repository%}"
@@ -40,74 +41,35 @@ else
 fi
 
 if [ "$DISTRO" = "Ubuntu" ]; then
-  if [ "${DISTRIB_RELEASE%%.*}" -lt "14" ]; then
+  if [ "${DISTRIB_RELEASE%%.*}" -lt "18" ]; then
     echo_err "Not a supported version of Ubuntu"
-    echo_err "Version is $DISTRIB_RELEASE we require 14.04 or greater."
+    echo_err "Version is $DISTRIB_RELEASE we require 18.04 or greater."
     exit 1
   fi
 else
   echo_err "Not a supported operating system: " $DISTRO
-  echo_err "It's recommended you use Ubuntu 14.04 or greater."
+  echo_err "It's recommended you use Ubuntu 18.04 or greater."
   echo_err ""
   echo_err "Please file an issue against https://github.com/spinnaker/spinnaker/issues"
   echo_err "if you'd like to see support for your OS and version"
   exit 1
 fi
 
-function add_redis_apt_repository() {
-  # Only Ubuntu prior to 18.04 LTS requires this PPA
-  if [ "${DISTRIB_RELEASE%%.*}" -lt "18" ]; then
-    echo "Adding Redis PPA repository for Ubuntu version less than 18.04"
-    add-apt-repository -y ppa:chris-lea/redis-server
-  fi
-}
-
 function add_spinnaker_apt_repository() {
-  echo "Adding Spinnaker apt repository"
-  REPOSITORY_HOST=$(echo $REPOSITORY_URL | cut -d/ -f3)
-  echo "deb [arch=all] $REPOSITORY_URL apt main" | tee /etc/apt/sources.list.d/spinnaker.list > /dev/null
-}
-
-function add_java_apt_repository() {
-  # Only Ubuntu prior to 18.04 LTS requires this PPA
-  if [ "${DISTRIB_RELEASE%%.*}" -lt "18" ]; then
-    echo "Adding Java PPA repository for Ubuntu version less than 18.04"
-    add-apt-repository -y ppa:openjdk-r/ppa
+  # Most probably not required since the repo would already
+  # need to exist in order to install the spinnaker-halyard
+  # package in the first place.
+  if [ ! -f /etc/apt/sources.list.d/spinnaker.list ]; then
+    echo "Adding Spinnaker apt repository"
+    REPOSITORY_HOST=$(echo $REPOSITORY_URL | cut -d/ -f3)
+    curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/spinnaker.gpg > /dev/null
+    echo "deb [signed-by=/usr/share/keyrings/spinnaker.gpg arch=all] $REPOSITORY_URL apt main" | tee /etc/apt/sources.list.d/spinnaker.list > /dev/null
   fi
-}
-
-function install_java() {
-  set +e
-  local java_version=$(java -version 2>&1 head -1)
-  set -e
-
-  if [[ "$java_version" == *11.0* ]]; then
-    echo "Java dependency is already installed"
-    return 0;
-  fi
-
-  echo "Installing Java"
-  apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages unzip
-  apt-get install -y --allow-downgrades --allow-remove-essential --allow-change-held-packages openjdk-11-jre-headless
-
-  # https://bugs.launchpad.net/ubuntu/+source/ca-certificates-java/+bug/983302
-  # It seems a circular dependency was introduced on 2016-04-22 with an openjdk-8 release, where
-  # the JRE relies on the ca-certificates-java package, which itself relies on the JRE.
-  # This causes the /etc/ssl/certs/java/cacerts file to never be generated, causing a startup
-  # failure in Clouddriver.
-  echo "Reinstalling Java CA certificates"
-  dpkg --purge --force-depends ca-certificates-java
-  apt-get install ca-certificates-java
 }
 
 echo "Updating apt package lists..."
 
-if [ -n "$INSTALL_REDIS" ]; then
-  add_redis_apt_repository
-fi
-
 if [ -n "$PREPARE_ENVIRONMENT" ]; then
-  add_java_apt_repository
   add_spinnaker_apt_repository
   {%upstart-init%}
 fi
@@ -115,10 +77,6 @@ fi
 apt-get update ||:
 
 echo "Installing desired components..."
-
-if [ -n "$PREPARE_ENVIRONMENT" ]; then
-  install_java
-fi
 
 if [ -z "$(getent group spinnaker)" ]; then
   groupadd spinnaker

--- a/halyard-deploy/src/main/resources/services/redis/install.sh
+++ b/halyard-deploy/src/main/resources/services/redis/install.sh
@@ -1,2 +1,1 @@
-add-apt-repository -y ppa:chris-lea/redis-server
-apt-get -q -y --force-yes install redis-server={%version%} redis-tools={%version%}
+apt-get -q -y --allow-unauthenticated --allow-downgrades --allow-remove-essential --allow-change-held-packages install redis-server={%version%} redis-tools={%version%}


### PR DESCRIPTION
1. Fixed various issues with the Debian installation scripts.
2. Removed Java installation from the script that halyard runs when applying a deployment, because Java would already need to be installed to install Halyard and start the daemon.
3. Changed the minimum Ubuntu requirement from 14.04 to 18.04 since anything prior to 18.04 is out of support.
4. Removed option for specifying a user and home directory, since the Halyard package depends on the user being `spinnaker` and creates the `spinnaker` user if it does not exist.