### PR TITLE
fix(commons-text): Bump commons text for CVE

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -6,7 +6,7 @@ dependencies {
   implementation "io.spinnaker.fiat:fiat-core:$fiatVersion"
   implementation 'io.spinnaker.kork:kork-secrets'
   implementation 'org.apache.commons:commons-lang3'
-  implementation 'org.apache.commons:commons-text:1.6'
+  implementation 'org.apache.commons:commons-text:1.10.0'
   implementation 'ch.qos.logback:logback-classic'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'com.squareup.retrofit:converter-jackson'


### PR DESCRIPTION
Another PR ideal to bump all the other libs that are WAY out of date... snakeyaml to 1.28 maybe? :P BUT fixes CVE scans.