### PR TITLE
refactor(core/test): refactor typo in test based on spockframework

### DIFF
--- a/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/registry/v1/VersionsSpec.groovy
+++ b/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/registry/v1/VersionsSpec.groovy
@@ -116,7 +116,7 @@ class VersionsSpec extends Specification {
 
     def "orderBySemVer throws an exception for invalid versions"() {
         when:
-        dev versions = ["1.0.0", badVersion]
+        def versions = ["1.0.0", badVersion]
         Collections.sort(versions, Versions.orderBySemVer())
 
         then:


### PR DESCRIPTION
It seems that typo is ignored while compilation by spockframework 1.3-groovy-2.5/groovy 2.5.15, however during upgrade of spockframework 2.0-groovy-3.0 and groovy 3.x, hit the test compilation error:
```
> Task :halyard-core:compileTestGroovy
startup failed:
/halyard/halyard-core/src/test/groovy/com/netflix/spinnaker/halyard/core/registry/v1/VersionsSpec.groovy: 119: unable to resolve class dev
 @ line 119, column 13.
           dev versions = ["1.0.0", badVersion]
               ^
1 error
> Task :halyard-core:compileTestGroovy FAILED
```