### PR TITLE
fix(ubuntu): add commands so apt-get can install libc

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -6,7 +6,7 @@ ENV KUBECTL_RELEASE=1.15.10
 ENV AWS_BINARY_RELEASE_DATE=2020-02-22
 ENV AWS_CLI_VERSION=2.15.57
 
-RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && \
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && apt-get --reinstall install libc-bin && \
     apt-get upgrade -y && \
     apt-get install -y \
       openjdk-17-jre-headless \

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -6,7 +6,7 @@ ENV KUBECTL_RELEASE=1.15.10
 ENV AWS_BINARY_RELEASE_DATE=2020-02-22
 ENV AWS_CLI_VERSION=2.15.57
 
-RUN apt-get update && \
+RUN rm /var/lib/dpkg/info/libc-bin.* && apt-get clean && apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
       openjdk-17-jre-headless \


### PR DESCRIPTION
specifically:
```
rm /var/lib/dpkg/info/libc-bin.* && apt-get clean
```
to fix errors like
```
#9 39.69 Setting up libc-bin (2.35-0ubuntu3.9) ...
#9 39.83 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 40.19 Segmentation fault (core dumped)
#9 40.24 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
#9 40.64 Segmentation fault (core dumped)
#9 40.64 dpkg: error processing package libc-bin (--configure):
#9 40.64  installed libc-bin package post-installation script subprocess returned error exit status 139 #9 40.65 Errors were encountered while processing:
#9 40.65  libc-bin
#9 40.73 E: Sub-process /usr/bin/dpkg returned an error code (1)
```
from https://github.com/spinnaker/halyard/actions/runs/13294126631/job/37121795924?pr=2207

suggestion from https://stackoverflow.com/a/78107622

similar to https://github.com/spinnaker/orca/pull/4834