### PR TITLE
fix(halyard): cli boolean flags not working

### DIFF
--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/NestableCommand.java
@@ -81,14 +81,14 @@ public abstract class NestableCommand {
   @Parameter(
       names = {"-d", "--debug"},
       description = "Show detailed network traffic with halyard daemon.")
-  public void setDebug(boolean debug) {
+  public void setDebug(Boolean debug) {
     GlobalOptions.getGlobalOptions().setDebug(debug);
   }
 
   @Parameter(
       names = {"-a", "--alpha"},
       description = "Enable alpha halyard features.")
-  public void setAlpha(boolean alpha) {
+  public void setAlpha(Boolean alpha) {
     GlobalOptions.getGlobalOptions().setAlpha(alpha);
   }
 
@@ -96,7 +96,7 @@ public abstract class NestableCommand {
       names = {"-q", "--quiet"},
       description =
           "Show no task information or messages. When set, ANSI formatting will be disabled, and all prompts will be accepted.")
-  public void setQuiet(boolean quiet) {
+  public void setQuiet(Boolean quiet) {
     GlobalOptions.getGlobalOptions().setQuiet(quiet);
     GlobalOptions.getGlobalOptions().setColor(!quiet);
   }
@@ -113,7 +113,7 @@ public abstract class NestableCommand {
       names = {"-c", "--color"},
       description = "Enable terminal color output.",
       arity = 1)
-  public void setColor(boolean color) {
+  public void setColor(Boolean color) {
     GlobalOptions.getGlobalOptions().setColor(color);
   }
 

--- a/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
+++ b/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
@@ -18,6 +18,7 @@ package com.netflix.spinnaker.halyard.cli.command.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static uk.org.webcompere.systemstubs.SystemStubs.catchSystemExit;
 
 import com.beust.jcommander.JCommander;
@@ -129,6 +130,15 @@ class HalCommandTest {
     assertThatThrownBy(() -> jc.parse(ArrayUtils.addAll(args)))
         .isInstanceOf(ParameterException.class)
         .hasMessageContaining("Only one main parameter allowed but found several");
+  }
+
+  @org.junit.jupiter.api.Test
+  void testHalyardGlobalOptionsBoolean() {
+    String[] args = {"deploy", "clean", "--quiet", "--debug", "--alpha"};
+    jc.parse(args);
+    assertTrue(GlobalOptions.getGlobalOptions().isQuiet());
+    assertTrue(GlobalOptions.getGlobalOptions().isDebug());
+    assertTrue(GlobalOptions.getGlobalOptions().isAlpha());
   }
 
   // Inspired by https://stackoverflow.com/a/46931618


### PR DESCRIPTION
Some of the boolean flags that are parameterized via jcommander are not working
See new unit test added that are failing with the current jcommander version
Parameters that are saved as private boolean like `--help` work, but not the
ones attached to more complex method_x(booalean y). There is not much documentation
in jcommander for those so I suspect a bug, since attaching them to methods with
a signature using Boolean instead of boolean do work.
This fixes issue reported https://github.com/spinnaker/spinnaker/issues/6700
in addition to `--quiet` it also fixes `--debug`, `--alpha` and `--color`