### PR TITLE
refactor(dependency): replace groovy coordinates during upgrade of groovy 4.x

### DIFF
--- a/halyard-backup/halyard-backup.gradle
+++ b/halyard-backup/halyard-backup.gradle
@@ -12,7 +12,7 @@ dependencies {
   implementation 'commons-io:commons-io'
   implementation 'org.apache.commons:commons-compress:1.20'
   implementation 'io.fabric8:kubernetes-client:4.1.1'
-  implementation 'org.codehaus.groovy:groovy'
+  implementation 'org.apache.groovy:groovy'
 
   implementation project(':halyard-config')
   implementation project(':halyard-core')

--- a/halyard-cli/halyard-cli.gradle
+++ b/halyard-cli/halyard-cli.gradle
@@ -15,7 +15,7 @@ dependencies {
   implementation 'com.fasterxml.jackson.core:jackson-databind'
   implementation 'org.aspectj:aspectjweaver'
   implementation 'org.yaml:snakeyaml:1.24'
-  implementation 'org.codehaus.groovy:groovy'
+  implementation 'org.apache.groovy:groovy'
   implementation 'com.beust:jcommander:1.81'
   implementation 'org.nibor.autolink:autolink:0.10.0'
 

--- a/halyard-config/halyard-config.gradle
+++ b/halyard-config/halyard-config.gradle
@@ -49,7 +49,7 @@ dependencies {
   testImplementation 'org.spockframework:spock-core'
   testImplementation 'org.springframework:spring-test'
   testImplementation 'org.springframework.boot:spring-boot-starter-test'
-  testImplementation 'org.codehaus.groovy:groovy'
+  testImplementation 'org.apache.groovy:groovy'
   testRuntimeOnly 'net.bytebuddy:byte-buddy'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 }

--- a/halyard-deploy/halyard-deploy.gradle
+++ b/halyard-deploy/halyard-deploy.gradle
@@ -23,7 +23,7 @@ dependencies {
   implementation "com.jakewharton.retrofit:retrofit1-okhttp3-client:1.1.0"
   implementation 'io.fabric8:kubernetes-client'
   implementation 'redis.clients:jedis'
-  implementation 'org.codehaus.groovy:groovy'
+  implementation 'org.apache.groovy:groovy'
 
   implementation project(':halyard-config')
   implementation project(':halyard-core')

--- a/halyard-web/halyard-web.gradle
+++ b/halyard-web/halyard-web.gradle
@@ -24,7 +24,7 @@ dependencies {
   implementation 'org.apache.commons:commons-lang3'
   implementation 'com.squareup.retrofit:retrofit'
   implementation 'io.github.lognet:grpc-spring-boot-starter:2.4.4'
-  implementation 'org.codehaus.groovy:groovy'
+  implementation 'org.apache.groovy:groovy'
   implementation "io.spinnaker.kork:kork-web"
   implementation "io.spinnaker.kork:kork-cloud-config-server"
   implementation "io.spinnaker.kork:kork-config"


### PR DESCRIPTION
Replacing the groovy coordinates from `org.codehaus.groovy` to `org.apache.groovy` supported by groovy 4.x and above versions.