### PR TITLE
Revert "chore(dependencies): Autobump front50Version (#2082)"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 korkVersion=7.189.0
 clouddriverVersion=5.82.0
 fiatVersion=1.42.0
-front50Version=2.30.1
+front50Version=2.30.0
 org.gradle.parallel=true
 spinnakerGradleVersion=8.31.0
 targetJava11=true


### PR DESCRIPTION
This reverts commit 1ee701ba5a18000c7ac843638d14858ccfe6b5aa.

https://github.com/spinnaker/halyard/pull/2082 was generated from a tag on the release-1.32.x branch of front50.

Halyard is supposed to use versions of front50 from master, so revert this.

See https://github.com/spinnaker/spinnaker/projects/20#card-85655999 for a fix for this.