### PR TITLE
Autobump clouddriver version master and use the same azure dependency as in clouddriver

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-clouddriverVersion=5.78.0
+clouddriverVersion=5.79.0
 fiatVersion=1.36.0
 korkVersion=7.149.0
 front50Version=2.27.0

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -24,8 +24,8 @@ dependencies {
   implementation 'com.amazonaws:aws-java-sdk-s3:1.11.534'
   implementation 'com.google.apis:google-api-services-compute'
   implementation 'com.google.apis:google-api-services-appengine:v1-rev92-1.25.0'
-  implementation 'com.microsoft.azure:adal4j:1.6.3'
-  implementation 'com.microsoft.azure:azure:1.19.0'
+  implementation "com.azure.resourcemanager:azure-resourcemanager:2.19.0"
+  implementation "com.azure:azure-storage-blob:12.19.1"
   implementation 'commons-collections:commons-collections:3.2.2'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'commons-io:commons-io'
@@ -34,6 +34,8 @@ dependencies {
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0"
   implementation 'com.squareup.retrofit:retrofit'
   implementation "com.squareup.retrofit:converter-jackson"
+  implementation "com.squareup.retrofit2:retrofit"
+  implementation "com.squareup.retrofit2:converter-jackson"
   implementation 'com.jcraft:jsch'
   implementation 'de.huxhorn.sulky:de.huxhorn.sulky.ulid'
   implementation "net.logstash.logback:logstash-logback-encoder"

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/AzsValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/persistentStorage/AzsValidator.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.halyard.config.validate.v1.persistentStorage;
 
-import com.microsoft.azure.storage.CloudStorageAccount;
-import com.microsoft.azure.storage.blob.CloudBlobContainer;
+import com.azure.storage.blob.BlobContainerClient;
+import com.azure.storage.blob.BlobContainerClientBuilder;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
 import com.netflix.spinnaker.halyard.config.model.v1.persistentStorage.AzsPersistentStore;
 import com.netflix.spinnaker.halyard.config.problem.v1.ConfigProblemSetBuilder;
@@ -35,11 +35,13 @@ public class AzsValidator extends Validator<AzsPersistentStore> {
             + secretSessionManager.decrypt(n.getStorageAccountKey());
 
     try {
-      CloudStorageAccount storageAccount = CloudStorageAccount.parse(connectionString);
+      final BlobContainerClient blobContainerClient =
+          new BlobContainerClientBuilder()
+              .connectionString(connectionString)
+              .containerName(n.getStorageContainerName())
+              .buildClient();
 
-      CloudBlobContainer container =
-          storageAccount.createCloudBlobClient().getContainerReference(n.getStorageContainerName());
-      container.exists();
+      blobContainerClient.exists();
     } catch (Exception e) {
       ps.addProblem(
           Problem.Severity.ERROR,
@@ -47,7 +49,6 @@ public class AzsValidator extends Validator<AzsPersistentStore> {
               + n.getStorageAccountName()
               + "\": "
               + e.getMessage());
-      return;
     }
   }
 }

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureAccountValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureAccountValidator.java
@@ -16,8 +16,8 @@
 
 package com.netflix.spinnaker.halyard.config.validate.v1.providers.azure;
 
-import com.microsoft.azure.CloudException;
-import com.microsoft.azure.management.resources.GenericResources;
+import com.azure.core.management.exception.ManagementException;
+import com.azure.resourcemanager.resources.models.GenericResources;
 import com.netflix.spinnaker.clouddriver.azure.client.AzureResourceManagerClient;
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
@@ -83,8 +83,8 @@ public class AzureAccountValidator extends Validator<AzureAccount> {
       // exception, so use the cause instead
       Throwable cause = e.getCause();
       String errorMessage =
-          cause instanceof CloudException
-              ? CloudException.class.cast(cause).body().message()
+          cause instanceof ManagementException
+              ? ((ManagementException) cause).getValue().getMessage()
               : cause.getMessage();
       if (errorMessage.contains("AADSTS90002")) {
         p.addProblem(Severity.ERROR, "Tenant Id '" + tenantId + "' is invalid.", "tenantId")

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureBaseImageValidator.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/validate/v1/providers/azure/AzureBaseImageValidator.java
@@ -16,7 +16,7 @@
 
 package com.netflix.spinnaker.halyard.config.validate.v1.providers.azure;
 
-import com.microsoft.azure.CloudException;
+import com.azure.core.management.exception.ManagementException;
 import com.netflix.spinnaker.clouddriver.azure.client.AzureComputeClient;
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials;
 import com.netflix.spinnaker.halyard.config.model.v1.node.Validator;
@@ -47,8 +47,8 @@ public class AzureBaseImageValidator extends Validator<AzureBaseImage> {
           "westus", osSettings.getPublisher(), osSettings.getOffer(), osSettings.getSku(), version);
     } catch (Exception e) {
       String message =
-          e instanceof CloudException
-              ? CloudException.class.cast(e).body().message()
+          e instanceof ManagementException
+              ? ((ManagementException) e).getValue().getMessage()
               : e.getMessage();
       p.addProblem(
               Problem.Severity.WARNING,


### PR DESCRIPTION
- update imports
- add retrofit2 in `halyard-config.gradle` (before updating the library it was fetched from the azure-runtime library which is no longer available)