### PR TITLE
fix(install): Enable Halyard and Spinnaker services to start on reboot, and fixed Debian artifacts URL

### DIFF
--- a/halyard-deploy/src/main/resources/debian/install.sh
+++ b/halyard-deploy/src/main/resources/debian/install.sh
@@ -112,7 +112,12 @@ chown spinnaker /opt/spinnaker-monitoring/registry
 
 # so this script can be used for updates
 set +e
-service spinnaker {%service-action%}
+systemctl {%service-action%} spinnaker
 
 # Ensure apache is started for deck. Restart to ensure enabled site is loaded.
-service apache2 restart
+systemctl restart apache2
+
+# Ensure that Halyard and Spinnaker start up automatically on reboot
+systemctl daemon-reload
+systemctl enable spinnaker
+systemctl enable halyard

--- a/halyard-web/config/halyard.yml
+++ b/halyard-web/config/halyard.yml
@@ -10,7 +10,7 @@ halconfig:
 
 spinnaker:
   artifacts:
-    debian: https://dl.bintray.com/spinnaker-releases/debians
+    debian: https://us-apt.pkg.dev/projects/spinnaker-community
     docker: us-docker.pkg.dev/spinnaker-community/docker
   config:
     input:

--- a/halyard-web/lib/systemd/system/halyard.service
+++ b/halyard-web/lib/systemd/system/halyard.service
@@ -9,4 +9,4 @@ ExecStart=/opt/halyard/bin/halyard
 User=spinnaker
 
 [Install]
-WantedBy=user.target
+WantedBy=multi-user.target


### PR DESCRIPTION
### Resolves the following issues

1. Spinnaker and Halyard services are not enabled once they are installed, and do not start automatically on reboot.
2. The Halyard service is added as a dependency to a non-existent unit user.target in the systemd unit file.
3. The Debian artifact repository URL still points to Bintray.