### PR TITLE
fix(docker image): cleanup /var/lib/apt/lists/* as it is a best practice

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -12,6 +12,7 @@ RUN apt-get update && \
       openjdk-11-jre-headless \
       curl \
       python-pip && \
+    rm -rf /var/lib/apt/lists/* && \
     pip install awscli==${AWS_CLI_VERSION} --upgrade
 
 RUN echo '#!/usr/bin/env bash' > /usr/local/bin/hal && \


### PR DESCRIPTION
Apply docker best practice for debian/ubuntu bases docker images.

Also see the [official documentation](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run)