### PR TITLE
chore(web): clean up spring boot 2.4-related changes

### DIFF
--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -39,8 +39,6 @@ dependencies {
   implementation project(':halyard-core')
   implementation project(':halyard-deploy')
   implementation project(':halyard-proto')
-
-  runtimeOnly 'org.springframework.cloud:spring-cloud-starter-bootstrap'
 }
 
 def cliScript = project.tasks.create('createCliStartScripts', CreateStartScripts) {

--- a/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
+++ b/halyard-web/src/main/java/com/netflix/spinnaker/halyard/Main.java
@@ -31,8 +31,7 @@ import org.springframework.context.annotation.Configuration;
 @EnableAutoConfiguration
 @EnableConfigServer
 public class Main extends SpringBootServletInitializer {
-  private static final Map<String, Object> DEFAULT_PROPS =
-      new DefaultPropertiesBuilder().property("spring.config.on-not-found", "ignore").build();
+  private static final Map<String, Object> DEFAULT_PROPS = new DefaultPropertiesBuilder().build();
 
   public static void main(String... args) {
     ConfigServerBootstrap.systemProperties("halyard");


### PR DESCRIPTION
Now that https://github.com/spinnaker/kork/pull/990 and https://github.com/spinnaker/kork/pull/1002 are in (and halyard consumes them), we don't need these changes here anymore.

Revert "fix(web): adjust configuration so that the halyard daemon starts with spring boot 2.4 (#1987)"

This reverts commit 442810565b8dd1f6529b6df6c8eace29117ea64c.