### PR TITLE
fix(install): Fix issue running Halyard within a docker container that does not have sudo installed

### DIFF
--- a/halyard-deploy/src/main/resources/debian/install.sh
+++ b/halyard-deploy/src/main/resources/debian/install.sh
@@ -70,7 +70,7 @@ function add_spinnaker_apt_repository() {
   if [ ! -f /etc/apt/sources.list.d/spinnaker.list ]; then
     echo "Adding Spinnaker apt repository"
     REPOSITORY_HOST=$(echo $REPOSITORY_URL | cut -d/ -f3)
-    curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor | sudo tee /usr/share/keyrings/spinnaker.gpg > /dev/null
+    curl -fsSL https://us-apt.pkg.dev/doc/repo-signing-key.gpg | gpg --dearmor | tee /usr/share/keyrings/spinnaker.gpg > /dev/null
     echo "deb [signed-by=/usr/share/keyrings/spinnaker.gpg arch=all] $REPOSITORY_URL apt main" | tee /etc/apt/sources.list.d/spinnaker.list > /dev/null
   fi
 }


### PR DESCRIPTION
Resolves the following issue:

```bash
root@e306cf20f7c5:/# hal deploy apply
+ Get current deployment
  Success
+ Prep deployment
  Success
Validation in default.stats:
- INFO Stats are currently ENABLED. Usage statistics are being
  collected. Thank you! These stats inform improvements to the product, and that
  helps the community. To disable, run `hal config stats disable`. To learn more
  about what and how stats data is used, please see
  https://spinnaker.io/docs/community/stay-informed/stats.

+ Preparation complete... deploying Spinnaker
+ Get current deployment
  Success
+ Apply deployment
  Success
+ Run `hal deploy connect` to connect to Spinnaker.
Updating apt package lists...
Adding Spinnaker apt repository
/home/spinnaker/.hal/default/install.sh: line 73: sudo: command not found
gpg: [stdout]: write error: Broken pipe
gpg: filter_flush failed on close: Broken pipe
! ERROR Error encountered running script. See above output for more
  details.
```