### PR TITLE
fix(tests): Introduce junit5 vintage engine for running junit4 test cases over junit5 in halyard

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,7 @@ subprojects {
     }
     minHeapSize = "512m"
     maxHeapSize = "512m"
+    useJUnitPlatform()
   }
 
   if ([korkVersion, fiatVersion, clouddriverVersion, front50Version].any { it.endsWith("-SNAPSHOT") }) {
@@ -52,6 +53,7 @@ subprojects {
     annotationProcessor "org.projectlombok:lombok"
     testAnnotationProcessor platform("io.spinnaker.kork:kork-bom:$korkVersion")
     testAnnotationProcessor "org.projectlombok:lombok"
+    testRuntimeOnly "org.junit.vintage:junit-vintage-engine"
   }
 }
 


### PR DESCRIPTION
Spring boot 2.4.x removed JUnit5 vintage engine from [spring-boot-starter-test](https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.4-Release-Notes#junit-5s-vintage-engine-removed-from-spring-boot-starter-test). It is required for executing junit4 based test cases in halyard. So, introducing junit-vintage-engine dependency in build.gradle, using testRuntimeOnly() as suggested in section 3.1 of https://junit.org/junit5/docs/5.6.2/user-guide/index.pdf

After applying this fix, coverage increased from 54 to 227 test case executions.