### PR TITLE
Update FileService.java

### DIFF
--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/FileService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/FileService.java
@@ -84,7 +84,7 @@ public class FileService {
       String localPath = cloudConfigResourceService.getLocalPath(fileReference);
       return configFileService.getContents(localPath).getBytes();
     }
-    if (EncryptedSecret.isEncryptedSecret(fileReference)) {
+    if (EncryptedSecret.isEncryptedFile(fileReference)) {
       return secretSessionManager.decryptAsBytes(fileReference);
     }
 


### PR DESCRIPTION
As a potential fix for https://github.com/armory/spinnaker-operator/issues/203 This fixes the getFileContentBytes to check for an encryptedFile rather than an encryptedSecret