### PR TITLE
fix(config): import RetrofitConfiguration class

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/RetrofitConfig.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/config/v1/RetrofitConfig.java
@@ -19,6 +19,7 @@ package com.netflix.spinnaker.halyard.config.config.v1;
 import com.jakewharton.retrofit.Ok3Client;
 import com.netflix.spinnaker.config.OkHttp3ClientConfiguration;
 import com.netflix.spinnaker.config.OkHttpClientComponents;
+import com.netflix.spinnaker.config.RetrofitConfiguration;
 import com.netflix.spinnaker.config.okhttp3.OkHttpClientProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +32,11 @@ import retrofit.RequestInterceptor;
 import retrofit.RestAdapter;
 
 @Configuration
-@Import({OkHttp3ClientConfiguration.class, OkHttpClientComponents.class})
+@Import({
+  OkHttp3ClientConfiguration.class,
+  OkHttpClientComponents.class,
+  RetrofitConfiguration.class
+})
 class RetrofitConfig {
   @Autowired OkHttp3ClientConfiguration okHttpClientConfig;
 


### PR DESCRIPTION
to get a okhttp3.logging.HttpLoggingInterceptor$Level bean to fix the
```
***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 2 of constructor in com.netflix.spinnaker.config.OkHttp3ClientConfiguration required a bean of type 'okhttp3.logging.HttpLoggingInterceptor$Level' that could not be found.

Action:

Consider defining a bean of type 'okhttp3.logging.HttpLoggingInterceptor$Level' in your configuration.
```
message on startup.  More specifically, from
```
$ ./gradlew build halyard-web:installDist
$ docker build -f Dockerfile.slim -t halyard:test-me .
$ docker run --rm halyard:test-me
```