### PR TITLE
feat(provider/google): Added all cloudrun commands in halyard

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -413,6 +413,16 @@
  * [**hal config provider cloudfoundry account list**](#hal-config-provider-cloudfoundry-account-list)
  * [**hal config provider cloudfoundry disable**](#hal-config-provider-cloudfoundry-disable)
  * [**hal config provider cloudfoundry enable**](#hal-config-provider-cloudfoundry-enable)
+ * [**hal config provider cloudrun**](#hal-config-provider-cloudrun)
+ * [**hal config provider cloudrun account**](#hal-config-provider-cloudrun-account)
+ * [**hal config provider cloudrun account add**](#hal-config-provider-cloudrun-account-add)
+ * [**hal config provider cloudrun account delete**](#hal-config-provider-cloudrun-account-delete)
+ * [**hal config provider cloudrun account edit**](#hal-config-provider-cloudrun-account-edit)
+ * [**hal config provider cloudrun account get**](#hal-config-provider-cloudrun-account-get)
+ * [**hal config provider cloudrun account list**](#hal-config-provider-cloudrun-account-list)
+ * [**hal config provider cloudrun disable**](#hal-config-provider-cloudrun-disable)
+ * [**hal config provider cloudrun edit**](#hal-config-provider-cloudrun-edit)
+ * [**hal config provider cloudrun enable**](#hal-config-provider-cloudrun-enable)
  * [**hal config provider dcos**](#hal-config-provider-dcos)
  * [**hal config provider dcos account**](#hal-config-provider-dcos-account)
  * [**hal config provider dcos account add**](#hal-config-provider-dcos-account-add)
@@ -7124,6 +7134,7 @@ hal config provider [subcommands]
  * `aws`: Manage and view Spinnaker configuration for the aws provider
  * `azure`: Manage and view Spinnaker configuration for the azure provider
  * `cloudfoundry`: Manage and view Spinnaker configuration for the cloudfoundry provider
+ * `cloudrun`: Manage and view Spinnaker configuration for the cloudrun provider
  * `dcos`: Manage and view Spinnaker configuration for the dcos provider
  * `docker-registry`: Manage and view Spinnaker configuration for the dockerRegistry provider
  * `ecs`: Manage and view Spinnaker configuration for the ecs provider
@@ -8165,6 +8176,196 @@ Set the cloudfoundry provider as enabled
 #### Usage
 ```
 hal config provider cloudfoundry enable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider cloudrun
+
+The Cloud Run provider is used to deploy resources to any number of Cloud Run applications. To get started with Cloud Run, visit [https://cloud.google.com/run/docs/](https://cloud.google.com/run/docs/). For more information on how to configure individual accounts, please read the documentation under `hal config provider cloudrun account -h`.
+
+#### Usage
+```
+hal config provider cloudrun [parameters] [subcommands]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `account`: Manage and view Spinnaker configuration for the cloudrun provider's account
+ * `disable`: Set the cloudrun provider as disabled
+ * `edit`: Edit Spinnaker's cloudrun configuration.
+ * `enable`: Set the cloudrun provider as enabled
+
+---
+## hal config provider cloudrun account
+
+An account in the Cloud Run provider refers to a single Cloud Run application. Spinnaker assumes that your Cloud Run application already exists. You can create an application in your Google Cloud Platform project by running `gcloud app create --region <region>`.
+
+#### Usage
+```
+hal config provider cloudrun account ACCOUNT [parameters] [subcommands]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+#### Subcommands
+ * `add`: Add an account to the cloudrun provider.
+ * `delete`: Delete a specific cloudrun account by name.
+ * `edit`: Edit an account in the cloudrun provider.
+ * `get`: Get the specified account details for the cloudrun provider.
+ * `list`: List the account names for the cloudrun provider.
+
+---
+## hal config provider cloudrun account add
+
+Add an account to the cloudrun provider.
+
+#### Usage
+```
+hal config provider cloudrun account add ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
+ * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
+ * `--local-repository-directory`: (*Default*: `/var/tmp/clouddriver`) A local directory to be used to stage source files for Cloud Run deployments within Spinnaker's Clouddriver microservice.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--project`: (*Required*) The Google Cloud Platform project this Spinnaker account will manage.
+ * `--read-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to view this account's cloud resources.
+ * `--required-group-membership`: (*Default*: `[]`) A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
+ * `--ssh-trust-unknown-hosts`: (*Default*: `false`) Enabling this flag will allow Spinnaker to connect with a remote git repository over SSH without verifying the server's IP address against a known_hosts file.
+ * `--write-permissions`: (*Default*: `[]`) A user must have at least one of these roles in order to make changes to this account's cloud resources.
+
+
+---
+## hal config provider cloudrun account delete
+
+Delete a specific cloudrun account by name.
+
+#### Usage
+```
+hal config provider cloudrun account delete ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider cloudrun account edit
+
+Edit an account in the cloudrun provider.
+
+#### Usage
+```
+hal config provider cloudrun account edit ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--add-read-permission`: Add this permission to the list of read permissions.
+ * `--add-required-group-membership`: Add this group to the list of required group memberships.
+ * `--add-write-permission`: Add this permission to the list of write permissions.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--environment`: The environment name for the account. Many accounts can share the same environment (e.g. dev, test, prod)
+ * `--json-path`: The path to a JSON service account that Spinnaker will use as credentials. This is only needed if Spinnaker is not deployed on a Google Compute Engine VM, or needs permissions not afforded to the VM it is running on. See [https://cloud.google.com/compute/docs/access/service-accounts](https://cloud.google.com/compute/docs/access/service-accounts) for more information.
+ * `--local-repository-directory`: A local directory to be used to stage source files for Cloud Run deployments within Spinnaker's Clouddriver microservice.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+ * `--project`: The Google Cloud Platform project this Spinnaker account will manage.
+ * `--read-permissions`: A user must have at least one of these roles in order to view this account's cloud resources.
+ * `--remove-read-permission`: Remove this permission from the list of read permissions.
+ * `--remove-required-group-membership`: Remove this group from the list of required group memberships.
+ * `--remove-write-permission`: Remove this permission to from list of write permissions.
+ * `--required-group-membership`: A user must be a member of at least one specified group in order to make changes to this account's cloud resources.
+ * `--ssh-known-hosts-file-path`: The path to a known_hosts file to be used when connecting with a remote git repository over SSH.
+ * `--ssh-trust-unknown-hosts`: Enabling this flag will allow Spinnaker to connect with a remote git repository over SSH without verifying the server's IP address against a known_hosts file.
+ * `--write-permissions`: A user must have at least one of these roles in order to make changes to this account's cloud resources.
+
+
+---
+## hal config provider cloudrun account get
+
+Get the specified account details for the cloudrun provider.
+
+#### Usage
+```
+hal config provider cloudrun account get ACCOUNT [parameters]
+```
+
+#### Parameters
+`ACCOUNT`: The name of the account to operate on.
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider cloudrun account list
+
+List the account names for the cloudrun provider.
+
+#### Usage
+```
+hal config provider cloudrun account list [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider cloudrun disable
+
+Set the cloudrun provider as disabled
+
+#### Usage
+```
+hal config provider cloudrun disable [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider cloudrun edit
+
+Edit Spinnaker's cloudrun configuration.
+
+#### Usage
+```
+hal config provider cloudrun edit [parameters]
+```
+
+#### Parameters
+ * `--deployment`: If supplied, use this Halyard deployment. This will _not_ create a new deployment.
+ * `--gcloudPath`: The path to the gcloud executable on the machine running clouddriver.
+ * `--no-validate`: (*Default*: `false`) Skip validation.
+
+
+---
+## hal config provider cloudrun enable
+
+Set the cloudrun provider as enabled
+
+#### Usage
+```
+hal config provider cloudrun enable [parameters]
 ```
 
 #### Parameters

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/ProviderCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/ProviderCommand.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.appengine.A
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.aws.AwsCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.azure.AzureCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudfoundry.CloudFoundryCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun.CloudrunCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.dcos.DCOSCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.dockerRegistry.DockerRegistryCommand;
 import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.ecs.EcsCommand;
@@ -50,6 +51,7 @@ public class ProviderCommand extends NestableCommand {
     registerSubcommand(new AwsCommand());
     registerSubcommand(new AzureCommand());
     registerSubcommand(new CloudFoundryCommand());
+    registerSubcommand(new CloudrunCommand());
     registerSubcommand(new DCOSCommand());
     registerSubcommand(new DockerRegistryCommand());
     registerSubcommand(new EcsCommand());

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunAccountCommand.java
@@ -1,0 +1,27 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractAccountCommand;
+
+@Parameters(separators = "=")
+public class CloudrunAccountCommand extends AbstractAccountCommand {
+  protected String getProviderName() {
+    return "cloudrun";
+  }
+
+  @Override
+  protected String getLongDescription() {
+    return String.join(
+        "",
+        "An account in the Cloud Run provider refers to a single Cloud Run application. ",
+        "Spinnaker assumes that your Cloud Run application already exists. ",
+        "You can create an application in your Google Cloud Platform project by running ",
+        "`gcloud app create --region <region>`.");
+  }
+
+  public CloudrunAccountCommand() {
+    super();
+    registerSubcommand(new CloudrunAddAccountCommand());
+    registerSubcommand(new CloudrunEditAccountCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunAddAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunAddAccountCommand.java
@@ -1,0 +1,55 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractAddAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.google.CommonGoogleCommandProperties;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun.CloudrunAccount;
+
+@Parameters(separators = "=")
+public class CloudrunAddAccountCommand extends AbstractAddAccountCommand {
+  protected String getProviderName() {
+    return "cloudrun";
+  }
+
+  @Parameter(
+      names = "--project",
+      required = true,
+      description = CommonGoogleCommandProperties.PROJECT_DESCRIPTION)
+  private String project;
+
+  @Parameter(
+      names = "--json-path",
+      converter = LocalFileConverter.class,
+      description = CommonGoogleCommandProperties.JSON_PATH_DESCRIPTION)
+  private String jsonPath;
+
+  @Parameter(
+      names = "--local-repository-directory",
+      description = CloudrunCommandProperties.LOCAL_REPOSITORY_DIRECTORY_DESCRIPTION)
+  private String localRepositoryDirectory = "/var/tmp/clouddriver";
+
+  @Parameter(
+      names = "--ssh-trust-unknown-hosts",
+      description = CloudrunCommandProperties.SSH_TRUST_UNKNOWN_HOSTS,
+      arity = 1)
+  private boolean sshTrustUnknownHosts = false;
+
+  @Override
+  protected Account buildAccount(String accountName) {
+    CloudrunAccount account = (CloudrunAccount) new CloudrunAccount().setName(accountName);
+    account.setProject(project).setJsonPath(jsonPath);
+
+    account
+        .setLocalRepositoryDirectory(localRepositoryDirectory)
+        .setSshTrustUnknownHosts(sshTrustUnknownHosts);
+    return account;
+  }
+
+  @Override
+  protected Account emptyAccount() {
+    return new CloudrunAccount();
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunCommand.java
@@ -1,0 +1,27 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun;
+
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractNamedProviderCommand;
+
+@Parameters(separators = "=")
+public class CloudrunCommand extends AbstractNamedProviderCommand {
+  protected String getProviderName() {
+    return "cloudrun";
+  }
+
+  @Override
+  protected String getLongDescription() {
+    return String.join(
+        "",
+        "The Cloud Run provider is used to deploy resources to any number of Cloud Run applications. ",
+        "To get started with Cloud Run, visit https://cloud.google.com/run/docs/. ",
+        "For more information on how to configure individual accounts, please read the documentation ",
+        "under `hal config provider cloudrun account -h`.");
+  }
+
+  public CloudrunCommand() {
+    super();
+    registerSubcommand(new CloudrunEditCommand());
+    registerSubcommand(new CloudrunAccountCommand());
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunCommandProperties.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunCommandProperties.java
@@ -1,0 +1,32 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun;
+
+public class CloudrunCommandProperties {
+  static final String LOCAL_REPOSITORY_DIRECTORY_DESCRIPTION =
+      "A local directory to be used to stage source files"
+          + " for Cloud Run deployments within Spinnaker's Clouddriver microservice.";
+  static final String SSH_KNOWN_HOSTS_FILE_PATH =
+      "The path to a known_hosts file to be used when connecting with"
+          + " a remote git repository over SSH.";
+  static final String SSH_TRUST_UNKNOWN_HOSTS =
+      "Enabling this flag will allow Spinnaker to connect"
+          + " with a remote git repository over SSH without verifying the server's IP address"
+          + " against a known_hosts file.";
+  static final String GCLOUD_RELEASE_TRACK =
+      "The gcloud release track (ALPHA, BETA, or STABLE) that Spinnaker"
+          + " will use when deploying to Cloud Run.";
+  static final String SERVICES =
+      "A list of regular expressions. Any service matching one of these regexes "
+          + "will be indexed by Spinnaker.";
+  static final String VERSIONS =
+      "A list of regular expressions. Any version matching one of these regexes "
+          + "will be indexed by Spinnaker.";
+  static final String OMIT_SERVICES =
+      "A list of regular expressions. Any service matching one of these regexes "
+          + "will be ignored by Spinnaker.";
+  static final String OMIT_VERSIONS =
+      "A list of regular expressions. Any version matching one of these regexes "
+          + "will be ignored by Spinnaker.";
+  static final String CACHING_INTERVAL_SECONDS =
+      "The interval in seconds at which Spinnaker will poll for updates "
+          + "in your Cloud Run clusters.";
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunEditAccountCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunEditAccountCommand.java
@@ -1,0 +1,60 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.account.AbstractEditAccountCommand;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.google.CommonGoogleCommandProperties;
+import com.netflix.spinnaker.halyard.cli.command.v1.converter.LocalFileConverter;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Account;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun.CloudrunAccount;
+
+@Parameters(separators = "=")
+public class CloudrunEditAccountCommand extends AbstractEditAccountCommand<CloudrunAccount> {
+  @Override
+  protected String getProviderName() {
+    return "cloudrun";
+  }
+
+  @Parameter(names = "--project", description = CommonGoogleCommandProperties.PROJECT_DESCRIPTION)
+  private String project;
+
+  @Parameter(
+      names = "--json-path",
+      converter = LocalFileConverter.class,
+      description = CommonGoogleCommandProperties.JSON_PATH_DESCRIPTION)
+  private String jsonPath;
+
+  @Parameter(
+      names = "--local-repository-directory",
+      description = CloudrunCommandProperties.LOCAL_REPOSITORY_DIRECTORY_DESCRIPTION)
+  private String localRepositoryDirectory;
+
+  @Parameter(
+      names = "--ssh-known-hosts-file-path",
+      converter = LocalFileConverter.class,
+      description = CloudrunCommandProperties.SSH_KNOWN_HOSTS_FILE_PATH)
+  private String sshKnownHostsFilePath;
+
+  @Parameter(
+      names = "--ssh-trust-unknown-hosts",
+      description = CloudrunCommandProperties.SSH_TRUST_UNKNOWN_HOSTS,
+      arity = 1)
+  private Boolean sshTrustUnknownHosts = null;
+
+  @Override
+  protected Account editAccount(CloudrunAccount account) {
+    account.setJsonPath(isSet(jsonPath) ? jsonPath : account.getJsonPath());
+    account.setProject(isSet(project) ? project : account.getProject());
+    account.setLocalRepositoryDirectory(
+        isSet(localRepositoryDirectory)
+            ? localRepositoryDirectory
+            : account.getLocalRepositoryDirectory());
+
+    account.setSshKnownHostsFilePath(
+        isSet(sshKnownHostsFilePath) ? sshKnownHostsFilePath : account.getSshKnownHostsFilePath());
+    account.setSshTrustUnknownHosts(
+        sshTrustUnknownHosts != null ? sshTrustUnknownHosts : account.isSshTrustUnknownHosts());
+
+    return account;
+  }
+}

--- a/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunEditCommand.java
+++ b/halyard-cli/src/main/java/com/netflix/spinnaker/halyard/cli/command/v1/config/providers/cloudrun/CloudrunEditCommand.java
@@ -1,0 +1,71 @@
+package com.netflix.spinnaker.halyard.cli.command.v1.config.providers.cloudrun;
+
+import static com.netflix.spinnaker.halyard.cli.ui.v1.AnsiFormatUtils.Format.STRING;
+
+import com.beust.jcommander.Parameter;
+import com.netflix.spinnaker.halyard.cli.command.v1.config.providers.AbstractProviderCommand;
+import com.netflix.spinnaker.halyard.cli.services.v1.Daemon;
+import com.netflix.spinnaker.halyard.cli.services.v1.OperationHandler;
+import com.netflix.spinnaker.halyard.cli.ui.v1.AnsiUi;
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun.CloudrunProvider;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+public class CloudrunEditCommand extends AbstractProviderCommand {
+  @Getter(AccessLevel.PUBLIC)
+  private String commandName = "edit";
+
+  @Getter(AccessLevel.PUBLIC)
+  private String shortDescription = "Edit Spinnaker's cloudrun configuration.";
+
+  @Parameter(
+      names = "--gcloudPath",
+      description = "The path to the gcloud executable on the machine running clouddriver.")
+  private String gcloudPath;
+
+  protected String getProviderName() {
+    return "cloudrun";
+  }
+
+  public CloudrunEditCommand() {}
+
+  @Override
+  protected void executeThis() {
+    String currentDeployment = getCurrentDeployment();
+
+    String providerName = getProviderName();
+    new OperationHandler<Provider>()
+        .setFailureMesssage("Failed to get provider " + providerName + ".")
+        .setSuccessMessage("Successfully got provider " + providerName + ".")
+        .setFormat(STRING)
+        .setUserFormatted(true)
+        .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+        .get();
+
+    CloudrunProvider provider =
+        (CloudrunProvider)
+            new OperationHandler<Provider>()
+                .setOperation(Daemon.getProvider(currentDeployment, providerName, !noValidate))
+                .setFailureMesssage("Failed to get provider " + providerName + ".")
+                .get();
+
+    int originalHash = provider.hashCode();
+
+    if (isSet(gcloudPath)) {
+      provider.setGcloudPath(gcloudPath);
+    }
+
+    if (originalHash == provider.hashCode()) {
+      AnsiUi.failure("No changes supplied.");
+      return;
+    }
+
+    new OperationHandler<Void>()
+        .setFailureMesssage("Failed to edit update cloudrun provider.")
+        .setSuccessMessage("Successfully edited cloudrun provider.")
+        .setOperation(
+            Daemon.setProvider(currentDeployment, getProviderName(), !noValidate, provider))
+        .get();
+  }
+}

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -24,6 +24,7 @@ dependencies {
   implementation 'com.amazonaws:aws-java-sdk-s3:1.11.534'
   implementation 'com.google.apis:google-api-services-compute'
   implementation 'com.google.apis:google-api-services-appengine:v1-rev92-1.25.0'
+  implementation 'com.google.apis:google-api-services-run:v2-rev20220429-1.32.1'
   implementation "com.azure.resourcemanager:azure-resourcemanager:2.19.0"
   implementation "com.azure:azure-storage-blob:12.19.1"
   implementation 'commons-collections:commons-collections:3.2.2'

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Provider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Provider.java
@@ -78,6 +78,7 @@ public abstract class Provider<A extends Account> extends Node implements Clonea
     ECS("ecs"),
     AZURE("azure"),
     CLOUDFOUNDRY("cloudfoundry"),
+    CLOUDRUN("cloudrun"),
     DCOS("dcos"),
     DOCKERREGISTRY("dockerRegistry"),
     GOOGLE("google", "gce"),

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Providers.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/node/Providers.java
@@ -23,6 +23,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.appengine.Appengi
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudfoundry.CloudFoundryProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun.CloudrunProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.ecs.EcsProvider;
@@ -48,6 +49,8 @@ public class Providers extends Node implements Cloneable {
   AwsProvider aws = new AwsProvider();
   EcsProvider ecs = new EcsProvider();
   AzureProvider azure = new AzureProvider();
+
+  CloudrunProvider cloudrun = new CloudrunProvider();
   DCOSProvider dcos = new DCOSProvider();
   DockerRegistryProvider dockerRegistry = new DockerRegistryProvider();
   GoogleProvider google = new GoogleProvider();

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudrun/CloudrunAccount.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudrun/CloudrunAccount.java
@@ -1,0 +1,15 @@
+package com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.LocalFile;
+import com.netflix.spinnaker.halyard.config.model.v1.node.SecretFile;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.google.CommonGoogleAccount;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CloudrunAccount extends CommonGoogleAccount {
+  private String localRepositoryDirectory;
+  @LocalFile @SecretFile private String sshKnownHostsFilePath;
+  private boolean sshTrustUnknownHosts;
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudrun/CloudrunProvider.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/model/v1/providers/cloudrun/CloudrunProvider.java
@@ -1,0 +1,16 @@
+package com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun;
+
+import com.netflix.spinnaker.halyard.config.model.v1.node.Provider;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+
+@Data
+@EqualsAndHashCode(callSuper = true)
+public class CloudrunProvider extends Provider<CloudrunAccount> {
+  private String gcloudPath;
+
+  @Override
+  public Provider.ProviderType providerType() {
+    return ProviderType.CLOUDRUN;
+  }
+}

--- a/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ProviderService.java
+++ b/halyard-config/src/main/java/com/netflix/spinnaker/halyard/config/services/v1/ProviderService.java
@@ -22,6 +22,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.node.*;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.appengine.AppengineProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun.CloudrunProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dockerRegistry.DockerRegistryProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleProvider;
@@ -118,6 +119,9 @@ public class ProviderService {
         break;
       case AZURE:
         providers.setAzure((AzureProvider) provider);
+        break;
+      case CLOUDRUN:
+        providers.setCloudrun((CloudrunProvider) provider);
         break;
       case DCOS:
         providers.setDcos((DCOSProvider) provider);

--- a/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
+++ b/halyard-deploy/src/main/java/com/netflix/spinnaker/halyard/deploy/spinnaker/v1/profile/deck/DeckProfileFactory.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsAccount;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.aws.AwsProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.azure.AzureProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudfoundry.CloudFoundryProvider;
+import com.netflix.spinnaker.halyard.config.model.v1.providers.cloudrun.CloudrunProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.dcos.DCOSProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.ecs.EcsProvider;
 import com.netflix.spinnaker.halyard.config.model.v1.providers.google.GoogleProvider;
@@ -157,6 +158,10 @@ public class DeckProfileFactory extends RegistryBackedProfileFactory {
     // Configure Appengine
     AppengineProvider appengineProvider = deploymentConfiguration.getProviders().getAppengine();
     bindings.put("appengine.default.account", appengineProvider.getPrimaryAccount());
+
+    // Configure CloudRun
+    CloudrunProvider cloudrunProvider = deploymentConfiguration.getProviders().getCloudrun();
+    bindings.put("cloudrun.default.account", cloudrunProvider.getPrimaryAccount());
 
     // Configure DC/OS
     final DCOSProvider dcosProvider = deploymentConfiguration.getProviders().getDcos();


### PR DESCRIPTION
This is part of https://github.com/spinnaker/governance/issues/302

Added all cloudrun commands in halyard.

halyard cloudrun commands:

1. hal config provider appengine [parameters] [subcommands]
       account: Manage and view Spinnaker configuration for the cloudrun provider’s account
       disable: Set the cloudrun provider as disabled
       edit: Edit cloudrun’s app engine configuration.
       enable: Set the cloudrun provider as enabled

2. hal config provider cloudrun account ACCOUNT [parameters] [subcommands]

     add: Add an account to the cloudrun provider.
     delete: Delete a specific cloudrun account by name.
     edit: Edit an account in the cloudrun provider.
     get: Get the specified account details for the cloudrun provider.
     list: List the account names for the cloudrun provider.
     
3. hal config provider cloudrun account delete ACCOUNT [parameters]

      ACCOUNT: The name of the account to operate on.

4. hal config provider cloudrun account get ACCOUNT [parameters]

      ACCOUNT: The name of the account to operate on.
      
5. hal config provider cloudrun disable [parameters]


6. hal config provider cloudrun account list [parameters]


7. hal config provider cloudrun enable [parameters]
      
   
   
Parameters 
--deployment: If supplied, use this Halyard deployment. This will not create a new deployment.
--no-validate: (Default: false) Skip validation.

      
      
      
 
