### PR TITLE
refactor(tests): convert junit4 based testcases to junit5, clean up and unpin spock in halyard

### DIFF
--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -28,9 +28,9 @@ dependencies {
   testImplementation 'uk.org.webcompere:system-stubs-jupiter:1.2.0'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
   testImplementation 'org.junit.jupiter:junit-jupiter-params'
-  testImplementation 'org.junit.platform:junit-platform-runner'
-  testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+  testImplementation 'org.spockframework:spock-core'
   testImplementation 'org.springframework:spring-test'
+  testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine"
 }
 
 apply plugin: 'application'

--- a/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
+++ b/halyard-cli/src/test/java/com/netflix/spinnaker/halyard/cli/command/v1/HalCommandTest.java
@@ -33,10 +33,7 @@ import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 
-@RunWith(JUnitPlatform.class)
 class HalCommandTest {
 
   private HalCommand hal;

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -46,9 +46,9 @@ dependencies {
 
   testImplementation 'org.assertj:assertj-core'
   testImplementation 'org.junit.jupiter:junit-jupiter-api'
-  testImplementation 'org.junit.platform:junit-platform-runner'
-  testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+  testImplementation 'org.spockframework:spock-core'
   testImplementation 'org.springframework:spring-test'
   testImplementation 'org.codehaus.groovy:groovy'
   testRuntimeOnly 'net.bytebuddy:byte-buddy'
+  testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
+++ b/halyard-config/src/test/java/com/netflix/spinnaker/halyard/config/model/v1/providers/kubernetes/KubernetesAccountTest.java
@@ -24,11 +24,8 @@ import com.netflix.spinnaker.halyard.config.config.v1.StrictObjectMapper;
 import java.io.IOException;
 import java.io.StringWriter;
 import org.junit.jupiter.api.Test;
-import org.junit.platform.runner.JUnitPlatform;
-import org.junit.runner.RunWith;
 import org.yaml.snakeyaml.Yaml;
 
-@RunWith(JUnitPlatform.class)
 final class KubernetesAccountTest {
 
   @Test

--- a/halyard-core/halyard-core.gradle
+++ b/halyard-core/halyard-core.gradle
@@ -17,7 +17,7 @@ dependencies {
   implementation 'commons-io:commons-io'
   implementation 'io.reactivex:rxjava'
   implementation 'com.hubspot.jinjava:jinjava:2.2.3'
-  implementation 'org.spockframework:spock-spring:1.1-groovy-2.4'
+  implementation 'org.spockframework:spock-spring'
   implementation 'org.yaml:snakeyaml:1.24'
 
   testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -29,7 +29,7 @@ dependencies {
   implementation project(':halyard-core')
   implementation project(':halyard-backup')
 
-  testImplementation 'org.spockframework:spock-core:1.3-groovy-2.5'
+  testImplementation 'org.spockframework:spock-core'
   testImplementation 'org.springframework:spring-test'
   testRuntimeOnly 'net.bytebuddy:byte-buddy'
   testRuntimeOnly 'org.objenesis:objenesis'


### PR DESCRIPTION
Before refactor, total test cases executed were 173. 
After refactor, total test cases executed are 227.