### PR TITLE
refactor(web): Clean up redundant spring property in gradle file

### DIFF
--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -1,12 +1,5 @@
 apply plugin: 'io.spinnaker.package'
 
-ext {
-  springConfigLocation = System.getProperty('spring.config.additional-location', "${System.getProperty('user.home')}/.spinnaker/".toString())
-}
-
-run {
-  systemProperty('spring.config.additional-location', project.springConfigLocation)
-}
 mainClassName = 'com.netflix.spinnaker.halyard.Main'
 
 configurations.all {


### PR DESCRIPTION
The property spring.config.additional-location is redundant in halyard-web.gradle file. This property is set by class com.netflix.spinnaker.kork.boot.DefaultPropertiesBuilder in com.netflix.spinnaker.halyard.Main. So removing it from gradle file.